### PR TITLE
HTTPCLIENT-1611: NoClassDefFoundError: org/apache/http/ssl/SSLContexts i...

### DIFF
--- a/httpclient-osgi/pom.xml
+++ b/httpclient-osgi/pom.xml
@@ -151,6 +151,7 @@
             org.apache.http.params;version=${httpcore.osgi.import.version},
             org.apache.http.pool;version=${httpcore.osgi.import.version},
             org.apache.http.protocol;version=${httpcore.osgi.import.version},
+            org.apache.http.ssl;version=${httpcore.osgi.import.version},
             org.apache.http.util;version=${httpcore.osgi.import.version},
             org.apache.http.impl;version=${httpcore.osgi.import.version},
             org.apache.http.impl.entity;version=${httpcore.osgi.import.version},


### PR DESCRIPTION
...n httpclient-osgi

Adds the missing import-package to httpclient-osgi.

Fixes https://issues.apache.org/jira/browse/HTTPCLIENT-1611
