### PR TITLE
HTTPCLIENT-1560: Request mutual auth in WinHttpClient

### DIFF
--- a/httpclient-win/src/main/java/org/apache/http/impl/auth/win/WindowsNegotiateScheme.java
+++ b/httpclient-win/src/main/java/org/apache/http/impl/auth/win/WindowsNegotiateScheme.java
@@ -275,7 +275,7 @@ public class WindowsNegotiateScheme extends AuthSchemeBase {
 
         sppicontext = new CtxtHandle();
         final int rc = Secur32.INSTANCE.InitializeSecurityContext(clientCred,
-                continueCtx, targetName, Sspi.ISC_REQ_CONNECTION | Sspi.ISC_REQ_DELEGATE, 0,
+                continueCtx, targetName, Sspi.ISC_REQ_DELEGATE | Sspi.ISC_REQ_MUTUAL_AUTH, 0,
                 Sspi.SECURITY_NATIVE_DREP, continueToken, 0, sppicontext, token,
                 attr, null);
         switch (rc) {


### PR DESCRIPTION
Removed ISC_REQ_CONNECTION because it is already set
by default. Added ISC_REQ_MUTUAL_AUTH which is also
required by ISC_REQ_DELEGATE.
