### PR TITLE
Make some package protected classes public as we need to extend them in current jmeter

### DIFF
--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -8,6 +8,9 @@ Please note that as of 4.4 HttpClient requires Java 1.6 or newer.
 Changelog:
 -------------------
 
+* [HTTPCLIENT-1817] Add a "Trust All" TrustStrategy implementation.
+  Contributed by Gary Gregory <ggregory at apache.org>
+
 * [HTTPCLIENT-1816] Update Apache Commons Codec 1.9 to 1.10.
   Contributed by Gary Gregory <ggregory at apache.org>
 

--- a/httpclient/src/main/java-deprecated/org/apache/http/impl/conn/HttpConnPool.java
+++ b/httpclient/src/main/java-deprecated/org/apache/http/impl/conn/HttpConnPool.java
@@ -43,7 +43,7 @@ import org.apache.http.pool.ConnFactory;
  * @deprecated (4.3) no longer used.
  */
 @Deprecated
-class HttpConnPool extends AbstractConnPool<HttpRoute, OperatedClientConnection, HttpPoolEntry> {
+public class HttpConnPool extends AbstractConnPool<HttpRoute, OperatedClientConnection, HttpPoolEntry> {
 
     private static final AtomicLong COUNTER = new AtomicLong();
 

--- a/httpclient/src/main/java-deprecated/org/apache/http/impl/conn/HttpPoolEntry.java
+++ b/httpclient/src/main/java-deprecated/org/apache/http/impl/conn/HttpPoolEntry.java
@@ -42,7 +42,7 @@ import org.apache.http.pool.PoolEntry;
  * @deprecated (4.3) no longer used.
  */
 @Deprecated
-class HttpPoolEntry extends PoolEntry<HttpRoute, OperatedClientConnection> {
+public class HttpPoolEntry extends PoolEntry<HttpRoute, OperatedClientConnection> {
 
     private final Log log;
     private final RouteTracker tracker;

--- a/httpclient/src/main/java-deprecated/org/apache/http/impl/conn/ManagedClientConnectionImpl.java
+++ b/httpclient/src/main/java-deprecated/org/apache/http/impl/conn/ManagedClientConnectionImpl.java
@@ -58,7 +58,7 @@ import org.apache.http.util.Asserts;
  * @deprecated (4.3) use {@link ManagedHttpClientConnectionFactory}.
  */
 @Deprecated
-class ManagedClientConnectionImpl implements ManagedClientConnection {
+public class ManagedClientConnectionImpl implements ManagedClientConnection {
 
     private final ClientConnectionManager manager;
     private final ClientConnectionOperator operator;
@@ -66,7 +66,7 @@ class ManagedClientConnectionImpl implements ManagedClientConnection {
     private volatile boolean reusable;
     private volatile long duration;
 
-    ManagedClientConnectionImpl(
+    public ManagedClientConnectionImpl(
             final ClientConnectionManager manager,
             final ClientConnectionOperator operator,
             final HttpPoolEntry entry) {
@@ -90,7 +90,7 @@ class ManagedClientConnectionImpl implements ManagedClientConnection {
         return this.poolEntry;
     }
 
-    HttpPoolEntry detach() {
+    public HttpPoolEntry detach() {
         final HttpPoolEntry local = this.poolEntry;
         this.poolEntry = null;
         return local;

--- a/httpclient/src/main/java/org/apache/http/conn/ssl/TrustAllStrategy.java
+++ b/httpclient/src/main/java/org/apache/http/conn/ssl/TrustAllStrategy.java
@@ -38,11 +38,11 @@ import java.security.cert.X509Certificate;
  */
 public class TrustAllStrategy implements TrustStrategy {
 
-	public static final TrustAllStrategy INSTANCE = new TrustAllStrategy();
+    public static final TrustAllStrategy INSTANCE = new TrustAllStrategy();
 
-	@Override
-	public boolean isTrusted(final X509Certificate[] chain, final String authType) throws CertificateException {
-		return true;
-	}
+    @Override
+    public boolean isTrusted(final X509Certificate[] chain, final String authType) throws CertificateException {
+        return true;
+    }
 
 }

--- a/httpclient/src/main/java/org/apache/http/conn/ssl/TrustAllStrategy.java
+++ b/httpclient/src/main/java/org/apache/http/conn/ssl/TrustAllStrategy.java
@@ -1,0 +1,48 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.http.conn.ssl;
+
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+/**
+ * A trust strategy that accepts all certificates as trusted. Verification of
+ * all other certificates is done by the trust manager configured in the SSL
+ * context.
+ *
+ * @since 4.5.4
+ */
+public class TrustAllStrategy implements TrustStrategy {
+
+	public static final TrustAllStrategy INSTANCE = new TrustAllStrategy();
+
+	@Override
+	public boolean isTrusted(final X509Certificate[] chain, final String authType) throws CertificateException {
+		return true;
+	}
+
+}

--- a/httpclient/src/main/java/org/apache/http/conn/ssl/TrustStrategy.java
+++ b/httpclient/src/main/java/org/apache/http/conn/ssl/TrustStrategy.java
@@ -34,5 +34,7 @@ package org.apache.http.conn.ssl;
  * @since 4.1
  */
 public interface TrustStrategy extends org.apache.http.ssl.TrustStrategy {
+	
+	// Empty! Inherits from org.apache.http.ssl.TrustStrategy.
 
 }


### PR DESCRIPTION
Hello,
Would it be possible to make those classes public as for now in JMeter, to use validation mechanism introduced in 4.3 we had to create a custom class located in  package "org.apache.http.impl.conn" which is clearly a hack.
In the future we will probably migrate directly to HttpClient5.

Thanks