### PR TITLE
make m2e ignore the maven notice plugin and import the project error free

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -382,6 +382,34 @@
         </executions>
       </plugin>
     </plugins>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.eclipse.m2e</groupId>
+          <artifactId>lifecycle-mapping</artifactId>
+          <version>1.0.0</version>
+          <configuration>
+            <lifecycleMappingMetadata>
+              <pluginExecutions>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>maven-notice-plugin</artifactId>
+                    <versionRange>[0.0.2,)</versionRange>
+                    <goals>
+                      <goal>generate</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore/>
+                  </action>
+                </pluginExecution>
+              </pluginExecutions>
+            </lifecycleMappingMetadata>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>    
   </build>
 
   <reporting>


### PR DESCRIPTION
make m2e ignore the maven notice plugin and import the project error free

note. submitted the cla to secretary@apache.org this morning, as discussed with Oleg
