### PR TITLE
Allow usage of MultipartFormEntity in HttpAsyncClient.

### DIFF
--- a/httpmime/src/main/java/org/apache/http/entity/mime/MultipartFormEntity.java
+++ b/httpmime/src/main/java/org/apache/http/entity/mime/MultipartFormEntity.java
@@ -33,7 +33,11 @@ import org.apache.http.entity.ContentType;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.protocol.HTTP;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 
 class MultipartFormEntity implements HttpEntity {
 
@@ -91,10 +95,11 @@ class MultipartFormEntity implements HttpEntity {
 
     @Override
     public InputStream getContent() throws IOException {
-        try (ByteArrayOutputStream outstream = new ByteArrayOutputStream()) {
-            writeTo(outstream);
-            return new ByteArrayInputStream(outstream.toByteArray());
-        }
+        ByteArrayOutputStream outstream = new ByteArrayOutputStream();
+        writeTo(outstream);
+        InputStream instream = new ByteArrayInputStream(outstream.toByteArray());
+        outstream.close();
+        return instream;
     }
 
     @Override

--- a/httpmime/src/main/java/org/apache/http/entity/mime/MultipartFormEntity.java
+++ b/httpmime/src/main/java/org/apache/http/entity/mime/MultipartFormEntity.java
@@ -27,15 +27,13 @@
 
 package org.apache.http.entity.mime;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.entity.ContentType;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.protocol.HTTP;
+
+import java.io.*;
 
 class MultipartFormEntity implements HttpEntity {
 
@@ -93,8 +91,10 @@ class MultipartFormEntity implements HttpEntity {
 
     @Override
     public InputStream getContent() throws IOException {
-        throw new UnsupportedOperationException(
-                    "Multipart form entity does not implement #getContent()");
+        try (ByteArrayOutputStream outstream = new ByteArrayOutputStream()) {
+            writeTo(outstream);
+            return new ByteArrayInputStream(outstream.toByteArray());
+        }
     }
 
     @Override


### PR DESCRIPTION
There currently is only a workaround for the usage of MultipartFormEntity which requires sending the binary data of the MultipartFormEntity to a NByteArrayEntity. Actually I couldn't get this workaround working and it appears to not capture all part of the purpose of MultipartFormEntity.
See: http://mail-archives.apache.org/mod_mbox/hc-httpclient-users/201311.mbox/%3C13034392.132.1384195516775.JavaMail.Hal@Harold-Rosenbergs-MacBook-Pro.local%3E

This fix allows the usage of the MultipartFormEntity in the HttpAsyncClient because it calls #getContent() instead of #writeTo().

See people who have a similar problem:
http://stackoverflow.com/questions/4720077/how-can-i-see-the-content-of-a-multipartform-request
https://github.com/Mashape/unirest-java/issues/31

Something I want to point out is this quote: "That's the problem with trying to mix an asynchronous transport with an inherently blocking content producer. MultipartFormEntity can only produce its content using #writeTo method and cannot be used asynchronously. You basically have two options. (1) Write out entity content to ByteArrayOutputStream (or similar) and then create NByteArrayEntity using the resultant byte array. (2) Create multipart entity implementation that can produce its content asynchronously. " - Source: http://mail-archives.apache.org/mod_mbox/hc-httpclient-users/201311.mbox/%3C13034392.132.1384195516775.JavaMail.Hal@Harold-Rosenbergs-MacBook-Pro.local%3E

I'd like to get some discussion going on this approach and end up having a solution to this problem because I had to recreate part of the HttpMime in my project to support MultipartFormEntity in my HttpAsyncClient.

Thank you for reading!
