### PR TITLE
Adding support for using delegated GSSCredential for Kerberos authentication

### DIFF
--- a/httpclient/src/main/java-deprecated/org/apache/http/impl/auth/NegotiateScheme.java
+++ b/httpclient/src/main/java-deprecated/org/apache/http/impl/auth/NegotiateScheme.java
@@ -112,7 +112,7 @@ public class NegotiateScheme extends GGSSchemeBase {
     }
 
     @Override
-    protected byte[] generateToken(final byte[] input, final String authServer) throws GSSException {
+    protected byte[] generateToken(final byte[] input, final String authServer, final Credentials credentials) throws GSSException {
         /* Using the SPNEGO OID is the correct method.
          * Kerberos v5 works for IIS but not JBoss. Unwrapping
          * the initial token when using SPNEGO OID looks like what is
@@ -133,7 +133,7 @@ public class NegotiateScheme extends GGSSchemeBase {
         byte[] token = input;
         boolean tryKerberos = false;
         try {
-            token = generateGSSToken(token, negotiationOid, authServer);
+            token = generateGSSToken(token, negotiationOid, authServer, credentials);
         } catch (final GSSException ex){
             // BAD MECH means we are likely to be using 1.5, fall back to Kerberos MECH.
             // Rethrow any other exception.
@@ -149,7 +149,7 @@ public class NegotiateScheme extends GGSSchemeBase {
             /* Kerberos v5 GSS-API mechanism defined in RFC 1964.*/
             log.debug("Using Kerberos MECH " + KERBEROS_OID);
             negotiationOid  = new Oid(KERBEROS_OID);
-            token = generateGSSToken(token, negotiationOid, authServer);
+            token = generateGSSToken(token, negotiationOid, authServer, credentials);
 
             /*
              * IIS accepts Kerberos and SPNEGO tokens. Some other servers Jboss, Glassfish?

--- a/httpclient/src/main/java/org/apache/http/auth/KerberosCredentials.java
+++ b/httpclient/src/main/java/org/apache/http/auth/KerberosCredentials.java
@@ -1,0 +1,66 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.http.auth;
+
+import java.io.Serializable;
+import java.security.Principal;
+
+import org.ietf.jgss.GSSCredential;
+
+/**
+ * {@link Credentials} implementation based on GSSCredential for Kerberos Authentication.
+ */
+public class KerberosCredentials implements Credentials, Serializable {
+
+    private static final long serialVersionUID = 487421613855550713L;
+
+    /** GSSCredential  */
+    private final GSSCredential gssCredential;
+
+    /**
+     * Constructor with GSSCredential argument
+     *
+     * @param gssCredential
+     */
+    public KerberosCredentials(final GSSCredential gssCredential) {
+        this.gssCredential = gssCredential;
+    }
+
+    public GSSCredential getGSSCredential() {
+        return gssCredential;
+    }
+
+    public Principal getUserPrincipal() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    public String getPassword() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+}

--- a/httpclient/src/main/java/org/apache/http/impl/auth/KerberosScheme.java
+++ b/httpclient/src/main/java/org/apache/http/impl/auth/KerberosScheme.java
@@ -87,8 +87,8 @@ public class KerberosScheme extends GGSSchemeBase {
     }
 
     @Override
-    protected byte[] generateToken(final byte[] input, final String authServer) throws GSSException {
-        return generateGSSToken(input, new Oid(KERBEROS_OID), authServer);
+    protected byte[] generateToken(final byte[] input, final String authServer, final Credentials credentials) throws GSSException {
+        return generateGSSToken(input, new Oid(KERBEROS_OID), authServer, credentials);
     }
 
     /**

--- a/httpclient/src/main/java/org/apache/http/impl/auth/SPNegoScheme.java
+++ b/httpclient/src/main/java/org/apache/http/impl/auth/SPNegoScheme.java
@@ -88,8 +88,8 @@ public class SPNegoScheme extends GGSSchemeBase {
     }
 
     @Override
-    protected byte[] generateToken(final byte[] input, final String authServer) throws GSSException {
-        return generateGSSToken(input, new Oid(SPNEGO_OID), authServer);
+    protected byte[] generateToken(final byte[] input, final String authServer, final Credentials credentials) throws GSSException {
+        return generateGSSToken(input, new Oid(SPNEGO_OID), authServer, credentials);
     }
 
     /**


### PR DESCRIPTION
Internally httpclient relies on GSS API which uses JAAS login
configuration specified by user to get the GSSCredential. This patch
will allow a user to avoid the config file and directly set a delegated
or normal GSSCredential. A normal GSSCredential can be  obtained
programatically from
spn-keytab or user-password using custom Login module.

Snippet to set GSSCredential for SPNEGO-KERBEROS Authentication :
//gssCredential is the GSSCredential Object
KerberosCredentials kerebrosCredential = new
KerberosCredentials(gssCredential);

CredentialsProvider credsProvider = new BasicCredentialsProvider();
credsProvider.setCredentials(new AuthScope(null, -1, null),
kerebrosCredential);

Registry<AuthSchemeProvider> authSchemeRegistry = RegistryBuilder
.<AuthSchemeProvider> create().register(AuthSchemes.SPNEGO,
new SPNegoSchemeFactory()).build();

Use this authSchemeRegistry for HttpClient.
