### PR TITLE
SSLSocketFactorySelector and related changes.

### DIFF
--- a/httpclient/src/main/java/org/apache/http/conn/ssl/SSLSocketFactorySelector.java
+++ b/httpclient/src/main/java/org/apache/http/conn/ssl/SSLSocketFactorySelector.java
@@ -1,0 +1,43 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.http.conn.ssl;
+
+import org.apache.http.protocol.HttpContext;
+
+/**
+ * Selector that allows HTTPClient to use multiple pre-created SSLContexts and SSLSocketFactories.
+ *
+ * @since 4.3.3
+ */
+public interface SSLSocketFactorySelector
+{
+  /**
+   * Returns the {@link javax.net.ssl.SSLSocketFactory} based on passed in {@link HttpContext}, never {@code null}.
+   */
+  javax.net.ssl.SSLSocketFactory select(HttpContext httpContext);
+}


### PR DESCRIPTION
This change would allow single instance of HttpClient to be used with multiple SSLSocketFactories, unlike today, where one instance of client uses single instance of it.

This way, one can use multiple specially configured SSLContexts/SSLSockectFactories to connect to different targets. Some of them might be "weak" (accepting self signed certs too), some of the might use their own trust material, and some of the might use the "default" Java trust store (having default CA chain verification).
