### PR TITLE
Remove arbitrary, unsettable content length restriction from MultipartFormEntity

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/entity/mime/MultipartFormEntity.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/entity/mime/MultipartFormEntity.java
@@ -93,8 +93,6 @@ class MultipartFormEntity implements HttpEntity {
     public InputStream getContent() throws IOException {
         if (this.contentLength < 0) {
             throw new ContentTooLongException("Content length is unknown");
-        } else if (this.contentLength > 25 * 1024) {
-            throw new ContentTooLongException("Content length is too long: " + this.contentLength);
         }
         final ByteArrayOutputStream outstream = new ByteArrayOutputStream();
         writeTo(outstream);


### PR DESCRIPTION
MultipartFormEntity is used to upload files. Its getContent method should not be size-restricted by an arbitrary, unalterable constant. 
