### PR TITLE
URIBuilder extended for new method for empty values

### DIFF
--- a/httpclient/src/main/java/org/apache/http/client/utils/URIBuilder.java
+++ b/httpclient/src/main/java/org/apache/http/client/utils/URIBuilder.java
@@ -364,7 +364,7 @@ public class URIBuilder {
      * will remove custom query if present.
      * </p>
      */
-    public URIBuilder addParameterIfValueNotBlank(final String param, final String value) {
+    public URIBuilder addParameterIfValueNotEmpty(final String param, final String value) {
         if (value == null || value.isEmpty()) {
             return this;
         }

--- a/httpclient/src/main/java/org/apache/http/client/utils/URIBuilder.java
+++ b/httpclient/src/main/java/org/apache/http/client/utils/URIBuilder.java
@@ -26,18 +26,18 @@
  */
 package org.apache.http.client.utils;
 
+import org.apache.http.Consts;
+import org.apache.http.NameValuePair;
+import org.apache.http.annotation.NotThreadSafe;
+import org.apache.http.conn.util.InetAddressUtils;
+import org.apache.http.message.BasicNameValuePair;
+
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-
-import org.apache.http.Consts;
-import org.apache.http.NameValuePair;
-import org.apache.http.annotation.NotThreadSafe;
-import org.apache.http.conn.util.InetAddressUtils;
-import org.apache.http.message.BasicNameValuePair;
 
 /**
  * Builder for {@link URI} instances.
@@ -355,6 +355,22 @@ public class URIBuilder {
         this.query = null;
         return this;
     }
+
+    /**
+     * Adds parameter to URI query if the value is not null or empty. The parameter name and value are expected to be unescaped
+     * and may contain non ASCII characters.
+     * <p>
+     * Please note query parameters and custom query component are mutually exclusive. This method
+     * will remove custom query if present.
+     * </p>
+     */
+    public URIBuilder addParameterIfValueNotBlank(final String param, final String value) {
+        if (value == null || value.isEmpty()) {
+            return this;
+        }
+        return addParameter(param, value);
+    }
+
 
     /**
      * Sets parameter of URI query overriding existing value if set. The parameter name and value

--- a/httpclient/src/test/java/org/apache/http/client/utils/TestURIBuilder.java
+++ b/httpclient/src/test/java/org/apache/http/client/utils/TestURIBuilder.java
@@ -26,17 +26,17 @@
  */
 package org.apache.http.client.utils;
 
-import java.net.URI;
-import java.net.URLEncoder;
-import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.List;
-
 import org.apache.http.Consts;
 import org.apache.http.NameValuePair;
 import org.apache.http.message.BasicNameValuePair;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
 
 public class TestURIBuilder {
 
@@ -151,10 +151,10 @@ public class TestURIBuilder {
     }
 
     @Test
-    public void testAddParameterIfValueNotBlank() throws Exception {
+    public void testAddParameterIfValueNotEmpty() throws Exception {
         final URI uri = new URI("http", null, "localhost", 80, "/", "param=stuff&blah&blah", null);
         final URIBuilder uribuilder = new URIBuilder(uri).addParameter("param", "some other stuff")
-                .addParameterIfValueNotBlank("blah", "").addParameterIfValueNotBlank("blah", null);
+                .addParameterIfValueNotEmpty("blah", "").addParameterIfValueNotEmpty("blah", null);
         final URI result = uribuilder.build();
         Assert.assertEquals(new URI("http://localhost:80/?param=stuff&blah&blah&" +
                 "param=some+other+stuff"), result);

--- a/httpclient/src/test/java/org/apache/http/client/utils/TestURIBuilder.java
+++ b/httpclient/src/test/java/org/apache/http/client/utils/TestURIBuilder.java
@@ -151,6 +151,16 @@ public class TestURIBuilder {
     }
 
     @Test
+    public void testAddParameterIfValueNotBlank() throws Exception {
+        final URI uri = new URI("http", null, "localhost", 80, "/", "param=stuff&blah&blah", null);
+        final URIBuilder uribuilder = new URIBuilder(uri).addParameter("param", "some other stuff")
+                .addParameterIfValueNotBlank("blah", "").addParameterIfValueNotBlank("blah", null);
+        final URI result = uribuilder.build();
+        Assert.assertEquals(new URI("http://localhost:80/?param=stuff&blah&blah&" +
+                "param=some+other+stuff"), result);
+    }
+
+    @Test
     public void testQueryEncoding() throws Exception {
         final URI uri1 = new URI("https://somehost.com/stuff?client_id=1234567890" +
                 "&redirect_uri=https%3A%2F%2Fsomehost.com%2Fblah+blah%2F");


### PR DESCRIPTION
We are using the URIBuilder heavily across many projects. Before this we had our only implementation of an 'UrlBuilder' but we changed every usage to the URIBuilder. There is only one method missing - we add a lot of parameters, but sometimes they are not set/ empty/ null.

So this method would really help us to keep urls short and to not add unnecessary parameters.
