### PR TITLE
use getRawQuery and getRawFragment, to reduce gc from decode

### DIFF
--- a/httpclient/src/main/java/org/apache/http/client/utils/URIUtils.java
+++ b/httpclient/src/main/java/org/apache/http/client/utils/URIUtils.java
@@ -291,16 +291,16 @@ public class URIUtils {
             final String auth = uri.getAuthority().toLowerCase();
             final URI ref = new URI(scheme, auth, outputBuffer.toString(),
                     null, null);
-            if (uri.getQuery() == null && uri.getFragment() == null) {
+            if (uri.getRawQuery() == null && uri.getRawFragment() == null) {
                 return ref;
             }
             final StringBuilder normalized = new StringBuilder(
                     ref.toASCIIString());
-            if (uri.getQuery() != null) {
+            if (uri.getRawQuery() != null) {
                 // query string passed through unchanged
                 normalized.append('?').append(uri.getRawQuery());
             }
-            if (uri.getFragment() != null) {
+            if (uri.getRawFragment() != null) {
                 // fragment passed through unchanged
                 normalized.append('#').append(uri.getRawFragment());
             }


### PR DESCRIPTION
Hi,

I was just wondering if there was any specific need to use getQuery() and getFragment(), when the resulting if's use getRawQuery and getRawFragment;  as the calls to getQuery and getFragment() cause a call to decode under the hood; which would be redundant (increase object allocation/deallocation)

locally all test pass with getRaw equivalent calls.

thanks
/dom
