### PR TITLE
Add option to set the charset to encode GET parameters

### DIFF
--- a/httpclient/src/main/java/org/apache/http/client/methods/RequestBuilder.java
+++ b/httpclient/src/main/java/org/apache/http/client/methods/RequestBuilder.java
@@ -300,13 +300,19 @@ public class RequestBuilder {
         return this;
     }
 
-    public RequestBuilder setCharset(Charset charset) {
-      this.charset = charset;
-      return this;
+    /**
+     * @since 4.4
+     */
+    public RequestBuilder setCharset(final Charset charset) {
+        this.charset = charset;
+        return this;
     }
 
+    /**
+     * @since 4.4
+     */
     public Charset getCharset() {
-      return charset;
+        return charset;
     }
 
     public String getMethod() {

--- a/httpclient/src/main/java/org/apache/http/client/utils/URIBuilder.java
+++ b/httpclient/src/main/java/org/apache/http/client/utils/URIBuilder.java
@@ -91,13 +91,19 @@ public class URIBuilder {
         digestURI(uri);
     }
 
-    public URIBuilder setCharset(Charset charset) {
-      this.charset = charset;
-      return this;
+    /**
+     * @since 4.4
+     */
+    public URIBuilder setCharset(final Charset charset) {
+        this.charset = charset;
+        return this;
     }
 
+    /**
+     * @since 4.4
+     */
     public Charset getCharset() {
-      return charset;
+        return charset;
     }
 
     private List <NameValuePair> parseQuery(final String query, final Charset charset) {

--- a/httpclient/src/test/java/org/apache/http/client/utils/TestRequestBuilder.java
+++ b/httpclient/src/test/java/org/apache/http/client/utils/TestRequestBuilder.java
@@ -1,3 +1,29 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
 package org.apache.http.client.utils;
 
 
@@ -14,35 +40,35 @@ import java.nio.charset.Charset;
 
 public class TestRequestBuilder {
 
-  @Test
-  public void testBuildGETwithUTF8() throws Exception {
-    assertBuild(Consts.UTF_8);
-  }
+    @Test
+    public void testBuildGETwithUTF8() throws Exception {
+        assertBuild(Consts.UTF_8);
+    }
 
-  @Test
-  public void testBuildGETwithISO88591() throws Exception {
-    assertBuild(Consts.ISO_8859_1);
-  }
+    @Test
+    public void testBuildGETwithISO88591() throws Exception {
+        assertBuild(Consts.ISO_8859_1);
+    }
 
-  private void assertBuild(Charset charset) throws Exception {
-    RequestBuilder requestBuilder = RequestBuilder.create("GET").setCharset(charset);
-    requestBuilder.setUri("https://somehost.com/stuff");
-    requestBuilder.addParameters(createParameters());
+    private void assertBuild(final Charset charset) throws Exception {
+        final RequestBuilder requestBuilder = RequestBuilder.create("GET").setCharset(charset);
+        requestBuilder.setUri("https://somehost.com/stuff");
+        requestBuilder.addParameters(createParameters());
 
-    String encodedData1 = URLEncoder.encode("\"1ª position\"", charset.displayName());
-    String encodedData2 = URLEncoder.encode("José Abraão", charset.displayName());
+        final String encodedData1 = URLEncoder.encode("\"1\u00aa position\"", charset.displayName());
+        final String encodedData2 = URLEncoder.encode("Jos\u00e9 Abra\u00e3o", charset.displayName());
 
-    String uriExpected = String.format("https://somehost.com/stuff?parameter1=value1&parameter2=%s&parameter3=%s", encodedData1, encodedData2);
+        final String uriExpected = String.format("https://somehost.com/stuff?parameter1=value1&parameter2=%s&parameter3=%s", encodedData1, encodedData2);
 
-    HttpUriRequest request = requestBuilder.build();
-    Assert.assertEquals(uriExpected, request.getURI().toString());
-  }
+        final HttpUriRequest request = requestBuilder.build();
+        Assert.assertEquals(uriExpected, request.getURI().toString());
+    }
 
-  private NameValuePair[] createParameters() {
-    NameValuePair parameters[] = new NameValuePair[3];
-    parameters[0] = new BasicNameValuePair("parameter1", "value1");
-    parameters[1] = new BasicNameValuePair("parameter2", "\"1ª position\"");
-    parameters[2] = new BasicNameValuePair("parameter3", "José Abraão");
-    return parameters;
-  }
+    private NameValuePair[] createParameters() {
+        final NameValuePair parameters[] = new NameValuePair[3];
+        parameters[0] = new BasicNameValuePair("parameter1", "value1");
+        parameters[1] = new BasicNameValuePair("parameter2", "\"1\u00aa position\"");
+        parameters[2] = new BasicNameValuePair("parameter3", "Jos\u00e9 Abra\u00e3o");
+        return parameters;
+    }
 }

--- a/httpclient/src/test/java/org/apache/http/client/utils/TestURIBuilder.java
+++ b/httpclient/src/test/java/org/apache/http/client/utils/TestURIBuilder.java
@@ -241,55 +241,55 @@ public class TestURIBuilder {
 
     @Test
     public void testBuildAddParametersUTF8() throws Exception {
-      assertAddParameters(Consts.UTF_8);
+        assertAddParameters(Consts.UTF_8);
     }
 
     @Test
     public void testBuildAddParametersISO88591() throws Exception {
-      assertAddParameters(Consts.ISO_8859_1);
+        assertAddParameters(Consts.ISO_8859_1);
     }
 
-    public void assertAddParameters(Charset charset) throws Exception {
-      final URI uri = new URIBuilder("https://somehost.com/stuff")
-                          .setCharset(charset)
-                          .addParameters(createParameters()).build();
+    public void assertAddParameters(final Charset charset) throws Exception {
+        final URI uri = new URIBuilder("https://somehost.com/stuff")
+                .setCharset(charset)
+                .addParameters(createParameters()).build();
 
-      assertBuild(charset, uri);
+        assertBuild(charset, uri);
     }
 
     @Test
     public void testBuildSetParametersUTF8() throws Exception {
-      assertSetParameters(Consts.UTF_8);
+        assertSetParameters(Consts.UTF_8);
     }
 
     @Test
     public void testBuildSetParametersISO88591() throws Exception {
-      assertSetParameters(Consts.ISO_8859_1);
+        assertSetParameters(Consts.ISO_8859_1);
     }
 
-    public void assertSetParameters(Charset charset) throws Exception {
-      final URI uri = new URIBuilder("https://somehost.com/stuff")
-                          .setCharset(charset)
-                          .setParameters(createParameters()).build();
+    public void assertSetParameters(final Charset charset) throws Exception {
+        final URI uri = new URIBuilder("https://somehost.com/stuff")
+                .setCharset(charset)
+                .setParameters(createParameters()).build();
 
-      assertBuild(charset, uri);
+        assertBuild(charset, uri);
     }
 
-    public void assertBuild(Charset charset, URI uri) throws Exception {
-      String encodedData1 = URLEncoder.encode("\"1ª position\"", charset.displayName());
-      String encodedData2 = URLEncoder.encode("José Abraão", charset.displayName());
+    public void assertBuild(final Charset charset, final URI uri) throws Exception {
+        final String encodedData1 = URLEncoder.encode("\"1\u00aa position\"", charset.displayName());
+        final String encodedData2 = URLEncoder.encode("Jos\u00e9 Abra\u00e3o", charset.displayName());
 
-      String uriExpected = String.format("https://somehost.com/stuff?parameter1=value1&parameter2=%s&parameter3=%s", encodedData1, encodedData2);
-      
-      Assert.assertEquals(uriExpected, uri.toString());
+        final String uriExpected = String.format("https://somehost.com/stuff?parameter1=value1&parameter2=%s&parameter3=%s", encodedData1, encodedData2);
+
+        Assert.assertEquals(uriExpected, uri.toString());
     }
 
     private List<NameValuePair> createParameters() {
-      List<NameValuePair> parameters = new ArrayList<NameValuePair>();
-      parameters.add(new BasicNameValuePair("parameter1", "value1"));
-      parameters.add(new BasicNameValuePair("parameter2", "\"1ª position\""));
-      parameters.add(new BasicNameValuePair("parameter3", "José Abraão"));
-      return parameters;
+        final List<NameValuePair> parameters = new ArrayList<NameValuePair>();
+        parameters.add(new BasicNameValuePair("parameter1", "value1"));
+        parameters.add(new BasicNameValuePair("parameter2", "\"1\u00aa position\""));
+        parameters.add(new BasicNameValuePair("parameter3", "Jos\u00e9 Abra\u00e3o"));
+        return parameters;
     }
 
 }


### PR DESCRIPTION
This allows to encode the get parameters with different charset instead of just use the default UTF-8.
