### PR TITLE
Add matrix parameters

### DIFF
--- a/httpclient/src/main/java/org/apache/http/client/utils/URLEncodedUtils.java
+++ b/httpclient/src/main/java/org/apache/http/client/utils/URLEncodedUtils.java
@@ -272,20 +272,7 @@ public class URLEncodedUtils {
             final List <? extends NameValuePair> parameters,
             final char parameterSeparator,
             final String charset) {
-        final StringBuilder result = new StringBuilder();
-        for (final NameValuePair parameter : parameters) {
-            final String encodedName = encodeFormFields(parameter.getName(), charset);
-            final String encodedValue = encodeFormFields(parameter.getValue(), charset);
-            if (result.length() > 0) {
-                result.append(parameterSeparator);
-            }
-            result.append(encodedName);
-            if (encodedValue != null) {
-                result.append(NAME_VALUE_SEPARATOR);
-                result.append(encodedValue);
-            }
-        }
-        return result.toString();
+        return format(parameters, parameterSeparator, Charset.forName(charset));
     }
 
     /**
@@ -535,24 +522,6 @@ public class URLEncodedUtils {
             return null;
         }
         return urlDecode(content, charset != null ? charset : Consts.UTF_8, true);
-    }
-
-    /**
-     * Encode/escape www-url-form-encoded content.
-     * <p>
-     * Uses the {@link #URLENCODER} set of characters, rather than
-     * the {@link #UNRESERVED} set; this is for compatibilty with previous
-     * releases, URLEncoder.encode() and most browsers.
-     *
-     * @param content the content to encode, will convert space to '+'
-     * @param charset the charset to use
-     * @return encoded string
-     */
-    private static String encodeFormFields(final String content, final String charset) {
-        if (content == null) {
-            return null;
-        }
-        return urlEncode(content, charset != null ? Charset.forName(charset) : Consts.UTF_8, URLENCODER, true);
     }
 
     /**

--- a/httpclient/src/test/java/org/apache/http/client/utils/TestURIBuilder.java
+++ b/httpclient/src/test/java/org/apache/http/client/utils/TestURIBuilder.java
@@ -151,6 +151,53 @@ public class TestURIBuilder {
     }
 
     @Test
+    public void testAddMatrixParameter() throws Exception {
+        final URI uri = new URI("https://somehost.com/stuff");
+        final URIBuilder uribuilder = new URIBuilder(uri)
+                .addMatrixParameter("param", "some other stuff")
+                .addMatrixParameter("blah", "blah");
+        final URI result = uribuilder.build();
+        Assert.assertEquals(new URI("https://somehost.com/stuff;param=some%20other%20stuff;blah=blah"), result);
+    }
+
+    @Test
+    public void testAddMatrixParameters() throws Exception {
+        final URI uri = new URI("https://somehost.com/stuff");
+        final List<NameValuePair> params = new ArrayList<>();
+        params.add(new BasicNameValuePair("param", "some other stuff"));
+        params.add(new BasicNameValuePair("blah", "blah"));
+        final URIBuilder uribuilder = new URIBuilder(uri).addMatrixParameters(params);
+        final URI result = uribuilder.build();
+        Assert.assertEquals(new URI("https://somehost.com/stuff;param=some%20other%20stuff;blah=blah"), result);
+    }
+
+    @Test
+    public void testSetMatrixParameter() throws Exception {
+        final URI uri = new URI("https://somehost.com/stuff");
+        final URIBuilder uribuilder = new URIBuilder(uri)
+                .addMatrixParameter("param", "some other stuff")
+                .addMatrixParameter("blah", "blah");
+        uribuilder.setMatrixParameter("blah", "foo");
+        final URI result = uribuilder.build();
+        Assert.assertEquals(new URI("https://somehost.com/stuff;param=some%20other%20stuff;blah=foo"), result);
+    }
+
+    @Test
+    public void testSetMatrixParameters() throws Exception {
+        final URI uri = new URI("https://somehost.com/stuff");
+        final List<NameValuePair> params = new ArrayList<>();
+        params.add(new BasicNameValuePair("param", "some other stuff"));
+        params.add(new BasicNameValuePair("blah", "blah"));
+        params.add(new BasicNameValuePair("tobe", "removed"));
+        final URIBuilder uribuilder = new URIBuilder(uri).addMatrixParameters(params);
+        uribuilder.setMatrixParameters(new BasicNameValuePair[]{
+                new BasicNameValuePair("param", "some other value"),
+                new BasicNameValuePair("blah", "foo")});
+        final URI result = uribuilder.build();
+        Assert.assertEquals(new URI("https://somehost.com/stuff;param=some%20other%20value;blah=foo"), result);
+    }
+
+    @Test
     public void testQueryEncoding() throws Exception {
         final URI uri1 = new URI("https://somehost.com/stuff?client_id=1234567890" +
                 "&redirect_uri=https%3A%2F%2Fsomehost.com%2Fblah+blah%2F");

--- a/httpclient/src/test/java/org/apache/http/client/utils/TestURLEncodedUtils.java
+++ b/httpclient/src/test/java/org/apache/http/client/utils/TestURLEncodedUtils.java
@@ -28,6 +28,7 @@
 package org.apache.http.client.utils;
 
 import java.net.URI;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -390,6 +391,21 @@ public class TestURLEncodedUtils {
         params.clear();
         params.add(new BasicNameValuePair("Name8", "xx,  yy  ,zz"));
         Assert.assertEquals("Name8=xx%2C++yy++%2Czz", URLEncodedUtils.format(params, "US-ASCII"));
+    }
+
+    @Test
+    public void testFormatMatrixParameters() throws Exception {
+        final List <NameValuePair> params = new ArrayList<>();
+        params.add(new BasicNameValuePair("Name0", "Value0"));
+        params.add(new BasicNameValuePair("Name1", "Value1"));
+        Assert.assertEquals("Name0=Value0;Name1=Value1", URLEncodedUtils.format(params,
+                URLEncodedUtils.QP_SEP_S, URLEncodedUtils.Type.MATRIX_PARAMETER, Charset.forName("UTF-8")));
+
+        params.clear();
+        params.add(new BasicNameValuePair("Name-2", "Value%2"));
+        params.add(new BasicNameValuePair("Name;3", "Value=3"));
+        Assert.assertEquals("Name-2=Value%252;Name%3B3=Value%3D3", URLEncodedUtils.format(params,
+                URLEncodedUtils.QP_SEP_S, URLEncodedUtils.Type.MATRIX_PARAMETER, Charset.forName("UTF-8")));
     }
 
     private List <NameValuePair> parse (final String params) {


### PR DESCRIPTION
Matrix parameters are part of [RFC-3986](https://www.ietf.org/rfc/rfc3986.txt) and many server-side frameworks like Spring or Jersey support using matrix parameters in controller methods.

This pull request allows adding matrix parameters to the last path segment of a URI.
The API is similar to that for adding query parameters.
