### PR TITLE
Httpclient-Win: If the proxy is requesting authentication, ask Windows for the proxy credentials

### DIFF
--- a/httpclient-win/src/main/java/org/apache/http/impl/auth/win/WindowsNegotiateScheme.java
+++ b/httpclient-win/src/main/java/org/apache/http/impl/auth/win/WindowsNegotiateScheme.java
@@ -243,6 +243,15 @@ public class WindowsNegotiateScheme extends AuthSchemeBase {
         final String spn;
         if (this.servicePrincipalName != null) {
             spn = this.servicePrincipalName;
+        } else if(isProxy()){
+            final HttpClientContext clientContext = HttpClientContext.adapt(context);
+            final RouteInfo route = clientContext.getHttpRoute();
+            if (route != null) {
+                spn = "HTTP/" + route.getProxyHost().getHostName();
+            } else {
+                // Should not happen
+                spn = null;
+            }
         } else {
             final HttpClientContext clientContext = HttpClientContext.adapt(context);
             final HttpHost target = clientContext.getTargetHost();


### PR DESCRIPTION
- Previously: Ask windows credentials for the target host for all cases.
- This doesn't work if the Proxy ask for authentication
- Fix: Pick the proxy host, if the proxy is asking for authentication
