### PR TITLE
Permit other addresses to be tried in the event of a NoRouteToHostExcept...

### DIFF
--- a/httpclient/src/main/java/org/apache/http/client/protocol/ResponseContentEncoding.java
+++ b/httpclient/src/main/java/org/apache/http/client/protocol/ResponseContentEncoding.java
@@ -95,7 +95,9 @@ public class ResponseContentEncoding implements HttpResponseInterceptor {
                         /* Don't need to transform the content - no-op */
                         return;
                     } else {
-                        throw new HttpException("Unsupported Content-Coding: " + codec.getName());
+                        // unknown encoding.  It SHOULD be one of the above, but it is not.  That is sub-optimal
+                        // but acceptable http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.5
+                        return;
                     }
                 }
                 if (uncompressed) {

--- a/httpclient/src/main/java/org/apache/http/impl/conn/HttpClientConnectionOperator.java
+++ b/httpclient/src/main/java/org/apache/http/impl/conn/HttpClientConnectionOperator.java
@@ -28,6 +28,7 @@ package org.apache.http.impl.conn;
 
 import java.io.IOException;
 import java.net.ConnectException;
+import java.net.NoRouteToHostException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
@@ -140,6 +141,10 @@ class HttpClientConnectionOperator {
                     } else {
                         throw new HttpHostConnectException(ex, host, addresses);
                     }
+                }
+            } catch (final NoRouteToHostException ex) {
+                if (last) {
+                    throw ex;
                 }
             }
             if (this.log.isDebugEnabled()) {

--- a/httpclient/src/test/java/org/apache/http/client/protocol/TestResponseContentEncoding.java
+++ b/httpclient/src/test/java/org/apache/http/client/protocol/TestResponseContentEncoding.java
@@ -27,7 +27,6 @@
 package org.apache.http.client.protocol;
 
 import org.apache.http.HttpEntity;
-import org.apache.http.HttpException;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpResponseInterceptor;
 import org.apache.http.HttpVersion;
@@ -142,7 +141,7 @@ public class TestResponseContentEncoding {
         Assert.assertTrue(entity instanceof StringEntity);
     }
 
-    @Test(expected=HttpException.class)
+    @Test
     public void testUnknownContentEncoding() throws Exception {
         final HttpResponse response = new BasicHttpResponse(HttpVersion.HTTP_1_1, 200, "OK");
         final StringEntity original = new StringEntity("encoded stuff");
@@ -152,6 +151,9 @@ public class TestResponseContentEncoding {
 
         final HttpResponseInterceptor interceptor = new ResponseContentEncoding();
         interceptor.process(response, context);
+        final HttpEntity entity = response.getEntity();
+        Assert.assertNotNull(entity);
+        Assert.assertTrue(entity instanceof StringEntity);
     }
 
 }


### PR DESCRIPTION
...ion.  e.g. when there one of the addresses to be used is an ipv6 address when the client does not have an ipv6 route to that particular host
