### PR TITLE
Ignore unsupported cookie policies

### DIFF
--- a/httpclient/src/main/java/org/apache/http/client/protocol/RequestAddCookies.java
+++ b/httpclient/src/main/java/org/apache/http/client/protocol/RequestAddCookies.java
@@ -148,7 +148,11 @@ public class RequestAddCookies implements HttpRequestInterceptor {
         // Get an instance of the selected cookie policy
         final CookieSpecProvider provider = registry.lookup(policy);
         if (provider == null) {
-            throw new HttpException("Unsupported cookie policy: " + policy);
+            if (this.log.isDebugEnabled()) {
+                this.log.debug("Unsupported cookie policy: " + policy);
+            }
+
+            return;
         }
         final CookieSpec cookieSpec = provider.create(clientContext);
         // Get all cookies available in the HTTP state


### PR DESCRIPTION
Do not throw HttpException on uknown policies. This will provide additional backward compatibility for HttpAsyncClient.
For more infomation see discussion at maillist: http://mail-archives.apache.org/mod_mbox/hc-dev/201409.mbox/%3C1410012674.7776.4.camel@ubuntu%3E
