### PR TITLE
HTTPCLIENT-1454: (re)Introducing HttpClientConnectionOperator in public API

### DIFF
--- a/httpclient/src/main/java/org/apache/http/conn/HttpClientConnectionOperator.java
+++ b/httpclient/src/main/java/org/apache/http/conn/HttpClientConnectionOperator.java
@@ -1,0 +1,59 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.http.conn;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+
+import org.apache.http.HttpHost;
+import org.apache.http.config.SocketConfig;
+import org.apache.http.protocol.HttpContext;
+
+/**
+ * Connection operator that performs connecting and upgrading of the connections. Usually, components participating in
+ * these operations are registry of {@link org.apache.http.conn.socket.ConnectionSocketFactory}, {@link
+ * SchemePortResolver} and {@link DnsResolver}. In general, HTTP client user should not provide implementations of this
+ * interface, as Client will use the default one that covers most of the cases needed for majority of users.
+ *
+ * @since 4.4
+ */
+public interface HttpClientConnectionOperator
+{
+  void connect(
+      final ManagedHttpClientConnection conn,
+      final HttpHost host,
+      final InetSocketAddress localAddress,
+      final int connectTimeout,
+      final SocketConfig socketConfig,
+      final HttpContext context) throws IOException;
+
+  void upgrade(
+      final ManagedHttpClientConnection conn,
+      final HttpHost host,
+      final HttpContext context) throws IOException;
+}

--- a/httpclient/src/main/java/org/apache/http/impl/conn/DefaultHttpClientConnectionOperator.java
+++ b/httpclient/src/main/java/org/apache/http/impl/conn/DefaultHttpClientConnectionOperator.java
@@ -43,6 +43,7 @@ import org.apache.http.config.SocketConfig;
 import org.apache.http.conn.ConnectTimeoutException;
 import org.apache.http.conn.DnsResolver;
 import org.apache.http.conn.HttpClientConnectionManager;
+import org.apache.http.conn.HttpClientConnectionOperator;
 import org.apache.http.conn.HttpHostConnectException;
 import org.apache.http.conn.ManagedHttpClientConnection;
 import org.apache.http.conn.SchemePortResolver;
@@ -52,8 +53,16 @@ import org.apache.http.conn.socket.LayeredConnectionSocketFactory;
 import org.apache.http.protocol.HttpContext;
 import org.apache.http.util.Args;
 
+/**
+ * Default implementation of {@link HttpClientConnectionOperator} used as default in Http client,
+ * when no instance provided by user to {@link BasicHttpClientConnectionManager} or {@link
+ * PoolingHttpClientConnectionManager} constructor.
+ *
+ * @since 4.4
+ */
 @Immutable
-class HttpClientConnectionOperator {
+public class DefaultHttpClientConnectionOperator implements HttpClientConnectionOperator
+{
 
     static final String SOCKET_FACTORY_REGISTRY = "http.socket-factory-registry";
 
@@ -63,10 +72,10 @@ class HttpClientConnectionOperator {
     private final SchemePortResolver schemePortResolver;
     private final DnsResolver dnsResolver;
 
-    HttpClientConnectionOperator(
-            final Lookup<ConnectionSocketFactory> socketFactoryRegistry,
-            final SchemePortResolver schemePortResolver,
-            final DnsResolver dnsResolver) {
+    DefaultHttpClientConnectionOperator(
+        final Lookup<ConnectionSocketFactory> socketFactoryRegistry,
+        final SchemePortResolver schemePortResolver,
+        final DnsResolver dnsResolver) {
         super();
         Args.notNull(socketFactoryRegistry, "Socket factory registry");
         this.socketFactoryRegistry = socketFactoryRegistry;
@@ -86,6 +95,7 @@ class HttpClientConnectionOperator {
         return reg;
     }
 
+    @Override
     public void connect(
             final ManagedHttpClientConnection conn,
             final HttpHost host,
@@ -146,6 +156,7 @@ class HttpClientConnectionOperator {
         }
     }
 
+    @Override
     public void upgrade(
             final ManagedHttpClientConnection conn,
             final HttpHost host,

--- a/httpclient/src/main/java/org/apache/http/impl/conn/PoolingHttpClientConnectionManager.java
+++ b/httpclient/src/main/java/org/apache/http/impl/conn/PoolingHttpClientConnectionManager.java
@@ -50,6 +50,7 @@ import org.apache.http.conn.ConnectionPoolTimeoutException;
 import org.apache.http.conn.ConnectionRequest;
 import org.apache.http.conn.DnsResolver;
 import org.apache.http.conn.HttpClientConnectionManager;
+import org.apache.http.conn.HttpClientConnectionOperator;
 import org.apache.http.conn.HttpConnectionFactory;
 import org.apache.http.conn.SchemePortResolver;
 import org.apache.http.conn.ManagedHttpClientConnection;
@@ -142,14 +143,30 @@ public class PoolingHttpClientConnectionManager
             final SchemePortResolver schemePortResolver,
             final DnsResolver dnsResolver,
             final long timeToLive, final TimeUnit tunit) {
-        super();
-        this.configData = new ConfigData();
-        this.pool = new CPool(
-                new InternalConnectionFactory(this.configData, connFactory), 2, 20, timeToLive, tunit);
-        this.connectionOperator = new HttpClientConnectionOperator(
-                socketFactoryRegistry, schemePortResolver, dnsResolver);
+        this(
+            new DefaultHttpClientConnectionOperator(socketFactoryRegistry, schemePortResolver, dnsResolver),
+            connFactory,
+            timeToLive, tunit
+        );
     }
 
+    /**
+     * @since 4.4
+     */
+    public PoolingHttpClientConnectionManager(
+        final org.apache.http.conn.HttpClientConnectionOperator httpClientConnectionOperator,
+        final HttpConnectionFactory<HttpRoute, ManagedHttpClientConnection> connFactory,
+        final long timeToLive, final TimeUnit tunit) {
+      super();
+      this.configData = new ConfigData();
+      this.pool = new CPool(
+          new InternalConnectionFactory(this.configData, connFactory), 2, 20, timeToLive, tunit);
+      this.connectionOperator = Args.notNull(httpClientConnectionOperator, "HttpClientConnectionOperator");
+    }
+
+    /**
+     * Visible for test.
+     */
     PoolingHttpClientConnectionManager(
             final CPool pool,
             final Lookup<ConnectionSocketFactory> socketFactoryRegistry,
@@ -158,7 +175,7 @@ public class PoolingHttpClientConnectionManager
         super();
         this.configData = new ConfigData();
         this.pool = pool;
-        this.connectionOperator = new HttpClientConnectionOperator(
+        this.connectionOperator = new DefaultHttpClientConnectionOperator(
                 socketFactoryRegistry, schemePortResolver, dnsResolver);
     }
 

--- a/httpclient/src/test/java/org/apache/http/impl/conn/TestHttpClientConnectionOperator.java
+++ b/httpclient/src/test/java/org/apache/http/impl/conn/TestHttpClientConnectionOperator.java
@@ -59,7 +59,7 @@ public class TestHttpClientConnectionOperator {
     private Lookup<ConnectionSocketFactory> socketFactoryRegistry;
     private SchemePortResolver schemePortResolver;
     private DnsResolver dnsResolver;
-    private HttpClientConnectionOperator connectionOperator;
+    private DefaultHttpClientConnectionOperator connectionOperator;
 
     @SuppressWarnings("unchecked")
     @Before
@@ -71,7 +71,7 @@ public class TestHttpClientConnectionOperator {
         socketFactoryRegistry = Mockito.mock(Lookup.class);
         schemePortResolver = Mockito.mock(SchemePortResolver.class);
         dnsResolver = Mockito.mock(DnsResolver.class);
-        connectionOperator = new HttpClientConnectionOperator(
+        connectionOperator = new DefaultHttpClientConnectionOperator(
                 socketFactoryRegistry, schemePortResolver, dnsResolver);
     }
 


### PR DESCRIPTION
In some edge cases, possibility to provide own implementation of
HttpClientConnectionOperator is desired, but in general, HttpClient
users should not mangle it, as the default provided by client
is completely satisfying.

Related issue
https://issues.apache.org/jira/browse/HTTPCLIENT-1454

Makes PR obsolete (supersedes it)
https://github.com/apache/httpclient/pull/9
