### PR TITLE
CredSSP implementation, NTLM engine reworked

### DIFF
--- a/httpclient/src/main/java/org/apache/http/client/config/AuthSchemes.java
+++ b/httpclient/src/main/java/org/apache/http/client/config/AuthSchemes.java
@@ -65,6 +65,11 @@ public final class AuthSchemes {
      */
     public static final String KERBEROS = "Kerberos";
 
+    /**
+     * CredSSP authentication scheme defined in [MS-CSSP].
+     */
+    public static final String CREDSSP = "CredSSP";
+
     private AuthSchemes() {
     }
 

--- a/httpclient/src/main/java/org/apache/http/impl/auth/CredSspScheme.java
+++ b/httpclient/src/main/java/org/apache/http/impl/auth/CredSspScheme.java
@@ -76,6 +76,7 @@ import org.apache.http.util.CharsetUtils;
  * can be also switched to GSS. In fact it only works in CredSSP+NTLM case.
  * </p>
  * <p>
+ * Based on [MS-CSSP]: Credential Security Support Provider (CredSSP) Protocol (Revision 13.0, 7/14/2016).
  * The implementation was inspired by Python CredSSP and NTLM implementation by Jordan Borean.
  * </p>
  */

--- a/httpclient/src/main/java/org/apache/http/impl/auth/CredSspScheme.java
+++ b/httpclient/src/main/java/org/apache/http/impl/auth/CredSspScheme.java
@@ -1,0 +1,805 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.http.impl.auth;
+
+
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.Base64;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLEngineResult;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import javax.net.ssl.SSLEngineResult.HandshakeStatus;
+import javax.net.ssl.SSLEngineResult.Status;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.http.Header;
+import org.apache.http.HttpRequest;
+import org.apache.http.auth.AUTH;
+import org.apache.http.auth.AuthenticationException;
+import org.apache.http.auth.Credentials;
+import org.apache.http.auth.InvalidCredentialsException;
+import org.apache.http.auth.MalformedChallengeException;
+import org.apache.http.auth.NTCredentials;
+import org.apache.http.message.BufferedHeader;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.ssl.SSLContexts;
+import org.apache.http.util.CharArrayBuffer;
+import org.apache.http.util.CharsetUtils;
+
+
+/**
+ * <p>
+ * Client implementation of the CredSSP protocol specified in [MS-CSSP].
+ * </p>
+ * <p>
+ * Note: This is implementation is NOT GSS based. It should be. But there is no Java NTLM
+ * implementation as GSS module. Maybe the NTLMEngine can be converted to GSS and then this
+ * can be also switched to GSS. In fact it only works in CredSSP+NTLM case.
+ * </p>
+ * <p>
+ * The implementation was inspired by Python CredSSP and NTLM implementation by Jordan Borean.
+ * </p>
+ */
+public class CredSspScheme extends AuthSchemeBase
+{
+    private static final Charset UNICODE_LITTLE_UNMARKED = CharsetUtils.lookup( "UnicodeLittleUnmarked" );
+    public static final String SCHEME_NAME = "CredSSP";
+
+    private final Log log = LogFactory.getLog( CredSspScheme.class );
+
+    enum State
+    {
+        // Nothing sent, nothing received
+        UNINITIATED,
+
+        // We are handshaking. Several messages are exchanged in this state
+        TLS_HANDSHAKE,
+
+        // TLS handshake finished. Channel established
+        TLS_HANDSHAKE_FINISHED,
+
+        // NTLM NEGOTIATE message sent (strictly speaking this should be SPNEGO)
+        NEGO_TOKEN_SENT,
+
+        // NTLM CHALLENGE message received  (strictly speaking this should be SPNEGO)
+        NEGO_TOKEN_RECEIVED,
+
+        // NTLM AUTHENTICATE message sent together with a server public key
+        PUB_KEY_AUTH_SENT,
+
+        // Server public key authentication message received
+        PUB_KEY_AUTH_RECEIVED,
+
+        // Credentials message sent. Protocol exchange finished.
+        CREDENTIALS_SENT;
+    }
+
+    private State state;
+    private SSLEngine sslEngine;
+    private NTLMEngineImpl ntlmEngine;
+    private CredSspTsRequest lastReceivedTsRequest;
+    private NTLMEngineImpl.Handle ntlmOutgoingHandle;
+    private NTLMEngineImpl.Handle ntlmIncomingHandle;
+    private byte[] peerPublicKey;
+
+    /**
+     * Enabling or disabling the development trace (extra logging).
+     * We do NOT want this to be enabled by default.
+     * We do not want to enable it even if full logging is turned on.
+     * This may leak sensitive key material to the log files. It is supposed to be used only
+     * for development purposes. We really need this to diagnose protocol issues. Most of the
+     * protocol is TLS-encrypted. Some parts are encrypted several times. We cannot use packet
+     * sniffer or other tools for diagnostics. We need to see the values before encryption.
+     */
+    private static boolean develTrace = false;
+
+
+    public CredSspScheme()
+    {
+        state = State.UNINITIATED;
+    }
+
+
+    @Override
+    public String getSchemeName()
+    {
+        return SCHEME_NAME;
+    }
+
+
+    @Override
+    public String getParameter( final String name )
+    {
+        return null;
+    }
+
+
+    @Override
+    public String getRealm()
+    {
+        return null;
+    }
+
+
+    @Override
+    public boolean isConnectionBased()
+    {
+        return true;
+    }
+
+
+    private SSLEngine getSSLEngine()
+    {
+        if ( sslEngine == null )
+        {
+            sslEngine = createSSLEngine();
+        }
+        return sslEngine;
+    }
+
+
+    private SSLEngine createSSLEngine()
+    {
+        SSLContext sslContext;
+        try
+        {
+            sslContext = SSLContexts.custom().build();
+        }
+        catch ( NoSuchAlgorithmException e )
+        {
+            throw new RuntimeException( "Error creating SSL Context: " + e.getMessage(), e );
+        }
+        catch ( KeyManagementException e )
+        {
+            throw new RuntimeException( "Error creating SSL Context: " + e.getMessage(), e );
+        }
+
+        final X509TrustManager tm = new X509TrustManager()
+        {
+
+            @Override
+            public void checkClientTrusted( final X509Certificate[] chain, final String authType )
+                throws CertificateException
+            {
+                // Nothing to do.
+            }
+
+
+            @Override
+            public void checkServerTrusted( final X509Certificate[] chain, final String authType )
+                throws CertificateException
+            {
+                // Nothing to do, accept all. CredSSP server is using its own certificate without any
+                // binding to the PKI trust chains. The public key is verified as part of the CredSSP
+                // protocol exchange.
+            }
+
+
+            @Override
+            public X509Certificate[] getAcceptedIssuers()
+            {
+                return null;
+            }
+
+        };
+        try
+        {
+            sslContext.init( null, new TrustManager[]
+                { tm }, null );
+        }
+        catch ( KeyManagementException e )
+        {
+            throw new RuntimeException( "SSL Context initialization error: " + e.getMessage(), e );
+        }
+        final SSLEngine sslEngine = sslContext.createSSLEngine();
+        sslEngine.setUseClientMode( true );
+        return sslEngine;
+    }
+
+
+    @Override
+    protected void parseChallenge( final CharArrayBuffer buffer, final int beginIndex, final int endIndex )
+        throws MalformedChallengeException
+    {
+        final String inputString = buffer.substringTrimmed( beginIndex, endIndex );
+        if ( develTrace )
+        {
+            log.trace( "<< Received: " + inputString );
+        }
+
+        if ( inputString.isEmpty() )
+        {
+            if ( state == State.UNINITIATED )
+            {
+                // This is OK, just send out first message. That should start TLS handshake
+            }
+            else
+            {
+                final String msg = "Received unexpected empty input in state " + state;
+                log.error( msg );
+                throw new MalformedChallengeException( msg );
+            }
+        }
+
+        if ( state == State.TLS_HANDSHAKE )
+        {
+            unwrapHandshake( inputString );
+            if ( develTrace )
+            {
+                log.trace( "TLS handshake status: " + getSSLEngine().getHandshakeStatus() );
+            }
+            if ( getSSLEngine().getHandshakeStatus() == HandshakeStatus.NOT_HANDSHAKING )
+            {
+                log.trace( "TLS handshake finished" );
+                state = State.TLS_HANDSHAKE_FINISHED;
+            }
+        }
+
+        if ( state == State.NEGO_TOKEN_SENT )
+        {
+            final ByteBuffer buf = unwrap( inputString );
+            state = State.NEGO_TOKEN_RECEIVED;
+            lastReceivedTsRequest = CredSspTsRequest.createDecoded( buf );
+            if ( develTrace )
+            {
+                log.trace( "Received tsrequest(negotoken:CHALLENGE):\n" + lastReceivedTsRequest.debugDump() );
+            }
+        }
+
+        if ( state == State.PUB_KEY_AUTH_SENT )
+        {
+            final ByteBuffer buf = unwrap( inputString );
+            state = State.PUB_KEY_AUTH_RECEIVED;
+            lastReceivedTsRequest = CredSspTsRequest.createDecoded( buf );
+            if ( develTrace )
+            {
+                log.trace( "Received tsrequest(pubKeyAuth):\n" + lastReceivedTsRequest.debugDump() );
+            }
+        }
+    }
+
+
+    @Override
+    @Deprecated
+    public Header authenticate(
+        final Credentials credentials,
+        final HttpRequest request ) throws AuthenticationException
+    {
+        return authenticate( credentials, request, null );
+    }
+
+
+    @Override
+    public Header authenticate(
+        final Credentials credentials,
+        final HttpRequest request,
+        final HttpContext context ) throws AuthenticationException
+    {
+        NTCredentials ntcredentials = null;
+        try
+        {
+            ntcredentials = ( NTCredentials ) credentials;
+        }
+        catch ( final ClassCastException e )
+        {
+            throw new InvalidCredentialsException(
+                "Credentials cannot be used for CredSSP authentication: "
+                    + credentials.getClass().getName() );
+        }
+
+        if ( ntlmEngine == null )
+        {
+
+            ntlmEngine = new NTLMEngineImpl( ntcredentials, true );
+        }
+
+        String outputString = null;
+
+        if ( state == State.UNINITIATED )
+        {
+            beginTlsHandshake();
+            outputString = wrapHandshake();
+            state = State.TLS_HANDSHAKE;
+
+        }
+        else if ( state == State.TLS_HANDSHAKE )
+        {
+            outputString = wrapHandshake();
+
+        }
+        else if ( state == State.TLS_HANDSHAKE_FINISHED )
+        {
+
+            final int ntlmFlags = getNtlmFlags();
+            final ByteBuffer buf = allocateOutBuffer();
+            final NTLMEngineImpl.Type1Message ntlmNegoMessage = ntlmEngine.generateType1MsgObject( ntlmFlags );
+            if ( develTrace )
+            {
+                log.trace( "Prepared NTLM NEGOTIATE (type 1) message:\n" + ntlmNegoMessage.debugDump() );
+            }
+            final byte[] ntlmNegoMessageEncoded = ntlmNegoMessage.getBytes();
+            if ( develTrace )
+            {
+                log.trace( "Prepared NTLM NEGOTIATE (type 1) message (encoded):\n"
+                    + DebugUtil.dump( ntlmNegoMessageEncoded ) );
+            }
+            final CredSspTsRequest req = CredSspTsRequest.createNegoToken( ntlmNegoMessageEncoded );
+            req.encode( buf );
+            buf.flip();
+            if ( develTrace )
+            {
+                log.trace( "Prepared CredSSP TsRequest (NTLM negotiate):\n" + DebugUtil.dump( buf ) );
+            }
+            outputString = wrap( buf );
+            state = State.NEGO_TOKEN_SENT;
+
+        }
+        else if ( state == State.NEGO_TOKEN_RECEIVED )
+        {
+            final ByteBuffer buf = allocateOutBuffer();
+            final NTLMEngineImpl.Type2Message ntlmType2Message = ntlmEngine
+                .parseType2Message( lastReceivedTsRequest.getNegoToken() );
+
+            if ( develTrace )
+            {
+                log.trace( "Received NTLM CHALLENGE (type 2) message:\n" + ntlmType2Message.debugDump() );
+            }
+
+            final X509Certificate peerServerCertificate = getPeerServerCertificate();
+
+            final NTLMEngineImpl.Type3Message ntlmAuthenticateMessage = ntlmEngine
+                .generateType3MsgObject( peerServerCertificate );
+            if ( develTrace )
+            {
+                log.trace( "Prepared NTLM AUTHENTICATE (type 3) message:\n" + ntlmAuthenticateMessage.debugDump() );
+            }
+            final byte[] ntlmAuthenticateMessageEncoded = ntlmAuthenticateMessage.getBytes();
+            if ( develTrace )
+            {
+                log.trace( "Prepared NTLM AUTHENTICATE (type 3) message (encoded):\n"
+                    + DebugUtil.dump( ntlmAuthenticateMessageEncoded ) );
+            }
+
+            ntlmOutgoingHandle = ntlmEngine.createClientHandle();
+            ntlmIncomingHandle = ntlmEngine.createServer();
+
+            final CredSspTsRequest req = CredSspTsRequest.createNegoToken( ntlmAuthenticateMessageEncoded );
+            peerPublicKey = getSubjectPublicKeyDer( peerServerCertificate.getPublicKey() );
+            final byte[] pubKeyAuth = createPubKeyAuth();
+            req.setPubKeyAuth( pubKeyAuth );
+
+            req.encode( buf );
+            buf.flip();
+            if ( develTrace )
+            {
+                log.trace( "Prepared CredSSP TsRequest (NTLM authenticate + pubKeyAuth):\n" + DebugUtil.dump( buf ) );
+            }
+            outputString = wrap( buf );
+            state = State.PUB_KEY_AUTH_SENT;
+
+        }
+        else if ( state == State.PUB_KEY_AUTH_RECEIVED )
+        {
+            verifyPubKeyAuthResponse( lastReceivedTsRequest.getPubKeyAuth() );
+            final byte[] authInfo = createAuthInfo( ntcredentials );
+            final CredSspTsRequest req = CredSspTsRequest.createAuthInfo( authInfo );
+
+            final ByteBuffer buf = allocateOutBuffer();
+            req.encode( buf );
+            buf.flip();
+            if ( develTrace )
+            {
+                log.trace( "Prepared CredSSP TsRequest (authInfo):\n" + DebugUtil.dump( buf ) );
+            }
+            outputString = wrap( buf );
+            state = State.CREDENTIALS_SENT;
+        }
+        else
+        {
+            throw new AuthenticationException( "Wrong state " + state );
+        }
+        if ( develTrace )
+        {
+            log.trace( ">> Seding: " + outputString );
+        }
+        final CharArrayBuffer buffer = new CharArrayBuffer( 32 );
+        if ( isProxy() )
+        {
+            buffer.append( AUTH.PROXY_AUTH_RESP );
+        }
+        else
+        {
+            buffer.append( AUTH.WWW_AUTH_RESP );
+        }
+        buffer.append( ": CredSSP " );
+        buffer.append( outputString );
+        return new BufferedHeader( buffer );
+    }
+
+
+    private int getNtlmFlags()
+    {
+        return NTLMEngineImpl.FLAG_REQUEST_OEM_ENCODING |
+            NTLMEngineImpl.FLAG_REQUEST_SIGN |
+            NTLMEngineImpl.FLAG_REQUEST_SEAL |
+            NTLMEngineImpl.FLAG_DOMAIN_PRESENT |
+            NTLMEngineImpl.FLAG_REQUEST_ALWAYS_SIGN |
+            NTLMEngineImpl.FLAG_REQUEST_NTLM2_SESSION |
+            NTLMEngineImpl.FLAG_TARGETINFO_PRESENT |
+            NTLMEngineImpl.FLAG_REQUEST_VERSION |
+            NTLMEngineImpl.FLAG_REQUEST_128BIT_KEY_EXCH |
+            NTLMEngineImpl.FLAG_REQUEST_EXPLICIT_KEY_EXCH |
+            NTLMEngineImpl.FLAG_REQUEST_56BIT_ENCRYPTION;
+    }
+
+
+    private X509Certificate getPeerServerCertificate() throws AuthenticationException
+    {
+        Certificate[] peerCertificates;
+        try
+        {
+            peerCertificates = sslEngine.getSession().getPeerCertificates();
+        }
+        catch ( SSLPeerUnverifiedException e )
+        {
+            throw new AuthenticationException( e.getMessage(), e );
+        }
+        for ( Certificate peerCertificate : peerCertificates )
+        {
+            if ( !( peerCertificate instanceof X509Certificate ) )
+            {
+                continue;
+            }
+            final X509Certificate peerX509Cerificate = ( X509Certificate ) peerCertificate;
+            if ( peerX509Cerificate.getBasicConstraints() != -1 )
+            {
+                if ( develTrace )
+                {
+                    log.trace( "Skipping CA certificate " + ( ( X509Certificate ) peerCertificate ).getSubjectDN() );
+                }
+                continue;
+            }
+            return peerX509Cerificate;
+        }
+        return null;
+    }
+
+
+    private byte[] createPubKeyAuth() throws AuthenticationException
+    {
+        return ntlmOutgoingHandle.signAndEcryptMessage( peerPublicKey );
+    }
+
+
+    private void verifyPubKeyAuthResponse( final byte[] pubKeyAuthResponse ) throws AuthenticationException
+    {
+        final byte[] pubKeyReceived = ntlmIncomingHandle.decryptAndVerifySignedMessage( pubKeyAuthResponse );
+
+        // assert: pubKeyReceived = peerPublicKey + 1
+        // The following algorithm is a bit simplified. But due to the ASN.1 encoding the first byte
+        // of the public key will be 0x30 we can pretty much rely on a fact that there will be no carry
+        if ( peerPublicKey.length != pubKeyReceived.length )
+        {
+            throw new AuthenticationException( "Public key mismatch in pubKeyAuth response" );
+        }
+        if ( ( peerPublicKey[0] + 1 ) != pubKeyReceived[0] )
+        {
+            throw new AuthenticationException( "Public key mismatch in pubKeyAuth response" );
+        }
+        for ( int i = 1; i < peerPublicKey.length; i++ )
+        {
+            if ( peerPublicKey[i] != pubKeyReceived[i] )
+            {
+                throw new AuthenticationException( "Public key mismatch in pubKeyAuth response" );
+            }
+        }
+        log.trace( "Received public key response is valid" );
+    }
+
+
+    private byte[] createAuthInfo( final NTCredentials ntcredentials ) throws AuthenticationException
+    {
+
+        final byte[] domainBytes = encodeUnicode( ntcredentials.getDomain() );
+        final byte[] domainOctetStringBytesLengthBytes = DerUtil.encodeLength( domainBytes.length );
+        final int domainNameLength = 1 + domainOctetStringBytesLengthBytes.length + domainBytes.length;
+        final byte[] domainNameLengthBytes = DerUtil.encodeLength( domainNameLength );
+
+        final byte[] usernameBytes = encodeUnicode( ntcredentials.getUserName() );
+        final byte[] usernameOctetStringBytesLengthBytes = DerUtil.encodeLength( usernameBytes.length );
+        final int userNameLength = 1 + usernameOctetStringBytesLengthBytes.length + usernameBytes.length;
+        final byte[] userNameLengthBytes = DerUtil.encodeLength( userNameLength );
+
+        final byte[] passwordBytes = encodeUnicode( ntcredentials.getPassword() );
+        final byte[] passwordOctetStringBytesLengthBytes = DerUtil.encodeLength( passwordBytes.length );
+        final int passwordLength = 1 + passwordOctetStringBytesLengthBytes.length + passwordBytes.length;
+        final byte[] passwordLengthBytes = DerUtil.encodeLength( passwordLength );
+
+        final int tsPasswordLength = 1 + domainNameLengthBytes.length + domainNameLength +
+            1 + userNameLengthBytes.length + userNameLength +
+            1 + passwordLengthBytes.length + passwordLength;
+        final byte[] tsPasswordLengthBytes = DerUtil.encodeLength( tsPasswordLength );
+        final int credentialsOctetStringLength = 1 + tsPasswordLengthBytes.length + tsPasswordLength;
+        final byte[] credentialsOctetStringLengthBytes = DerUtil.encodeLength( credentialsOctetStringLength );
+        final int credentialsLength = 1 + credentialsOctetStringLengthBytes.length + credentialsOctetStringLength;
+        final byte[] credentialsLengthBytes = DerUtil.encodeLength( credentialsLength );
+        final int tsCredentialsLength = 5 + 1 + credentialsLengthBytes.length + credentialsLength;
+        final byte[] tsCredentialsLengthBytes = DerUtil.encodeLength( tsCredentialsLength );
+
+        final ByteBuffer buf = ByteBuffer.allocate( 1 + tsCredentialsLengthBytes.length + tsCredentialsLength );
+
+        // TSCredentials structure [MS-CSSP] section 2.2.1.2
+        buf.put( ( byte ) 0x30 ); // seq
+        buf.put( tsCredentialsLengthBytes );
+
+        buf.put( ( byte ) ( 0x00 | 0xa0 ) ); // credType tag [0]
+        buf.put( ( byte ) 3 ); // credType length
+        buf.put( ( byte ) 0x02 ); // type: INTEGER
+        buf.put( ( byte ) 1 ); // credType inner length
+        buf.put( ( byte ) 1 ); // credType value: 1 (password)
+
+        buf.put( ( byte ) ( 0x01 | 0xa0 ) ); // credentials tag [1]
+        buf.put( credentialsLengthBytes );
+        buf.put( ( byte ) 0x04 ); // type: OCTET STRING
+        buf.put( credentialsOctetStringLengthBytes );
+
+        // TSPasswordCreds structure [MS-CSSP] section 2.2.1.2.1
+        buf.put( ( byte ) 0x30 ); // seq
+        buf.put( tsPasswordLengthBytes );
+
+        buf.put( ( byte ) ( 0x00 | 0xa0 ) ); // domainName tag [0]
+        buf.put( domainNameLengthBytes );
+        buf.put( ( byte ) 0x04 ); // type: OCTET STRING
+        buf.put( domainOctetStringBytesLengthBytes );
+        buf.put( domainBytes );
+
+        buf.put( ( byte ) ( 0x01 | 0xa0 ) ); // userName tag [1]
+        buf.put( userNameLengthBytes );
+        buf.put( ( byte ) 0x04 ); // type: OCTET STRING
+        buf.put( usernameOctetStringBytesLengthBytes );
+        buf.put( usernameBytes );
+
+        buf.put( ( byte ) ( 0x02 | 0xa0 ) ); // password tag [2]
+        buf.put( passwordLengthBytes );
+        buf.put( ( byte ) 0x04 ); // type: OCTET STRING
+        buf.put( passwordOctetStringBytesLengthBytes );
+        buf.put( passwordBytes );
+
+        final byte[] authInfo = buf.array();
+        try
+        {
+            return ntlmOutgoingHandle.signAndEcryptMessage( authInfo );
+        }
+        catch ( NTLMEngineException e )
+        {
+            throw new AuthenticationException( e.getMessage(), e );
+        }
+    }
+
+
+    private byte[] encodeUnicode( final String string )
+    {
+        return string.getBytes( UNICODE_LITTLE_UNMARKED );
+    }
+
+
+    private byte[] getSubjectPublicKeyDer( final PublicKey publicKey ) throws AuthenticationException
+    {
+        // The publicKey.getEncoded() returns encoded SubjectPublicKeyInfo structure. But the CredSSP expects
+        // SubjectPublicKey subfield. I have found no easy way how to get just the SubjectPublicKey from
+        // java.security libraries. So let's use a primitive way and parse it out from the DER.
+
+        try
+        {
+            final byte[] encodedPubKeyInfo = publicKey.getEncoded();
+
+            final ByteBuffer buf = ByteBuffer.wrap( encodedPubKeyInfo );
+            DerUtil.getByteAndAssert( buf, 0x30, "initial sequence" );
+            DerUtil.parseLength( buf );
+            DerUtil.getByteAndAssert( buf, 0x30, "AlgorithmIdentifier sequence" );
+            final int algIdSeqLength = DerUtil.parseLength( buf );
+            buf.position( buf.position() + algIdSeqLength );
+            DerUtil.getByteAndAssert( buf, 0x03, "subjectPublicKey type" );
+            int subjectPublicKeyLegth = DerUtil.parseLength( buf );
+            // There may be leading padding byte ... or whatever that is. Skip that.
+            final byte b = buf.get();
+            if ( b == 0 )
+            {
+                subjectPublicKeyLegth--;
+            }
+            else
+            {
+                buf.position( buf.position() - 1 );
+            }
+            final byte[] subjectPublicKey = new byte[subjectPublicKeyLegth];
+            buf.get( subjectPublicKey );
+            return subjectPublicKey;
+        }
+        catch ( MalformedChallengeException e )
+        {
+            throw new AuthenticationException( e.getMessage(), e );
+        }
+    }
+
+
+    private void beginTlsHandshake() throws AuthenticationException
+    {
+        try
+        {
+            getSSLEngine().beginHandshake();
+        }
+        catch ( SSLException e )
+        {
+            throw new AuthenticationException( "SSL Engine error: " + e.getMessage(), e );
+        }
+    }
+
+
+    private ByteBuffer allocateOutBuffer()
+    {
+        final SSLEngine sslEngine = getSSLEngine();
+        final SSLSession sslSession = sslEngine.getSession();
+        return ByteBuffer.allocate( sslSession.getApplicationBufferSize() );
+    }
+
+
+    private String wrapHandshake() throws AuthenticationException
+    {
+        final ByteBuffer src = allocateOutBuffer();
+        src.flip();
+        final SSLEngine sslEngine = getSSLEngine();
+        final SSLSession sslSession = sslEngine.getSession();
+        // Needs to be twice the size as there may be two wraps during handshake.
+        // Primitive and inefficient solution, but it works.
+        final ByteBuffer dst = ByteBuffer.allocate( sslSession.getPacketBufferSize() * 2 );
+        while ( sslEngine.getHandshakeStatus() == HandshakeStatus.NEED_WRAP )
+        {
+            wrap( src, dst );
+        }
+        dst.flip();
+        return encodeBase64( dst );
+    }
+
+
+    private String wrap( final ByteBuffer src ) throws AuthenticationException
+    {
+        final SSLEngine sslEngine = getSSLEngine();
+        final SSLSession sslSession = sslEngine.getSession();
+        final ByteBuffer dst = ByteBuffer.allocate( sslSession.getPacketBufferSize() );
+        wrap( src, dst );
+        dst.flip();
+        return encodeBase64( dst );
+    }
+
+
+    private void wrap( final ByteBuffer src, final ByteBuffer dst ) throws AuthenticationException
+    {
+        final SSLEngine sslEngine = getSSLEngine();
+        try
+        {
+            final SSLEngineResult engineResult = sslEngine.wrap( src, dst );
+            if ( engineResult.getStatus() != Status.OK )
+            {
+                throw new AuthenticationException( "SSL Engine error status: " + engineResult.getStatus() );
+            }
+        }
+        catch ( SSLException e )
+        {
+            throw new AuthenticationException( "SSL Engine wrap error: " + e.getMessage(), e );
+        }
+    }
+
+
+    private void unwrapHandshake( final String inputString ) throws MalformedChallengeException
+    {
+        final SSLEngine sslEngine = getSSLEngine();
+        final SSLSession sslSession = sslEngine.getSession();
+        final ByteBuffer src = decodeBase64( inputString );
+        final ByteBuffer dst = ByteBuffer.allocate( sslSession.getApplicationBufferSize() );
+        while ( sslEngine.getHandshakeStatus() == HandshakeStatus.NEED_UNWRAP )
+        {
+            unwrap( src, dst );
+        }
+    }
+
+
+    private ByteBuffer unwrap( final String inputString ) throws MalformedChallengeException
+    {
+        final SSLEngine sslEngine = getSSLEngine();
+        final SSLSession sslSession = sslEngine.getSession();
+        final ByteBuffer src = decodeBase64( inputString );
+        final ByteBuffer dst = ByteBuffer.allocate( sslSession.getApplicationBufferSize() );
+        unwrap( src, dst );
+        dst.flip();
+        return dst;
+    }
+
+
+    private void unwrap( final ByteBuffer src, final ByteBuffer dst ) throws MalformedChallengeException
+    {
+
+        try
+        {
+            final SSLEngineResult engineResult = sslEngine.unwrap( src, dst );
+            if ( engineResult.getStatus() != Status.OK )
+            {
+                throw new MalformedChallengeException( "SSL Engine error status: " + engineResult.getStatus() );
+            }
+
+            if ( sslEngine.getHandshakeStatus() == HandshakeStatus.NEED_TASK )
+            {
+                final Runnable task = sslEngine.getDelegatedTask();
+                task.run();
+            }
+
+        }
+        catch ( SSLException e )
+        {
+            throw new MalformedChallengeException( "SSL Engine unwrap error: " + e.getMessage(), e );
+        }
+    }
+
+
+    private String encodeBase64( final ByteBuffer buffer )
+    {
+        final int limit = buffer.limit();
+        final byte[] bytes = new byte[limit];
+        buffer.get( bytes );
+        return Base64.getEncoder().encodeToString( bytes );
+    }
+
+
+    private ByteBuffer decodeBase64( final String inputString )
+    {
+        final byte[] inputBytes = Base64.getDecoder().decode( inputString );
+        final ByteBuffer buffer = ByteBuffer.wrap( inputBytes );
+        return buffer;
+    }
+
+
+    @Override
+    public boolean isComplete()
+    {
+        return state == State.CREDENTIALS_SENT;
+    }
+
+}

--- a/httpclient/src/main/java/org/apache/http/impl/auth/CredSspSchemeFactory.java
+++ b/httpclient/src/main/java/org/apache/http/impl/auth/CredSspSchemeFactory.java
@@ -1,0 +1,44 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.http.impl.auth;
+
+
+import org.apache.http.auth.AuthScheme;
+import org.apache.http.auth.AuthSchemeProvider;
+import org.apache.http.protocol.HttpContext;
+
+
+public class CredSspSchemeFactory implements AuthSchemeProvider
+{
+
+    @Override
+    public AuthScheme create( final HttpContext context )
+    {
+        return new CredSspScheme();
+    }
+}

--- a/httpclient/src/main/java/org/apache/http/impl/auth/CredSspTsRequest.java
+++ b/httpclient/src/main/java/org/apache/http/impl/auth/CredSspTsRequest.java
@@ -1,0 +1,313 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.http.impl.auth;
+
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+
+import org.apache.http.auth.MalformedChallengeException;
+
+
+/**
+ * Implementation of the TsRequest structure used in CredSSP protocol.
+ * It is specified in [MS-CPPS] section 2.2.1.
+ */
+public class CredSspTsRequest
+{
+
+    private static final int VERSION = 3;
+
+    private byte[] negoToken;
+    private byte[] authInfo;
+    private byte[] pubKeyAuth;
+
+
+    protected CredSspTsRequest()
+    {
+        super();
+    }
+
+
+    public static CredSspTsRequest createNegoToken( final byte[] negoToken )
+    {
+        final CredSspTsRequest req = new CredSspTsRequest();
+        req.negoToken = negoToken;
+        return req;
+    }
+
+
+    public static CredSspTsRequest createAuthInfo( final byte[] authInfo )
+    {
+        final CredSspTsRequest req = new CredSspTsRequest();
+        req.authInfo = authInfo;
+        return req;
+    }
+
+
+    public static CredSspTsRequest createDecoded( final ByteBuffer buf ) throws MalformedChallengeException
+    {
+        final CredSspTsRequest req = new CredSspTsRequest();
+        req.decode( buf );
+        return req;
+    }
+
+
+    public byte[] getNegoToken()
+    {
+        return negoToken;
+    }
+
+
+    public void setNegoToken( final byte[] negoToken )
+    {
+        this.negoToken = negoToken;
+    }
+
+
+    public byte[] getAuthInfo()
+    {
+        return authInfo;
+    }
+
+
+    public void setAuthInfo( final byte[] authInfo )
+    {
+        this.authInfo = authInfo;
+    }
+
+
+    public byte[] getPubKeyAuth()
+    {
+        return pubKeyAuth;
+    }
+
+
+    public void setPubKeyAuth( final byte[] pubKeyAuth )
+    {
+        this.pubKeyAuth = pubKeyAuth;
+    }
+
+
+    public void decode( final ByteBuffer buf ) throws MalformedChallengeException
+    {
+        negoToken = null;
+        authInfo = null;
+        pubKeyAuth = null;
+
+        DerUtil.getByteAndAssert( buf, 0x30, "initial sequence" );
+        DerUtil.parseLength( buf );
+
+        while ( buf.hasRemaining() )
+        {
+            final int contentTag = DerUtil.getAndAssertContentSpecificTag( buf, "content tag" );
+            DerUtil.parseLength( buf );
+            switch ( contentTag )
+            {
+                case 0:
+                    processVersion( buf );
+                    break;
+                case 1:
+                    parseNegoTokens( buf );
+                    break;
+                case 2:
+                    parseAuthInfo( buf );
+                    break;
+                case 3:
+                    parsePubKeyAuth( buf );
+                    break;
+                case 4:
+                    processErrorCode( buf );
+                    break;
+                default:
+                    DerUtil.parseError( buf, "unexpected content tag " + contentTag );
+            }
+        }
+    }
+
+
+    private void processVersion( final ByteBuffer buf ) throws MalformedChallengeException
+    {
+        DerUtil.getByteAndAssert( buf, 0x02, "version type" );
+        DerUtil.getLengthAndAssert( buf, 1, "version length" );
+        DerUtil.getByteAndAssert( buf, VERSION, "wrong protocol version" );
+    }
+
+
+    private void parseNegoTokens( final ByteBuffer buf ) throws MalformedChallengeException
+    {
+        DerUtil.getByteAndAssert( buf, 0x30, "negoTokens sequence" );
+        DerUtil.parseLength( buf );
+        // I have seen both 0x30LL encoding and 0x30LL0x30LL encoding. Accept both.
+        byte bufByte = buf.get();
+        if ( bufByte == 0x30 )
+        {
+            DerUtil.parseLength( buf );
+            bufByte = buf.get();
+        }
+        if ( ( bufByte & 0xff ) != 0xa0 )
+        {
+            DerUtil.parseError( buf, "negoTokens: wrong content-specific tag " + String.format( "%02X", bufByte ) );
+        }
+        DerUtil.parseLength( buf );
+        DerUtil.getByteAndAssert( buf, 0x04, "negoToken type" );
+
+        final int tokenLength = DerUtil.parseLength( buf );
+        negoToken = new byte[tokenLength];
+        buf.get( negoToken );
+    }
+
+
+    private void parseAuthInfo( final ByteBuffer buf ) throws MalformedChallengeException
+    {
+        DerUtil.getByteAndAssert( buf, 0x04, "authInfo type" );
+        final int length = DerUtil.parseLength( buf );
+        authInfo = new byte[length];
+        buf.get( authInfo );
+    }
+
+
+    private void parsePubKeyAuth( final ByteBuffer buf ) throws MalformedChallengeException
+    {
+        DerUtil.getByteAndAssert( buf, 0x04, "pubKeyAuth type" );
+        final int length = DerUtil.parseLength( buf );
+        pubKeyAuth = new byte[length];
+        buf.get( pubKeyAuth );
+    }
+
+
+    private void processErrorCode( final ByteBuffer buf ) throws MalformedChallengeException
+    {
+        DerUtil.getLengthAndAssert( buf, 3, "error code length" );
+        DerUtil.getByteAndAssert( buf, 0x02, "error code type" );
+        DerUtil.getLengthAndAssert( buf, 1, "error code length" );
+        final byte errorCode = buf.get();
+        DerUtil.parseError( buf, "Error code " + errorCode );
+    }
+
+
+    public void encode( final ByteBuffer buf )
+    {
+        final ByteBuffer inner = ByteBuffer.allocate( buf.capacity() );
+
+        // version tag [0]
+        inner.put( ( byte ) ( 0x00 | 0xa0 ) );
+        inner.put( ( byte ) 3 ); // length
+
+        inner.put( ( byte ) ( 0x02 ) ); // INTEGER tag
+        inner.put( ( byte ) 1 ); // length
+        inner.put( ( byte ) VERSION ); // value
+
+        if ( negoToken != null )
+        {
+            int len = negoToken.length;
+            final byte[] negoTokenLengthBytes = DerUtil.encodeLength( len );
+            len += 1 + negoTokenLengthBytes.length;
+            final byte[] negoTokenLength1Bytes = DerUtil.encodeLength( len );
+            len += 1 + negoTokenLength1Bytes.length;
+            final byte[] negoTokenLength2Bytes = DerUtil.encodeLength( len );
+            len += 1 + negoTokenLength2Bytes.length;
+            final byte[] negoTokenLength3Bytes = DerUtil.encodeLength( len );
+            len += 1 + negoTokenLength3Bytes.length;
+            final byte[] negoTokenLength4Bytes = DerUtil.encodeLength( len );
+
+            inner.put( ( byte ) ( 0x01 | 0xa0 ) ); // negoData tag [1]
+            inner.put( negoTokenLength4Bytes ); // length
+
+            inner.put( ( byte ) ( 0x30 ) ); // SEQUENCE tag
+            inner.put( negoTokenLength3Bytes ); // length
+
+            inner.put( ( byte ) ( 0x30 ) ); // .. of SEQUENCE tag
+            inner.put( negoTokenLength2Bytes ); // length
+
+            inner.put( ( byte ) ( 0x00 | 0xa0 ) ); // negoToken tag [0]
+            inner.put( negoTokenLength1Bytes ); // length
+
+            inner.put( ( byte ) ( 0x04 ) ); // OCTET STRING tag
+            inner.put( negoTokenLengthBytes ); // length
+
+            inner.put( negoToken );
+        }
+
+        if ( authInfo != null )
+        {
+            final byte[] authInfoEncodedLength = DerUtil.encodeLength( authInfo.length );
+
+            inner.put( ( byte ) ( 0x02 | 0xa0 ) ); // authInfo tag [2]
+            inner.put( DerUtil.encodeLength( 1 + authInfoEncodedLength.length + authInfo.length ) ); // length
+
+            inner.put( ( byte ) ( 0x04 ) ); // OCTET STRING tag
+            inner.put( authInfoEncodedLength );
+            inner.put( authInfo );
+        }
+
+        if ( pubKeyAuth != null )
+        {
+            final byte[] pubKeyAuthEncodedLength = DerUtil.encodeLength( pubKeyAuth.length );
+
+            inner.put( ( byte ) ( 0x03 | 0xa0 ) ); // pubKeyAuth tag [3]
+            inner.put( DerUtil.encodeLength( 1 + pubKeyAuthEncodedLength.length + pubKeyAuth.length ) ); // length
+
+            inner.put( ( byte ) ( 0x04 ) ); // OCTET STRING tag
+            inner.put( pubKeyAuthEncodedLength );
+            inner.put( pubKeyAuth );
+        }
+
+        inner.flip();
+
+        // SEQUENCE tag
+        buf.put( ( byte ) ( 0x10 | 0x20 ) );
+        buf.put( DerUtil.encodeLength( inner.limit() ) );
+        buf.put( inner );
+    }
+
+
+    public String debugDump()
+    {
+        final StringBuilder sb = new StringBuilder( "TsRequest\n" );
+        sb.append( "  negoToken:\n" );
+        sb.append( "    " );
+        DebugUtil.dump( sb, negoToken );
+        sb.append( "\n" );
+        sb.append( "  authInfo:\n" );
+        sb.append( "    " );
+        DebugUtil.dump( sb, authInfo );
+        sb.append( "\n" );
+        sb.append( "  pubKeyAuth:\n" );
+        sb.append( "    " );
+        DebugUtil.dump( sb, pubKeyAuth );
+        return sb.toString();
+    }
+
+
+    @Override
+    public String toString()
+    {
+        return "TsRequest(negoToken=" + Arrays.toString( negoToken ) + ", authInfo="
+            + Arrays.toString( authInfo ) + ", pubKeyAuth=" + Arrays.toString( pubKeyAuth ) + ")";
+    }
+}

--- a/httpclient/src/main/java/org/apache/http/impl/auth/DebugUtil.java
+++ b/httpclient/src/main/java/org/apache/http/impl/auth/DebugUtil.java
@@ -1,0 +1,96 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.http.impl.auth;
+
+
+import java.nio.ByteBuffer;
+
+
+/**
+ * Simple debugging utility class for CredSSP and NTLM implementations.
+ */
+public class DebugUtil
+{
+
+    public static String dump( final ByteBuffer buf )
+    {
+        final ByteBuffer dup = buf.duplicate();
+        final StringBuilder sb = new StringBuilder( dup.toString() );
+        sb.append( ": " );
+        while ( dup.position() < dup.limit() )
+        {
+            sb.append( String.format( "%02X ", dup.get() ) );
+        }
+        return sb.toString();
+    }
+
+
+    public static void dump( final StringBuilder sb, final byte[] bytes )
+    {
+        if ( bytes == null )
+        {
+            sb.append( "null" );
+            return;
+        }
+        for ( byte b : bytes )
+        {
+            sb.append( String.format( "%02X ", b ) );
+        }
+    }
+
+
+    public static String dump( final byte[] bytes )
+    {
+        final StringBuilder sb = new StringBuilder();
+        dump( sb, bytes );
+        return sb.toString();
+    }
+
+
+    public static byte[] fromHex( final String hex )
+    {
+        int i = 0;
+        final byte[] bytes = new byte[200000];
+        int h = 0;
+        while ( h < hex.length() )
+        {
+            if ( hex.charAt( h ) == ' ' )
+            {
+                h++;
+            }
+            final String str = hex.substring( h, h + 2 );
+            bytes[i] = ( byte ) Integer.parseInt( str, 16 );
+            i++;
+            h = h + 2;
+        }
+        final byte[] outbytes = new byte[i];
+        System.arraycopy( bytes, 0, outbytes, 0, i );
+        return outbytes;
+    }
+
+}

--- a/httpclient/src/main/java/org/apache/http/impl/auth/DerUtil.java
+++ b/httpclient/src/main/java/org/apache/http/impl/auth/DerUtil.java
@@ -1,0 +1,137 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.http.impl.auth;
+
+import java.nio.ByteBuffer;
+
+import org.apache.http.auth.MalformedChallengeException;
+
+/**
+ * Utilities for primitive (but working) ASN.1 DER encoding/decoding.
+ * Used in CredSSP and NTLM implementation.
+ */
+public class DerUtil
+{
+
+    public static void getByteAndAssert( final ByteBuffer buf, final int expectedValue, final String errorMessage )
+        throws MalformedChallengeException
+    {
+        final byte bufByte = buf.get();
+        if ( bufByte != expectedValue )
+        {
+            parseError( buf, errorMessage + expectMessage( expectedValue, bufByte ) );
+        }
+    }
+
+    private static String expectMessage( final int expectedValue, final int realValue )
+    {
+        return "(expected " + String.format( "%02X", expectedValue ) + ", got " + String.format( "%02X", realValue )
+            + ")";
+    }
+
+    public static int parseLength( final ByteBuffer buf )
+    {
+        byte bufByte = buf.get();
+        if ( bufByte == 0x80 )
+        {
+            return -1; // infinite
+        }
+        if ( ( bufByte & 0x80 ) == 0x80 )
+        {
+            final int size = bufByte & 0x7f;
+            int length = 0;
+            for ( int i = 0; i < size; i++ )
+            {
+                bufByte = buf.get();
+                length = ( length << 8 ) + ( bufByte & 0xff );
+            }
+            return length;
+        }
+        else
+        {
+            return bufByte;
+        }
+    }
+
+    public static void getLengthAndAssert( final ByteBuffer buf, final int expectedValue, final String errorMessage )
+        throws MalformedChallengeException
+    {
+        final int bufLength = parseLength( buf );
+        if ( expectedValue != bufLength )
+        {
+            parseError( buf, errorMessage + expectMessage( expectedValue, bufLength ) );
+        }
+    }
+
+    public static int getAndAssertContentSpecificTag( final ByteBuffer buf, final String errorMessage ) throws MalformedChallengeException
+    {
+        final byte bufByte = buf.get();
+        if ( ( bufByte & 0xe0 ) != 0xa0 )
+        {
+            parseError( buf, errorMessage + ": wrong content-specific tag " + String.format( "%02X", bufByte ) );
+        }
+        final int tag = bufByte & 0x1f;
+        return tag;
+    }
+
+    public static void parseError( final ByteBuffer buf, final String errorMessage ) throws MalformedChallengeException
+    {
+        throw new MalformedChallengeException(
+            "Error parsing TsRequest (position:" + buf.position() + "): " + errorMessage );
+    }
+
+    public static byte[] encodeLength( final int length )
+    {
+        if ( length < 128 )
+        {
+            final byte[] encoded = new byte[1];
+            encoded[0] = ( byte ) length;
+            return encoded;
+        }
+
+        int size = 1;
+
+        int val = length;
+        while ( ( val >>>= 8 ) != 0 )
+        {
+            size++;
+        }
+
+        final byte[] encoded = new byte[1 + size];
+        encoded[0] = ( byte ) ( size | 0x80 );
+
+        int shift = ( size - 1 ) * 8;
+        for ( int i = 0; i < size; i++ )
+        {
+            encoded[i + 1] = ( byte ) ( length >> shift );
+            shift -= 8;
+        }
+
+        return encoded;
+    }
+
+}

--- a/httpclient/src/main/java/org/apache/http/impl/auth/NTLMEngineImpl.java
+++ b/httpclient/src/main/java/org/apache/http/impl/auth/NTLMEngineImpl.java
@@ -75,6 +75,10 @@ import org.apache.http.util.EncodingUtils;
  * looked like. Maybe it should be separated to ordinary classes in the future.
  * The connection-less mode of operation is only partially implemented and not really tested.
  * </p>
+ * <p>
+ * Based on [MS-NLMP]: NT LAN Manager (NTLM) Authentication Protocol (Revision 28.0, 7/4/2016)
+ * https://msdn.microsoft.com/en-us/library/cc236621.aspx
+ * </p>
  *
  * @since 4.1
  */

--- a/httpclient/src/main/java/org/apache/http/impl/auth/NTLMEngineImpl.java
+++ b/httpclient/src/main/java/org/apache/http/impl/auth/NTLMEngineImpl.java
@@ -26,10 +26,13 @@
  */
 package org.apache.http.impl.auth;
 
-import java.io.UnsupportedEncodingException;
+
 import java.nio.charset.Charset;
 import java.security.Key;
 import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.Locale;
 
@@ -37,20 +40,49 @@ import javax.crypto.Cipher;
 import javax.crypto.spec.SecretKeySpec;
 
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.http.Consts;
+import org.apache.http.auth.NTCredentials;
 import org.apache.http.util.CharsetUtils;
 import org.apache.http.util.EncodingUtils;
 
+
 /**
+ * <p>
  * Provides an implementation for NTLMv1, NTLMv2, and NTLM2 Session forms of the NTLM
- * authentication protocol.
+ * authentication protocol. The implementation is based on the [MS-NLMP] specification.
+ * The implementation provides partial support for message integrity (signing) and
+ * confidentiality (sealing). However this is not full GSS API implementation yet.
+ * </p>
+ * <p>
+ * The NTLM Engine is stateful. It remembers the messages that were sent and received
+ * during the protocol exchange. This is needed for computation of message integrity
+ * code (MIC) that is computed from all protocol messages.
+ * </p>
+ * <p>
+ * Implementation notes: this is an implementation which is loosely based on older
+ * and very limited NTLM implementation. The old implementation was obviously NOT
+ * based on Microsoft specifications - or at least it have not used the terminology
+ * used in the specification. This new implementation is based on the [MS-NLMP]
+ * specification and an attempt was made to align the terminology with the specification.
+ * This was done with some success. But old names remain at places. I have decided to
+ * favor compatibility with previous implementation over reworking everything.
+ * That is also the reason that the NTLMEngine interface is unchanged.
+ * The extension of this implementation was mostly motivated by the needs of
+ * CredSSP protocol. CredSSP needs NTLM key exchange and message integrity/confidentiality.
+ * This class is using a lot of inner classes. That is how the original implementation
+ * looked like. Maybe it should be separated to ordinary classes in the future.
+ * The connection-less mode of operation is only partially implemented and not really tested.
+ * </p>
  *
  * @since 4.1
  */
-final class NTLMEngineImpl implements NTLMEngine {
+final class NTLMEngineImpl implements NTLMEngine
+{
 
     /** Unicode encoding */
-    private static final Charset UNICODE_LITTLE_UNMARKED = CharsetUtils.lookup("UnicodeLittleUnmarked");
+    private static final Charset UNICODE_LITTLE_UNMARKED = CharsetUtils.lookup( "UnicodeLittleUnmarked" );
     /** Character encoding */
     private static final Charset DEFAULT_CHARSET = Consts.ASCII;
 
@@ -58,48 +90,243 @@ final class NTLMEngineImpl implements NTLMEngine {
     // http://davenport.sourceforge.net/ntlm.html
     // and
     // http://msdn.microsoft.com/en-us/library/cc236650%28v=prot.20%29.aspx
-    protected static final int FLAG_REQUEST_UNICODE_ENCODING = 0x00000001;      // Unicode string encoding requested
-    protected static final int FLAG_REQUEST_TARGET = 0x00000004;                      // Requests target field
-    protected static final int FLAG_REQUEST_SIGN = 0x00000010;  // Requests all messages have a signature attached, in NEGOTIATE message.
-    protected static final int FLAG_REQUEST_SEAL = 0x00000020;  // Request key exchange for message confidentiality in NEGOTIATE message.  MUST be used in conjunction with 56BIT.
-    protected static final int FLAG_REQUEST_LAN_MANAGER_KEY = 0x00000080;    // Request Lan Manager key instead of user session key
-    protected static final int FLAG_REQUEST_NTLMv1 = 0x00000200; // Request NTLMv1 security.  MUST be set in NEGOTIATE and CHALLENGE both
-    protected static final int FLAG_DOMAIN_PRESENT = 0x00001000;        // Domain is present in message
-    protected static final int FLAG_WORKSTATION_PRESENT = 0x00002000;   // Workstation is present in message
-    protected static final int FLAG_REQUEST_ALWAYS_SIGN = 0x00008000;   // Requests a signature block on all messages.  Overridden by REQUEST_SIGN and REQUEST_SEAL.
-    protected static final int FLAG_REQUEST_NTLM2_SESSION = 0x00080000; // From server in challenge, requesting NTLM2 session security
-    protected static final int FLAG_REQUEST_VERSION = 0x02000000;       // Request protocol version
-    protected static final int FLAG_TARGETINFO_PRESENT = 0x00800000;    // From server in challenge message, indicating targetinfo is present
-    protected static final int FLAG_REQUEST_128BIT_KEY_EXCH = 0x20000000; // Request explicit 128-bit key exchange
-    protected static final int FLAG_REQUEST_EXPLICIT_KEY_EXCH = 0x40000000;     // Request explicit key exchange
-    protected static final int FLAG_REQUEST_56BIT_ENCRYPTION = 0x80000000;      // Must be used in conjunction with SEAL
+    // [MS-NLMP] section 2.2.2.5
+    public static final int FLAG_REQUEST_UNICODE_ENCODING = 0x00000001; // Unicode string encoding requested
+    public static final int FLAG_REQUEST_OEM_ENCODING = 0x00000002; // OEM codepage sstring encoding requested
+    public static final int FLAG_REQUEST_TARGET = 0x00000004; // Requests target field
+    public static final int FLAG_REQUEST_SIGN = 0x00000010; // Requests all messages have a signature attached, in NEGOTIATE message.
+    public static final int FLAG_REQUEST_SEAL = 0x00000020; // Request key exchange for message confidentiality in NEGOTIATE message.  MUST be used in conjunction with 56BIT.
+    public static final int FLAG_REQUEST_LAN_MANAGER_KEY = 0x00000080; // Request Lan Manager key instead of user session key
+    public static final int FLAG_REQUEST_NTLMv1 = 0x00000200; // Request NTLMv1 security.  MUST be set in NEGOTIATE and CHALLENGE both
+    public static final int FLAG_DOMAIN_PRESENT = 0x00001000; // Domain is present in message
+    public static final int FLAG_WORKSTATION_PRESENT = 0x00002000; // Workstation is present in message
+    public static final int FLAG_REQUEST_ALWAYS_SIGN = 0x00008000; // Requests a signature block on all messages.  Overridden by REQUEST_SIGN and REQUEST_SEAL.
+    public static final int FLAG_REQUEST_NTLM2_SESSION = 0x00080000; // From server in challenge, requesting NTLM2 session security
+    public static final int FLAG_REQUEST_VERSION = 0x02000000; // Request protocol version
+    public static final int FLAG_TARGETINFO_PRESENT = 0x00800000; // From server in challenge message, indicating targetinfo is present
+    public static final int FLAG_REQUEST_128BIT_KEY_EXCH = 0x20000000; // Request explicit 128-bit key exchange
+    public static final int FLAG_REQUEST_EXPLICIT_KEY_EXCH = 0x40000000; // Request explicit key exchange
+    public static final int FLAG_REQUEST_56BIT_ENCRYPTION = 0x80000000; // Must be used in conjunction with SEAL
 
+    // Attribute-value identifiers (AvId)
+    // according to [MS-NLMP] section 2.2.2.1
+    public static final int MSV_AV_EOL = 0x0000; // Indicates that this is the last AV_PAIR in the list.
+    public static final int MSV_AV_NB_COMPUTER_NAME = 0x0001; // The server's NetBIOS computer name.
+    public static final int MSV_AV_NB_DOMAIN_NAME = 0x0002; // The server's NetBIOS domain name.
+    public static final int MSV_AV_DNS_COMPUTER_NAME = 0x0003; // The fully qualified domain name (FQDN) of the computer.
+    public static final int MSV_AV_DNS_DOMAIN_NAME = 0x0004; // The FQDN of the domain.
+    public static final int MSV_AV_DNS_TREE_NAME = 0x0005; // The FQDN of the forest.
+    public static final int MSV_AV_FLAGS = 0x0006; // A 32-bit value indicating server or client configuration.
+    public static final int MSV_AV_TIMESTAMP = 0x0007; // server local time
+    public static final int MSV_AV_SINGLE_HOST = 0x0008; // A Single_Host_Data structure.
+    public static final int MSV_AV_TARGET_NAME = 0x0009; // The SPN of the target server.
+    public static final int MSV_AV_CHANNEL_BINDINGS = 0x000A; // A channel bindings hash.
+
+    public static final int MSV_AV_FLAGS_ACCOUNT_AUTH_CONSTAINED = 0x00000001; // Indicates to the client that the account authentication is constrained.
+    public static final int MSV_AV_FLAGS_MIC = 0x00000002; // Indicates that the client is providing message integrity in the MIC field in the AUTHENTICATE_MESSAGE.
+    public static final int MSV_AV_FLAGS_UNTRUSTED_TARGET_SPN = 0x00000004; // Indicates that the client is providing a target SPN generated from an untrusted source.
 
     /** Secure random generator */
     private static final java.security.SecureRandom RND_GEN;
-    static {
+    static
+    {
         java.security.SecureRandom rnd = null;
-        try {
-            rnd = java.security.SecureRandom.getInstance("SHA1PRNG");
-        } catch (final Exception ignore) {
+        try
+        {
+            rnd = java.security.SecureRandom.getInstance( "SHA1PRNG" );
+        }
+        catch ( final Exception ignore )
+        {
         }
         RND_GEN = rnd;
     }
 
     /** The signature string as bytes in the default encoding */
-    private static final byte[] SIGNATURE;
+    private static final byte[] SIGNATURE = getNullTerminatedAsciiString( "NTLMSSP" );
 
-    static {
-        final byte[] bytesWithoutNull = "NTLMSSP".getBytes(Consts.ASCII);
-        SIGNATURE = new byte[bytesWithoutNull.length + 1];
-        System.arraycopy(bytesWithoutNull, 0, SIGNATURE, 0, bytesWithoutNull.length);
-        SIGNATURE[bytesWithoutNull.length] = (byte) 0x00;
+    // Key derivation magic strings for the SIGNKEY algorithm defined in
+    // [MS-NLMP] section 3.4.5.2
+    private static final byte[] SIGN_MAGIC_SERVER = getNullTerminatedAsciiString(
+        "session key to server-to-client signing key magic constant" );
+    private static final byte[] SIGN_MAGIC_CLIENT = getNullTerminatedAsciiString(
+        "session key to client-to-server signing key magic constant" );
+    private static final byte[] SEAL_MAGIC_SERVER = getNullTerminatedAsciiString(
+        "session key to server-to-client sealing key magic constant" );
+    private static final byte[] SEAL_MAGIC_CLIENT = getNullTerminatedAsciiString(
+        "session key to client-to-server sealing key magic constant" );
+
+    // prefix for GSS API channel binding
+    private static final byte[] MAGIC_TLS_SERVER_ENDPOINT = "tls-server-end-point:".getBytes( Consts.ASCII );
+
+
+    private static byte[] getNullTerminatedAsciiString( final String source )
+    {
+        final byte[] bytesWithoutNull = source.getBytes( Consts.ASCII );
+        final byte[] target = new byte[bytesWithoutNull.length + 1];
+        System.arraycopy( bytesWithoutNull, 0, target, 0, bytesWithoutNull.length );
+        target[bytesWithoutNull.length] = ( byte ) 0x00;
+        return target;
     }
 
     private static final String TYPE_1_MESSAGE = new Type1Message().getResponse();
 
+    private static final Log log = LogFactory.getLog( NTLMEngineImpl.class );
+
+    /**
+     * Enabling or disabling the development trace (extra logging).
+     * We do NOT want this to be enabled by default.
+     * We do not want to enable it even if full logging is turned on.
+     * This may leak sensitive key material to the log files. It is supposed to be used only
+     * for development purposes. We really need this to diagnose protocol issues, especially
+     * if NTLM is used inside CredSSP.
+     */
+    private static boolean develTrace = false;
+
+    final NTCredentials credentials;
+    final private boolean isConnection;
+
+    /**
+     * Type 1 (NEGOTIATE) message sent by the client.
+     */
+    private Type1Message type1Message;
+
+    /**
+     * Type 2 (CHALLENGE) message received by the client.
+     */
+    private Type2Message type2Message;
+
+    /**
+     * Type 3 (AUTHENTICATE) message sent by the client.
+     */
+    private Type3Message type3Message;
+
+    /**
+     * The key that is result of the NTLM key exchange.
+     */
+    private byte[] exportedSessionKey;
+
+
+    // just for compatibility
+    public NTLMEngineImpl()
+    {
+        this( null, true );
+    }
+
+
+    /**
+     * Creates a new instance of NTLM engine.
+     *
+     * @param credentials NT credentials that will be used in the message exchange.
+     * @param isConnection true for connection mode, false for connection-less mode.
+     */
+    public NTLMEngineImpl( final NTCredentials credentials, final boolean isConnection )
+    {
+        super();
+        this.credentials = credentials;
+        this.isConnection = isConnection;
+    }
+
+
+    /**
+     * Generate (create) new NTLM AUTHENTICATE (type 1) message in a form of Java object.
+     * The generated message is remembered by the engine, e.g. for the purpose of MIC computation.
+     *
+     * @param ntlmFlags initial flags for the message. These flags influence the behavior of
+     *                  entire protocol exchange.
+     * @return NTLM AUTHENTICATE (type 1) message in a form of Java object
+     * @throws NTLMEngineException in case of any (foreseeable) error
+     */
+    public Type1Message generateType1MsgObject( final Integer ntlmFlags ) throws NTLMEngineException
+    {
+        if ( type1Message != null )
+        {
+            throw new NTLMEngineException( "Type 1 message already generated" );
+        }
+        if ( credentials == null )
+        {
+            throw new NTLMEngineException( "No credentials" );
+        }
+        type1Message = new Type1Message(
+            credentials.getDomain(),
+            credentials.getWorkstation(),
+            ntlmFlags );
+        return type1Message;
+    }
+
+
+    /**
+     * Parse NTLM CHALLENGE (type 2) message in a base64-encoded format. The message is remembered by the engine.
+     *
+     * @param type2MessageBase64 base64 encoded NTLM challenge message
+     * @return NTLM challenge message in a form of Java object.
+     * @throws NTLMEngineException in case of any (foreseeable) error
+     */
+    public Type2Message parseType2Message( final String type2MessageBase64 ) throws NTLMEngineException
+    {
+        return parseType2Message( Base64.decodeBase64( type2MessageBase64.getBytes( DEFAULT_CHARSET ) ) );
+    }
+
+
+    /**
+     * Parse NTLM CHALLENGE (type 2) message in a binary format. The message is remembered by the engine.
+     *
+     * @param type2MessageBytes binary (byte array) NTLM challenge message
+     * @return NTLM challenge message in a form of Java object.
+     * @throws NTLMEngineException in case of any (foreseeable) error
+     */
+    public Type2Message parseType2Message( final byte[] type2MessageBytes ) throws NTLMEngineException
+    {
+        if ( type2Message != null )
+        {
+            throw new NTLMEngineException( "Type 2 message already parsed" );
+        }
+        type2Message = new Type2Message( type2MessageBytes );
+        return type2Message;
+    }
+
+
+    /**
+     * Generate NTLM AUTHENTICATE (type 3) message based on previous messages that were seen by the engine.
+     *
+     * @param peerServerCertificate optional peer certificate. If present then it will be used to set up
+     *                              GSS API channel binding.
+     * @return NTLM authenticate message in a form of Java object.
+     * @throws NTLMEngineException in case of any (foreseeable) error
+     */
+    public Type3Message generateType3MsgObject( final X509Certificate peerServerCertificate ) throws NTLMEngineException
+    {
+        if ( type3Message != null )
+        {
+            throw new NTLMEngineException( "Type 3 message already generated" );
+        }
+        if ( type2Message == null )
+        {
+            throw new NTLMEngineException( "Type 2 message was not yet parsed" );
+        }
+        if ( credentials == null )
+        {
+            throw new NTLMEngineException( "No credentials" );
+        }
+        type3Message = new Type3Message(
+            credentials.getDomain(),
+            credentials.getWorkstation(),
+            credentials.getUserName(),
+            credentials.getPassword(),
+            type2Message.getChallenge(),
+            type2Message.getFlags(),
+            type2Message.getTarget(),
+            type2Message.getTargetInfo(),
+            peerServerCertificate );
+        this.exportedSessionKey = type3Message.getExportedSessionKey();
+        type3Message.addMic( type1Message.getBytes(), type2Message.getBytes() );
+        return type3Message;
+    }
+
+
     /**
      * Returns the response for the given message.
+     * This method is not really used. It is kept only for compatibility
+     * with previous implementation.
      *
      * @param message
      *            the message that was received from the server.
@@ -115,24 +342,32 @@ final class NTLMEngineImpl implements NTLMEngine {
      * @throws org.apache.http.HttpException
      *             If the messages cannot be retrieved.
      */
-    static String getResponseFor(final String message, final String username, final String password,
-            final String host, final String domain) throws NTLMEngineException {
+    @Deprecated
+    static String getResponseFor( final String message, final String username, final String password,
+        final String host, final String domain ) throws NTLMEngineException
+    {
 
         final String response;
-        if (message == null || message.trim().equals("")) {
-            response = getType1Message(host, domain);
-        } else {
-            final Type2Message t2m = new Type2Message(message);
-            response = getType3Message(username, password, host, domain, t2m.getChallenge(), t2m
-                    .getFlags(), t2m.getTarget(), t2m.getTargetInfo());
+        if ( message == null || message.trim().equals( "" ) )
+        {
+            response = getType1Message( host, domain );
+        }
+        else
+        {
+            final Type2Message t2m = new Type2Message( message );
+            response = getType3Message( username, password, host, domain, t2m.getChallenge(), t2m
+                .getFlags(), t2m.getTarget(), t2m.getTargetInfo() );
         }
         return response;
     }
 
+
     /**
      * Creates the first message (type 1 message) in the NTLM authentication
      * sequence. This message includes the user name, domain and host for the
-     * authentication session.
+     * authentication session. The message is created as a singleton. It is not
+     * remembered by the engine, therefore this method has limited functionality
+     * (e.g. no MIC). This is kept only for compatibility with previous implementation.
      *
      * @param host
      *            the computer name of the host requesting authentication.
@@ -140,17 +375,23 @@ final class NTLMEngineImpl implements NTLMEngine {
      *            The domain to authenticate with.
      * @return String the message to add to the HTTP request header.
      */
-    static String getType1Message(final String host, final String domain) throws NTLMEngineException {
+    @Deprecated
+    static String getType1Message( final String host, final String domain ) throws NTLMEngineException
+    {
         // For compatibility reason do not include domain and host in type 1 message
         //return new Type1Message(domain, host).getResponse();
         return TYPE_1_MESSAGE;
     }
+
 
     /**
      * Creates the type 3 message using the given server nonce. The type 3
      * message includes all the information for authentication, host, domain,
      * username and the result of encrypting the nonce sent by the server using
      * the user's password as the key.
+     * The message is not remembered by the engine, therefore this method has limited
+     * functionality (e.g. no MIC). This is kept only for compatibility with previous
+     * implementation.
      *
      * @param user
      *            The user name. This should not include the domain name.
@@ -166,87 +407,116 @@ final class NTLMEngineImpl implements NTLMEngine {
      * @throws NTLMEngineException
      *             If {@encrypt(byte[],byte[])} fails.
      */
-    static String getType3Message(final String user, final String password, final String host, final String domain,
-            final byte[] nonce, final int type2Flags, final String target, final byte[] targetInformation)
-            throws NTLMEngineException {
-        return new Type3Message(domain, host, user, password, nonce, type2Flags, target,
-                targetInformation).getResponse();
+    @Deprecated
+    static String getType3Message( final String user, final String password, final String host, final String domain,
+        final byte[] nonce, final int type2Flags, final String target, final byte[] targetInformation )
+        throws NTLMEngineException
+    {
+        return new Type3Message( domain, host, user, password, nonce, type2Flags, target,
+            targetInformation, null ).getResponse();
     }
 
+
     /** Strip dot suffix from a name */
-    private static String stripDotSuffix(final String value) {
-        if (value == null) {
+    private static String stripDotSuffix( final String value )
+    {
+        if ( value == null )
+        {
             return null;
         }
-        final int index = value.indexOf(".");
-        if (index != -1) {
-            return value.substring(0, index);
+        final int index = value.indexOf( "." );
+        if ( index != -1 )
+        {
+            return value.substring( 0, index );
         }
         return value;
     }
 
+
     /** Convert host to standard form */
-    private static String convertHost(final String host) {
-        return stripDotSuffix(host);
+    private static String convertHost( final String host )
+    {
+        return stripDotSuffix( host );
     }
+
 
     /** Convert domain to standard form */
-    private static String convertDomain(final String domain) {
-        return stripDotSuffix(domain);
+    private static String convertDomain( final String domain )
+    {
+        return stripDotSuffix( domain );
     }
 
-    private static int readULong(final byte[] src, final int index) throws NTLMEngineException {
-        if (src.length < index + 4) {
-            throw new NTLMEngineException("NTLM authentication - buffer too small for DWORD");
+
+    private static int readULong( final byte[] src, final int index ) throws NTLMEngineException
+    {
+        if ( src.length < index + 4 )
+        {
+            throw new NTLMEngineException( "NTLM authentication - buffer too small for DWORD" );
         }
-        return (src[index] & 0xff) | ((src[index + 1] & 0xff) << 8)
-                | ((src[index + 2] & 0xff) << 16) | ((src[index + 3] & 0xff) << 24);
+        return ( src[index] & 0xff ) | ( ( src[index + 1] & 0xff ) << 8 )
+            | ( ( src[index + 2] & 0xff ) << 16 ) | ( ( src[index + 3] & 0xff ) << 24 );
     }
 
-    private static int readUShort(final byte[] src, final int index) throws NTLMEngineException {
-        if (src.length < index + 2) {
-            throw new NTLMEngineException("NTLM authentication - buffer too small for WORD");
+
+    private static int readUShort( final byte[] src, final int index ) throws NTLMEngineException
+    {
+        if ( src.length < index + 2 )
+        {
+            throw new NTLMEngineException( "NTLM authentication - buffer too small for WORD" );
         }
-        return (src[index] & 0xff) | ((src[index + 1] & 0xff) << 8);
+        return ( src[index] & 0xff ) | ( ( src[index + 1] & 0xff ) << 8 );
     }
 
-    private static byte[] readSecurityBuffer(final byte[] src, final int index) throws NTLMEngineException {
-        final int length = readUShort(src, index);
-        final int offset = readULong(src, index + 4);
-        if (src.length < offset + length) {
+
+    private static byte[] readSecurityBuffer( final byte[] src, final int index ) throws NTLMEngineException
+    {
+        final int length = readUShort( src, index );
+        final int offset = readULong( src, index + 4 );
+        if ( src.length < offset + length )
+        {
             throw new NTLMEngineException(
-                    "NTLM authentication - buffer too small for data item");
+                "NTLM authentication - buffer too small for data item" );
         }
         final byte[] buffer = new byte[length];
-        System.arraycopy(src, offset, buffer, 0, length);
+        System.arraycopy( src, offset, buffer, 0, length );
         return buffer;
     }
 
+
     /** Calculate a challenge block */
-    private static byte[] makeRandomChallenge() throws NTLMEngineException {
-        if (RND_GEN == null) {
-            throw new NTLMEngineException("Random generator not available");
+    private static byte[] makeRandomChallenge() throws NTLMEngineException
+    {
+        if ( RND_GEN == null )
+        {
+            throw new NTLMEngineException( "Random generator not available" );
         }
         final byte[] rval = new byte[8];
-        synchronized (RND_GEN) {
-            RND_GEN.nextBytes(rval);
+        synchronized ( RND_GEN )
+        {
+            RND_GEN.nextBytes( rval );
         }
         return rval;
     }
+
 
     /** Calculate a 16-byte secondary key */
-    private static byte[] makeSecondaryKey() throws NTLMEngineException {
-        if (RND_GEN == null) {
-            throw new NTLMEngineException("Random generator not available");
+    private static byte[] makeSecondaryKey() throws NTLMEngineException
+    {
+        if ( RND_GEN == null )
+        {
+            throw new NTLMEngineException( "Random generator not available" );
         }
         final byte[] rval = new byte[16];
-        synchronized (RND_GEN) {
-            RND_GEN.nextBytes(rval);
+        synchronized ( RND_GEN )
+        {
+            RND_GEN.nextBytes( rval );
         }
+
         return rval;
     }
 
-    protected static class CipherGen {
+    protected static class CipherGen
+    {
 
         protected final String domain;
         protected final String user;
@@ -264,10 +534,10 @@ final class NTLMEngineImpl implements NTLMEngine {
         // Stuff we always generate
         protected byte[] lmHash = null;
         protected byte[] lmResponse = null;
-        protected byte[] ntlmHash = null;
+        protected byte[] ntlmPasswordHash = null;
         protected byte[] ntlmResponse = null;
-        protected byte[] ntlmv2Hash = null;
-        protected byte[] lmv2Hash = null;
+        protected byte[] responseKeyNt = null;
+        protected byte[] responseKeyLm = null;
         protected byte[] lmv2Response = null;
         protected byte[] ntlmv2Blob = null;
         protected byte[] ntlmv2Response = null;
@@ -275,14 +545,16 @@ final class NTLMEngineImpl implements NTLMEngine {
         protected byte[] lm2SessionResponse = null;
         protected byte[] lmUserSessionKey = null;
         protected byte[] ntlmUserSessionKey = null;
-        protected byte[] ntlmv2UserSessionKey = null;
+        protected byte[] ntlmv2SessionBaseKey = null;
         protected byte[] ntlm2SessionResponseUserSessionKey = null;
         protected byte[] lanManagerSessionKey = null;
 
-        public CipherGen(final String domain, final String user, final String password,
+
+        public CipherGen( final String domain, final String user, final String password,
             final byte[] challenge, final String target, final byte[] targetInformation,
             final byte[] clientChallenge, final byte[] clientChallenge2,
-            final byte[] secondaryKey, final byte[] timestamp) {
+            final byte[] secondaryKey, final byte[] timestamp )
+        {
             this.domain = domain;
             this.target = target;
             this.user = user;
@@ -295,251 +567,332 @@ final class NTLMEngineImpl implements NTLMEngine {
             this.timestamp = timestamp;
         }
 
-        public CipherGen(final String domain, final String user, final String password,
-            final byte[] challenge, final String target, final byte[] targetInformation) {
-            this(domain, user, password, challenge, target, targetInformation, null, null, null, null);
+
+        public CipherGen( final String domain, final String user, final String password,
+            final byte[] challenge, final String target, final byte[] targetInformation )
+        {
+            this( domain, user, password, challenge, target, targetInformation, null, null, null, null );
         }
+
 
         /** Calculate and return client challenge */
         public byte[] getClientChallenge()
-            throws NTLMEngineException {
-            if (clientChallenge == null) {
+            throws NTLMEngineException
+        {
+            if ( clientChallenge == null )
+            {
                 clientChallenge = makeRandomChallenge();
             }
             return clientChallenge;
         }
 
+
         /** Calculate and return second client challenge */
         public byte[] getClientChallenge2()
-            throws NTLMEngineException {
-            if (clientChallenge2 == null) {
+            throws NTLMEngineException
+        {
+            if ( clientChallenge2 == null )
+            {
                 clientChallenge2 = makeRandomChallenge();
             }
             return clientChallenge2;
         }
 
+
         /** Calculate and return random secondary key */
         public byte[] getSecondaryKey()
-            throws NTLMEngineException {
-            if (secondaryKey == null) {
+            throws NTLMEngineException
+        {
+            if ( secondaryKey == null )
+            {
                 secondaryKey = makeSecondaryKey();
             }
             return secondaryKey;
         }
 
+
         /** Calculate and return the LMHash */
         public byte[] getLMHash()
-            throws NTLMEngineException {
-            if (lmHash == null) {
-                lmHash = lmHash(password);
+            throws NTLMEngineException
+        {
+            if ( lmHash == null )
+            {
+                lmHash = lmHash( password );
             }
             return lmHash;
         }
 
+
         /** Calculate and return the LMResponse */
         public byte[] getLMResponse()
-            throws NTLMEngineException {
-            if (lmResponse == null) {
-                lmResponse = lmResponse(getLMHash(),challenge);
+            throws NTLMEngineException
+        {
+            if ( lmResponse == null )
+            {
+                lmResponse = lmResponse( getLMHash(), challenge );
             }
             return lmResponse;
         }
 
+
         /** Calculate and return the NTLMHash */
-        public byte[] getNTLMHash()
-            throws NTLMEngineException {
-            if (ntlmHash == null) {
-                ntlmHash = ntlmHash(password);
+        public byte[] getNTLMPasswordHash()
+            throws NTLMEngineException
+        {
+            if ( ntlmPasswordHash == null )
+            {
+                ntlmPasswordHash = ntowfv1( password );
             }
-            return ntlmHash;
+            return ntlmPasswordHash;
         }
+
 
         /** Calculate and return the NTLMResponse */
         public byte[] getNTLMResponse()
-            throws NTLMEngineException {
-            if (ntlmResponse == null) {
-                ntlmResponse = lmResponse(getNTLMHash(),challenge);
+            throws NTLMEngineException
+        {
+            if ( ntlmResponse == null )
+            {
+                ntlmResponse = lmResponse( getNTLMPasswordHash(), challenge );
             }
             return ntlmResponse;
         }
 
-        /** Calculate the LMv2 hash */
-        public byte[] getLMv2Hash()
-            throws NTLMEngineException {
-            if (lmv2Hash == null) {
-                lmv2Hash = lmv2Hash(domain, user, getNTLMHash());
+
+        /** Calculate the LMv2 hash. ResponseKeyLM in the specifications. */
+        public byte[] getResponseKeyLm()
+            throws NTLMEngineException
+        {
+            if ( responseKeyLm == null )
+            {
+                responseKeyLm = ntowfv2lm( domain, user, password );
             }
-            return lmv2Hash;
+            return responseKeyLm;
         }
 
-        /** Calculate the NTLMv2 hash */
-        public byte[] getNTLMv2Hash()
-            throws NTLMEngineException {
-            if (ntlmv2Hash == null) {
-                ntlmv2Hash = ntlmv2Hash(domain, user, getNTLMHash());
+
+        /** Calculate the NTLMv2 hash. ResponseKeyNT in the specifications. */
+        public byte[] getResponseKeyNt()
+            throws NTLMEngineException
+        {
+            if ( responseKeyNt == null )
+            {
+                responseKeyNt = ntowfv2( domain, user, getNTLMPasswordHash() );
             }
-            return ntlmv2Hash;
+            return responseKeyNt;
         }
+
 
         /** Calculate a timestamp */
-        public byte[] getTimestamp() {
-            if (timestamp == null) {
+        public byte[] getTimestamp()
+        {
+            if ( timestamp == null )
+            {
                 long time = System.currentTimeMillis();
                 time += 11644473600000l; // milliseconds from January 1, 1601 -> epoch.
                 time *= 10000; // tenths of a microsecond.
                 // convert to little-endian byte array.
                 timestamp = new byte[8];
-                for (int i = 0; i < 8; i++) {
-                    timestamp[i] = (byte) time;
+                for ( int i = 0; i < 8; i++ )
+                {
+                    timestamp[i] = ( byte ) time;
                     time >>>= 8;
                 }
+                //                timestamp = DebugUtil.fromHex( "d4 6e 19 48 41 81 d2 01" );
             }
             return timestamp;
         }
 
+
         /** Calculate the NTLMv2Blob */
         public byte[] getNTLMv2Blob()
-            throws NTLMEngineException {
-            if (ntlmv2Blob == null) {
-                ntlmv2Blob = createBlob(getClientChallenge2(), targetInformation, getTimestamp());
+            throws NTLMEngineException
+        {
+            if ( ntlmv2Blob == null )
+            {
+                ntlmv2Blob = createBlob( getClientChallenge2(), targetInformation, getTimestamp() );
             }
             return ntlmv2Blob;
         }
 
-        /** Calculate the NTLMv2Response */
+
+        /** Calculate the NTLMv2Response. NtChallengeResponse in the specifications. */
         public byte[] getNTLMv2Response()
-            throws NTLMEngineException {
-            if (ntlmv2Response == null) {
-                ntlmv2Response = lmv2Response(getNTLMv2Hash(),challenge,getNTLMv2Blob());
+            throws NTLMEngineException
+        {
+            if ( ntlmv2Response == null )
+            {
+                ntlmv2Response = lmv2Response( getResponseKeyNt(), challenge, getNTLMv2Blob() );
             }
             return ntlmv2Response;
         }
 
+
         /** Calculate the LMv2Response */
         public byte[] getLMv2Response()
-            throws NTLMEngineException {
-            if (lmv2Response == null) {
-                lmv2Response = lmv2Response(getLMv2Hash(),challenge,getClientChallenge());
+            throws NTLMEngineException
+        {
+            if ( lmv2Response == null )
+            {
+                lmv2Response = lmv2Response( getResponseKeyLm(), challenge, getClientChallenge() );
             }
             return lmv2Response;
         }
 
+
         /** Get NTLM2SessionResponse */
         public byte[] getNTLM2SessionResponse()
-            throws NTLMEngineException {
-            if (ntlm2SessionResponse == null) {
-                ntlm2SessionResponse = ntlm2SessionResponse(getNTLMHash(),challenge,getClientChallenge());
+            throws NTLMEngineException
+        {
+            if ( ntlm2SessionResponse == null )
+            {
+                ntlm2SessionResponse = ntlm2SessionResponse( getNTLMPasswordHash(), challenge, getClientChallenge() );
             }
             return ntlm2SessionResponse;
         }
 
+
         /** Calculate and return LM2 session response */
         public byte[] getLM2SessionResponse()
-            throws NTLMEngineException {
-            if (lm2SessionResponse == null) {
+            throws NTLMEngineException
+        {
+            if ( lm2SessionResponse == null )
+            {
                 final byte[] clntChallenge = getClientChallenge();
                 lm2SessionResponse = new byte[24];
-                System.arraycopy(clntChallenge, 0, lm2SessionResponse, 0, clntChallenge.length);
-                Arrays.fill(lm2SessionResponse, clntChallenge.length, lm2SessionResponse.length, (byte) 0x00);
+                System.arraycopy( clntChallenge, 0, lm2SessionResponse, 0, clntChallenge.length );
+                Arrays.fill( lm2SessionResponse, clntChallenge.length, lm2SessionResponse.length, ( byte ) 0x00 );
             }
             return lm2SessionResponse;
         }
 
+
         /** Get LMUserSessionKey */
         public byte[] getLMUserSessionKey()
-            throws NTLMEngineException {
-            if (lmUserSessionKey == null) {
+            throws NTLMEngineException
+        {
+            if ( lmUserSessionKey == null )
+            {
                 lmUserSessionKey = new byte[16];
-                System.arraycopy(getLMHash(), 0, lmUserSessionKey, 0, 8);
-                Arrays.fill(lmUserSessionKey, 8, 16, (byte) 0x00);
+                System.arraycopy( getLMHash(), 0, lmUserSessionKey, 0, 8 );
+                Arrays.fill( lmUserSessionKey, 8, 16, ( byte ) 0x00 );
             }
             return lmUserSessionKey;
         }
 
+
         /** Get NTLMUserSessionKey */
         public byte[] getNTLMUserSessionKey()
-            throws NTLMEngineException {
-            if (ntlmUserSessionKey == null) {
+            throws NTLMEngineException
+        {
+            if ( ntlmUserSessionKey == null )
+            {
                 final MD4 md4 = new MD4();
-                md4.update(getNTLMHash());
+                md4.update( getNTLMPasswordHash() );
                 ntlmUserSessionKey = md4.getOutput();
             }
             return ntlmUserSessionKey;
         }
 
+
         /** GetNTLMv2UserSessionKey */
-        public byte[] getNTLMv2UserSessionKey()
-            throws NTLMEngineException {
-            if (ntlmv2UserSessionKey == null) {
-                final byte[] ntlmv2hash = getNTLMv2Hash();
-                final byte[] truncatedResponse = new byte[16];
-                System.arraycopy(getNTLMv2Response(), 0, truncatedResponse, 0, 16);
-                ntlmv2UserSessionKey = hmacMD5(truncatedResponse, ntlmv2hash);
+        public byte[] getNTLMv2SessionBaseKey()
+            throws NTLMEngineException
+        {
+            if ( ntlmv2SessionBaseKey == null )
+            {
+                final byte[] responseKeyNt = getResponseKeyNt();
+                final byte[] ntChallengeResponse = getNTLMv2Response();
+                // Strictly speaking, the NtChallengeResponse should be composed from the ntProofStr and temp
+                // and we would like to reuse the ntProofStr here. But the construction of challenge response
+                // happens inside the lmv2Response() method called from getNTLMv2Response() method.
+                // Therefore we will rip out ntProofStr of the ntChallengeResponse.
+                final byte[] ntProofStr = new byte[16];
+                System.arraycopy( ntChallengeResponse, 0, ntProofStr, 0, 16 );
+                ntlmv2SessionBaseKey = hmacMD5( ntProofStr, responseKeyNt );
             }
-            return ntlmv2UserSessionKey;
+            return ntlmv2SessionBaseKey;
         }
+
 
         /** Get NTLM2SessionResponseUserSessionKey */
         public byte[] getNTLM2SessionResponseUserSessionKey()
-            throws NTLMEngineException {
-            if (ntlm2SessionResponseUserSessionKey == null) {
+            throws NTLMEngineException
+        {
+            if ( ntlm2SessionResponseUserSessionKey == null )
+            {
                 final byte[] ntlm2SessionResponseNonce = getLM2SessionResponse();
                 final byte[] sessionNonce = new byte[challenge.length + ntlm2SessionResponseNonce.length];
-                System.arraycopy(challenge, 0, sessionNonce, 0, challenge.length);
-                System.arraycopy(ntlm2SessionResponseNonce, 0, sessionNonce, challenge.length, ntlm2SessionResponseNonce.length);
-                ntlm2SessionResponseUserSessionKey = hmacMD5(sessionNonce,getNTLMUserSessionKey());
+                System.arraycopy( challenge, 0, sessionNonce, 0, challenge.length );
+                System.arraycopy( ntlm2SessionResponseNonce, 0, sessionNonce, challenge.length,
+                    ntlm2SessionResponseNonce.length );
+                ntlm2SessionResponseUserSessionKey = hmacMD5( sessionNonce, getNTLMUserSessionKey() );
             }
             return ntlm2SessionResponseUserSessionKey;
         }
 
+
         /** Get LAN Manager session key */
         public byte[] getLanManagerSessionKey()
-            throws NTLMEngineException {
-            if (lanManagerSessionKey == null) {
-                try {
+            throws NTLMEngineException
+        {
+            if ( lanManagerSessionKey == null )
+            {
+                try
+                {
                     final byte[] keyBytes = new byte[14];
-                    System.arraycopy(getLMHash(), 0, keyBytes, 0, 8);
-                    Arrays.fill(keyBytes, 8, keyBytes.length, (byte)0xbd);
-                    final Key lowKey = createDESKey(keyBytes, 0);
-                    final Key highKey = createDESKey(keyBytes, 7);
+                    System.arraycopy( getLMHash(), 0, keyBytes, 0, 8 );
+                    Arrays.fill( keyBytes, 8, keyBytes.length, ( byte ) 0xbd );
+                    final Key lowKey = createDESKey( keyBytes, 0 );
+                    final Key highKey = createDESKey( keyBytes, 7 );
                     final byte[] truncatedResponse = new byte[8];
-                    System.arraycopy(getLMResponse(), 0, truncatedResponse, 0, truncatedResponse.length);
-                    Cipher des = Cipher.getInstance("DES/ECB/NoPadding");
-                    des.init(Cipher.ENCRYPT_MODE, lowKey);
-                    final byte[] lowPart = des.doFinal(truncatedResponse);
-                    des = Cipher.getInstance("DES/ECB/NoPadding");
-                    des.init(Cipher.ENCRYPT_MODE, highKey);
-                    final byte[] highPart = des.doFinal(truncatedResponse);
+                    System.arraycopy( getLMResponse(), 0, truncatedResponse, 0, truncatedResponse.length );
+                    Cipher des = Cipher.getInstance( "DES/ECB/NoPadding" );
+                    des.init( Cipher.ENCRYPT_MODE, lowKey );
+                    final byte[] lowPart = des.doFinal( truncatedResponse );
+                    des = Cipher.getInstance( "DES/ECB/NoPadding" );
+                    des.init( Cipher.ENCRYPT_MODE, highKey );
+                    final byte[] highPart = des.doFinal( truncatedResponse );
                     lanManagerSessionKey = new byte[16];
-                    System.arraycopy(lowPart, 0, lanManagerSessionKey, 0, lowPart.length);
-                    System.arraycopy(highPart, 0, lanManagerSessionKey, lowPart.length, highPart.length);
-                } catch (final Exception e) {
-                    throw new NTLMEngineException(e.getMessage(), e);
+                    System.arraycopy( lowPart, 0, lanManagerSessionKey, 0, lowPart.length );
+                    System.arraycopy( highPart, 0, lanManagerSessionKey, lowPart.length, highPart.length );
+                }
+                catch ( final Exception e )
+                {
+                    throw new NTLMEngineException( e.getMessage(), e );
                 }
             }
             return lanManagerSessionKey;
         }
     }
 
+
     /** Calculates HMAC-MD5 */
-    static byte[] hmacMD5(final byte[] value, final byte[] key)
-        throws NTLMEngineException {
-        final HMACMD5 hmacMD5 = new HMACMD5(key);
-        hmacMD5.update(value);
+    static byte[] hmacMD5( final byte[] value, final byte[] key )
+        throws NTLMEngineException
+    {
+        final HMACMD5 hmacMD5 = new HMACMD5( key );
+        hmacMD5.update( value );
         return hmacMD5.getOutput();
     }
 
+
     /** Calculates RC4 */
-    static byte[] RC4(final byte[] value, final byte[] key)
-        throws NTLMEngineException {
-        try {
-            final Cipher rc4 = Cipher.getInstance("RC4");
-            rc4.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(key, "RC4"));
-            return rc4.doFinal(value);
-        } catch (final Exception e) {
-            throw new NTLMEngineException(e.getMessage(), e);
+    static byte[] RC4( final byte[] value, final byte[] key )
+        throws NTLMEngineException
+    {
+        try
+        {
+            final Cipher rc4 = Cipher.getInstance( "RC4" );
+            rc4.init( Cipher.ENCRYPT_MODE, new SecretKeySpec( key, "RC4" ) );
+            return rc4.doFinal( value );
+        }
+        catch ( final Exception e )
+        {
+            throw new NTLMEngineException( e.getMessage(), e );
         }
     }
+
 
     /**
      * Calculates the NTLM2 Session Response for the given challenge, using the
@@ -549,24 +902,30 @@ final class NTLMEngineImpl implements NTLMEngine {
      *         field of the Type 3 message; the LM response field contains the
      *         client challenge, null-padded to 24 bytes.
      */
-    static byte[] ntlm2SessionResponse(final byte[] ntlmHash, final byte[] challenge,
-            final byte[] clientChallenge) throws NTLMEngineException {
-        try {
-            final MessageDigest md5 = MessageDigest.getInstance("MD5");
-            md5.update(challenge);
-            md5.update(clientChallenge);
+    static byte[] ntlm2SessionResponse( final byte[] ntlmHash, final byte[] challenge,
+        final byte[] clientChallenge ) throws NTLMEngineException
+    {
+        try
+        {
+            final MessageDigest md5 = MessageDigest.getInstance( "MD5" );
+            md5.update( challenge );
+            md5.update( clientChallenge );
             final byte[] digest = md5.digest();
 
             final byte[] sessionHash = new byte[8];
-            System.arraycopy(digest, 0, sessionHash, 0, 8);
-            return lmResponse(ntlmHash, sessionHash);
-        } catch (final Exception e) {
-            if (e instanceof NTLMEngineException) {
-                throw (NTLMEngineException) e;
+            System.arraycopy( digest, 0, sessionHash, 0, 8 );
+            return lmResponse( ntlmHash, sessionHash );
+        }
+        catch ( final Exception e )
+        {
+            if ( e instanceof NTLMEngineException )
+            {
+                throw ( NTLMEngineException ) e;
             }
-            throw new NTLMEngineException(e.getMessage(), e);
+            throw new NTLMEngineException( e.getMessage(), e );
         }
     }
+
 
     /**
      * Creates the LM Hash of the user's password.
@@ -577,31 +936,37 @@ final class NTLMEngineImpl implements NTLMEngine {
      * @return The LM Hash of the given password, used in the calculation of the
      *         LM Response.
      */
-    private static byte[] lmHash(final String password) throws NTLMEngineException {
-        try {
-            final byte[] oemPassword = password.toUpperCase(Locale.ROOT).getBytes(Consts.ASCII);
-            final int length = Math.min(oemPassword.length, 14);
+    private static byte[] lmHash( final String password ) throws NTLMEngineException
+    {
+        try
+        {
+            final byte[] oemPassword = password.toUpperCase( Locale.ROOT ).getBytes( Consts.ASCII );
+            final int length = Math.min( oemPassword.length, 14 );
             final byte[] keyBytes = new byte[14];
-            System.arraycopy(oemPassword, 0, keyBytes, 0, length);
-            final Key lowKey = createDESKey(keyBytes, 0);
-            final Key highKey = createDESKey(keyBytes, 7);
-            final byte[] magicConstant = "KGS!@#$%".getBytes(Consts.ASCII);
-            final Cipher des = Cipher.getInstance("DES/ECB/NoPadding");
-            des.init(Cipher.ENCRYPT_MODE, lowKey);
-            final byte[] lowHash = des.doFinal(magicConstant);
-            des.init(Cipher.ENCRYPT_MODE, highKey);
-            final byte[] highHash = des.doFinal(magicConstant);
+            System.arraycopy( oemPassword, 0, keyBytes, 0, length );
+            final Key lowKey = createDESKey( keyBytes, 0 );
+            final Key highKey = createDESKey( keyBytes, 7 );
+            final byte[] magicConstant = "KGS!@#$%".getBytes( Consts.ASCII );
+            final Cipher des = Cipher.getInstance( "DES/ECB/NoPadding" );
+            des.init( Cipher.ENCRYPT_MODE, lowKey );
+            final byte[] lowHash = des.doFinal( magicConstant );
+            des.init( Cipher.ENCRYPT_MODE, highKey );
+            final byte[] highHash = des.doFinal( magicConstant );
             final byte[] lmHash = new byte[16];
-            System.arraycopy(lowHash, 0, lmHash, 0, 8);
-            System.arraycopy(highHash, 0, lmHash, 8, 8);
+            System.arraycopy( lowHash, 0, lmHash, 0, 8 );
+            System.arraycopy( highHash, 0, lmHash, 8, 8 );
             return lmHash;
-        } catch (final Exception e) {
-            throw new NTLMEngineException(e.getMessage(), e);
+        }
+        catch ( final Exception e )
+        {
+            throw new NTLMEngineException( e.getMessage(), e );
         }
     }
 
+
     /**
      * Creates the NTLM Hash of the user's password.
+     * [MS-NLMP] section 3.3.1
      *
      * @param password
      *            The password.
@@ -609,55 +974,63 @@ final class NTLMEngineImpl implements NTLMEngine {
      * @return The NTLM Hash of the given password, used in the calculation of
      *         the NTLM Response and the NTLMv2 and LMv2 Hashes.
      */
-    private static byte[] ntlmHash(final String password) throws NTLMEngineException {
-        if (UNICODE_LITTLE_UNMARKED == null) {
-            throw new NTLMEngineException("Unicode not supported");
-        }
-        final byte[] unicodePassword = password.getBytes(UNICODE_LITTLE_UNMARKED);
+    private static byte[] ntowfv1( final String password ) throws NTLMEngineException
+    {
+        // Password is always uncoded in unicode regardless of the encoding specified by flags
+        final byte[] unicodePassword = password.getBytes( UNICODE_LITTLE_UNMARKED );
         final MD4 md4 = new MD4();
-        md4.update(unicodePassword);
+        md4.update( unicodePassword );
         return md4.getOutput();
     }
 
+
     /**
      * Creates the LMv2 Hash of the user's password.
+     * Corresponds to the LMOWFv2(Passwd, User, UserDom) function from the specification.
+     * [MS-NLMP] section 3.3.1
+     *
+     * However, this has slight twist of uppercasing the domain name. Which I could not find
+     * in the specifications. The function is kept as it is because I'm not sure why it was
+     * implemented like this.
      *
      * @return The LMv2 Hash, used in the calculation of the NTLMv2 and LMv2
      *         Responses.
      */
-    private static byte[] lmv2Hash(final String domain, final String user, final byte[] ntlmHash)
-            throws NTLMEngineException {
-        if (UNICODE_LITTLE_UNMARKED == null) {
-            throw new NTLMEngineException("Unicode not supported");
-        }
-        final HMACMD5 hmacMD5 = new HMACMD5(ntlmHash);
+    private static byte[] ntowfv2lm( final String domain, final String user, final String password )
+        throws NTLMEngineException
+    {
+        // Password is always uncoded in unicode regardless of the encoding specified by flags
+        final HMACMD5 hmacMD5 = new HMACMD5( ntowfv1( password ) );
         // Upper case username, upper case domain!
-        hmacMD5.update(user.toUpperCase(Locale.ROOT).getBytes(UNICODE_LITTLE_UNMARKED));
-        if (domain != null) {
-            hmacMD5.update(domain.toUpperCase(Locale.ROOT).getBytes(UNICODE_LITTLE_UNMARKED));
+        hmacMD5.update( user.toUpperCase( Locale.ROOT ).getBytes( UNICODE_LITTLE_UNMARKED ) );
+        if ( domain != null )
+        {
+            hmacMD5.update( domain.toUpperCase( Locale.ROOT ).getBytes( UNICODE_LITTLE_UNMARKED ) );
         }
         return hmacMD5.getOutput();
     }
 
+
     /**
      * Creates the NTLMv2 Hash of the user's password.
+     * Corresponds to the LMOWFv2(Passwd, User, UserDom) function from the specification.
      *
      * @return The NTLMv2 Hash, used in the calculation of the NTLMv2 and LMv2
      *         Responses.
      */
-    private static byte[] ntlmv2Hash(final String domain, final String user, final byte[] ntlmHash)
-            throws NTLMEngineException {
-        if (UNICODE_LITTLE_UNMARKED == null) {
-            throw new NTLMEngineException("Unicode not supported");
-        }
-        final HMACMD5 hmacMD5 = new HMACMD5(ntlmHash);
+    private static byte[] ntowfv2( final String domain, final String user, final byte[] ntlmHash )
+        throws NTLMEngineException
+    {
+        final HMACMD5 hmacMD5 = new HMACMD5( ntlmHash );
         // Upper case username, mixed case target!!
-        hmacMD5.update(user.toUpperCase(Locale.ROOT).getBytes(UNICODE_LITTLE_UNMARKED));
-        if (domain != null) {
-            hmacMD5.update(domain.getBytes(UNICODE_LITTLE_UNMARKED));
+        hmacMD5.update( user.toUpperCase( Locale.ROOT ).getBytes( UNICODE_LITTLE_UNMARKED ) );
+        if ( domain != null )
+        {
+            hmacMD5.update( domain.getBytes( UNICODE_LITTLE_UNMARKED ) );
         }
         return hmacMD5.getOutput();
     }
+
 
     /**
      * Creates the LM Response from the given hash and Type 2 challenge.
@@ -669,36 +1042,42 @@ final class NTLMEngineImpl implements NTLMEngine {
      *
      * @return The response (either LM or NTLM, depending on the provided hash).
      */
-    private static byte[] lmResponse(final byte[] hash, final byte[] challenge) throws NTLMEngineException {
-        try {
+    private static byte[] lmResponse( final byte[] hash, final byte[] challenge ) throws NTLMEngineException
+    {
+        try
+        {
             final byte[] keyBytes = new byte[21];
-            System.arraycopy(hash, 0, keyBytes, 0, 16);
-            final Key lowKey = createDESKey(keyBytes, 0);
-            final Key middleKey = createDESKey(keyBytes, 7);
-            final Key highKey = createDESKey(keyBytes, 14);
-            final Cipher des = Cipher.getInstance("DES/ECB/NoPadding");
-            des.init(Cipher.ENCRYPT_MODE, lowKey);
-            final byte[] lowResponse = des.doFinal(challenge);
-            des.init(Cipher.ENCRYPT_MODE, middleKey);
-            final byte[] middleResponse = des.doFinal(challenge);
-            des.init(Cipher.ENCRYPT_MODE, highKey);
-            final byte[] highResponse = des.doFinal(challenge);
+            System.arraycopy( hash, 0, keyBytes, 0, 16 );
+            final Key lowKey = createDESKey( keyBytes, 0 );
+            final Key middleKey = createDESKey( keyBytes, 7 );
+            final Key highKey = createDESKey( keyBytes, 14 );
+            final Cipher des = Cipher.getInstance( "DES/ECB/NoPadding" );
+            des.init( Cipher.ENCRYPT_MODE, lowKey );
+            final byte[] lowResponse = des.doFinal( challenge );
+            des.init( Cipher.ENCRYPT_MODE, middleKey );
+            final byte[] middleResponse = des.doFinal( challenge );
+            des.init( Cipher.ENCRYPT_MODE, highKey );
+            final byte[] highResponse = des.doFinal( challenge );
             final byte[] lmResponse = new byte[24];
-            System.arraycopy(lowResponse, 0, lmResponse, 0, 8);
-            System.arraycopy(middleResponse, 0, lmResponse, 8, 8);
-            System.arraycopy(highResponse, 0, lmResponse, 16, 8);
+            System.arraycopy( lowResponse, 0, lmResponse, 0, 8 );
+            System.arraycopy( middleResponse, 0, lmResponse, 8, 8 );
+            System.arraycopy( highResponse, 0, lmResponse, 16, 8 );
             return lmResponse;
-        } catch (final Exception e) {
-            throw new NTLMEngineException(e.getMessage(), e);
+        }
+        catch ( final Exception e )
+        {
+            throw new NTLMEngineException( e.getMessage(), e );
         }
     }
+
 
     /**
      * Creates the LMv2 Response from the given hash, client data, and Type 2
      * challenge.
+     * Used for both LmChallengeResponse and NtChallengeResponse.
      *
-     * @param hash
-     *            The NTLMv2 Hash.
+     * @param responseKey
+     *            The NTLMv2 Hash. ResponseKeyNT or ResponseKeyLM
      * @param clientData
      *            The client data (blob or client challenge).
      * @param challenge
@@ -707,21 +1086,258 @@ final class NTLMEngineImpl implements NTLMEngine {
      * @return The response (either NTLMv2 or LMv2, depending on the client
      *         data).
      */
-    private static byte[] lmv2Response(final byte[] hash, final byte[] challenge, final byte[] clientData)
-            throws NTLMEngineException {
-        final HMACMD5 hmacMD5 = new HMACMD5(hash);
-        hmacMD5.update(challenge);
-        hmacMD5.update(clientData);
-        final byte[] mac = hmacMD5.getOutput();
-        final byte[] lmv2Response = new byte[mac.length + clientData.length];
-        System.arraycopy(mac, 0, lmv2Response, 0, mac.length);
-        System.arraycopy(clientData, 0, lmv2Response, mac.length, clientData.length);
+    private static byte[] lmv2Response( final byte[] responseKey, final byte[] challenge, final byte[] clientData )
+        throws NTLMEngineException
+    {
+        final HMACMD5 hmacMD5 = new HMACMD5( responseKey );
+        hmacMD5.update( challenge );
+        hmacMD5.update( clientData );
+        final byte[] proofStr = hmacMD5.getOutput(); // NtProofStr or its LM equivalent
+        final byte[] lmv2Response = new byte[proofStr.length + clientData.length];
+        System.arraycopy( proofStr, 0, lmv2Response, 0, proofStr.length );
+        System.arraycopy( clientData, 0, lmv2Response, proofStr.length, clientData.length );
+        if (NTLMEngineImpl.develTrace)
+        {
+            log.trace(
+            "lmv2Response\n   challenge:\n        " + DebugUtil.dump( challenge ) + "\n   clientData:\n        "
+                + DebugUtil.dump( clientData ) + "\n     proofStr\n        " + DebugUtil.dump( proofStr ) );
+        }
         return lmv2Response;
     }
+
+    public static enum Mode
+    {
+        CLIENT, SERVER;
+    }
+
+
+    public Handle createClientHandle() throws NTLMEngineException
+    {
+        final Handle handle = new Handle( exportedSessionKey, Mode.CLIENT, isConnection );
+        handle.init();
+        return handle;
+    }
+
+
+    public Handle createServer() throws NTLMEngineException
+    {
+        final Handle handle = new Handle( exportedSessionKey, Mode.SERVER, isConnection );
+        handle.init();
+        return handle;
+    }
+
+    public static class Handle
+    {
+        final private byte[] exportedSessionKey;
+        private byte[] signingKey;
+        private byte[] sealingKey;
+        private Cipher rc4;
+        final Mode mode;
+        final private boolean isConnection;
+        int sequenceNumber = 0;
+
+
+        Handle( final byte[] exportedSessionKey, final Mode mode, final boolean isSonnection )
+        {
+            this.exportedSessionKey = exportedSessionKey;
+            this.isConnection = isSonnection;
+            this.mode = mode;
+        }
+
+
+        public byte[] getSigningKey()
+        {
+            return signingKey;
+        }
+
+
+        public byte[] getSealingKey()
+        {
+            return sealingKey;
+        }
+
+
+        void init() throws NTLMEngineException
+        {
+            try
+            {
+                final MessageDigest signMd5 = MessageDigest.getInstance( "MD5" );
+                final MessageDigest sealMd5 = MessageDigest.getInstance( "MD5" );
+                signMd5.update( exportedSessionKey );
+                sealMd5.update( exportedSessionKey );
+                if ( mode == Mode.CLIENT )
+                {
+                    signMd5.update( SIGN_MAGIC_CLIENT );
+                    sealMd5.update( SEAL_MAGIC_CLIENT );
+                }
+                else
+                {
+                    signMd5.update( SIGN_MAGIC_SERVER );
+                    sealMd5.update( SEAL_MAGIC_SERVER );
+                }
+                signingKey = signMd5.digest();
+                sealingKey = sealMd5.digest();
+                if (develTrace)
+                {
+                    log.info( "signingKey: " + DebugUtil.dump( signingKey ) );
+                    log.info( "sealingKey: " + DebugUtil.dump( sealingKey ) );
+                }
+            }
+            catch ( final Exception e )
+            {
+                throw new NTLMEngineException( e.getMessage(), e );
+            }
+            rc4 = initCipher();
+        }
+
+
+        private Cipher initCipher() throws NTLMEngineException
+        {
+            Cipher cipher;
+            try
+            {
+                cipher = Cipher.getInstance( "RC4" );
+                if ( mode == Mode.CLIENT )
+                {
+                    cipher.init( Cipher.ENCRYPT_MODE, new SecretKeySpec( sealingKey, "RC4" ) );
+                }
+                else
+                {
+                    cipher.init( Cipher.DECRYPT_MODE, new SecretKeySpec( sealingKey, "RC4" ) );
+                }
+            }
+            catch ( Exception e )
+            {
+                throw new NTLMEngineException( e.getMessage(), e );
+            }
+            return cipher;
+        }
+
+
+        private void advanceMessageSequence() throws NTLMEngineException
+        {
+            if ( !isConnection )
+            {
+                MessageDigest sealMd5;
+                try
+                {
+                    sealMd5 = MessageDigest.getInstance( "MD5" );
+                }
+                catch ( NoSuchAlgorithmException e )
+                {
+                    throw new NTLMEngineException( e.getMessage(), e );
+                }
+                sealMd5.update( sealingKey );
+                final byte[] seqNumBytes = new byte[4];
+                writeULong( seqNumBytes, sequenceNumber, 0 );
+                sealMd5.update( seqNumBytes );
+                sealingKey = sealMd5.digest();
+                initCipher();
+            }
+            sequenceNumber++;
+        }
+
+
+        private byte[] encrypt( final byte[] data ) throws NTLMEngineException
+        {
+            return rc4.update( data );
+        }
+
+
+        private byte[] decrypt( final byte[] data ) throws NTLMEngineException
+        {
+            return rc4.update( data );
+        }
+
+
+        private byte[] computeSignature( final byte[] message ) throws NTLMEngineException
+        {
+            final byte[] sig = new byte[16];
+
+            // version
+            sig[0] = 0x01;
+            sig[1] = 0x00;
+            sig[2] = 0x00;
+            sig[3] = 0x00;
+
+            // HMAC (first 8 bytes)
+            final HMACMD5 hmacMD5 = new HMACMD5( signingKey );
+            hmacMD5.update( encodeLong( sequenceNumber ) );
+            hmacMD5.update( message );
+            final byte[] hmac = hmacMD5.getOutput();
+            final byte[] trimmedHmac = new byte[8];
+            System.arraycopy( hmac, 0, trimmedHmac, 0, 8 );
+            final byte[] encryptedHmac = encrypt( trimmedHmac );
+            System.arraycopy( encryptedHmac, 0, sig, 4, 8 );
+
+            // sequence number
+            encodeLong( sig, 12, sequenceNumber );
+
+            return sig;
+        }
+
+
+        private boolean validateSignature( final byte[] signature, final byte message[] ) throws NTLMEngineException
+        {
+            final byte[] computedSignature = computeSignature( message );
+            //            log.info( "SSSSS validateSignature("+seqNumber+")\n"
+            //                + "  received: " + DebugUtil.dump( signature ) + "\n"
+            //                + "  computed: " + DebugUtil.dump( computedSignature ) );
+            return Arrays.equals( signature, computedSignature );
+        }
+
+
+        public byte[] signAndEcryptMessage( final byte[] cleartextMessage ) throws NTLMEngineException
+        {
+            final byte[] encryptedMessage = encrypt( cleartextMessage );
+            final byte[] signature = computeSignature( cleartextMessage );
+            final byte[] outMessage = new byte[signature.length + encryptedMessage.length];
+            System.arraycopy( signature, 0, outMessage, 0, signature.length );
+            System.arraycopy( encryptedMessage, 0, outMessage, signature.length, encryptedMessage.length );
+            advanceMessageSequence();
+            return outMessage;
+        }
+
+
+        public byte[] decryptAndVerifySignedMessage( final byte[] inMessage ) throws NTLMEngineException
+        {
+            final byte[] signature = new byte[16];
+            System.arraycopy( inMessage, 0, signature, 0, signature.length );
+            final byte[] encryptedMessage = new byte[inMessage.length - 16];
+            System.arraycopy( inMessage, 16, encryptedMessage, 0, encryptedMessage.length );
+            final byte[] cleartextMessage = decrypt( encryptedMessage );
+            if ( !validateSignature( signature, cleartextMessage ) )
+            {
+                throw new NTLMEngineException( "Wrong signature" );
+            }
+            advanceMessageSequence();
+            return cleartextMessage;
+        }
+
+
+        private byte[] encodeLong( final int value )
+        {
+            final byte[] enc = new byte[4];
+            encodeLong( enc, 0, value );
+            return enc;
+        }
+
+
+        private void encodeLong( final byte[] buf, final int offset, final int value )
+        {
+            buf[offset + 0] = ( byte ) ( value & 0xff );
+            buf[offset + 1] = ( byte ) ( value >> 8 & 0xff );
+            buf[offset + 2] = ( byte ) ( value >> 16 & 0xff );
+            buf[offset + 3] = ( byte ) ( value >> 24 & 0xff );
+        }
+    }
+
 
     /**
      * Creates the NTLMv2 blob from the given target information block and
      * client challenge.
+     *
+     * This is "temp" in the specifications (ComputeResponse method, 3.3.2)
      *
      * @param targetInformation
      *            The target information block from the Type 2 message.
@@ -730,30 +1346,37 @@ final class NTLMEngineImpl implements NTLMEngine {
      *
      * @return The blob, used in the calculation of the NTLMv2 Response.
      */
-    private static byte[] createBlob(final byte[] clientChallenge, final byte[] targetInformation, final byte[] timestamp) {
-        final byte[] blobSignature = new byte[] { (byte) 0x01, (byte) 0x01, (byte) 0x00, (byte) 0x00 };
-        final byte[] reserved = new byte[] { (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00 };
-        final byte[] unknown1 = new byte[] { (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00 };
-        final byte[] unknown2 = new byte[] { (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00 };
+    private static byte[] createBlob( final byte[] clientChallenge, final byte[] targetInformation,
+        final byte[] timestamp )
+    {
+        final byte[] blobSignature = new byte[]
+            { ( byte ) 0x01, ( byte ) 0x01, ( byte ) 0x00, ( byte ) 0x00 };
+        final byte[] reserved = new byte[]
+            { ( byte ) 0x00, ( byte ) 0x00, ( byte ) 0x00, ( byte ) 0x00 };
+        final byte[] unknown1 = new byte[]
+            { ( byte ) 0x00, ( byte ) 0x00, ( byte ) 0x00, ( byte ) 0x00 };
+        final byte[] unknown2 = new byte[]
+            { ( byte ) 0x00, ( byte ) 0x00, ( byte ) 0x00, ( byte ) 0x00 };
         final byte[] blob = new byte[blobSignature.length + reserved.length + timestamp.length + 8
-                + unknown1.length + targetInformation.length + unknown2.length];
+            + unknown1.length + targetInformation.length + unknown2.length];
         int offset = 0;
-        System.arraycopy(blobSignature, 0, blob, offset, blobSignature.length);
+        System.arraycopy( blobSignature, 0, blob, offset, blobSignature.length );
         offset += blobSignature.length;
-        System.arraycopy(reserved, 0, blob, offset, reserved.length);
+        System.arraycopy( reserved, 0, blob, offset, reserved.length );
         offset += reserved.length;
-        System.arraycopy(timestamp, 0, blob, offset, timestamp.length);
+        System.arraycopy( timestamp, 0, blob, offset, timestamp.length );
         offset += timestamp.length;
-        System.arraycopy(clientChallenge, 0, blob, offset, 8);
+        System.arraycopy( clientChallenge, 0, blob, offset, 8 );
         offset += 8;
-        System.arraycopy(unknown1, 0, blob, offset, unknown1.length);
+        System.arraycopy( unknown1, 0, blob, offset, unknown1.length );
         offset += unknown1.length;
-        System.arraycopy(targetInformation, 0, blob, offset, targetInformation.length);
+        System.arraycopy( targetInformation, 0, blob, offset, targetInformation.length );
         offset += targetInformation.length;
-        System.arraycopy(unknown2, 0, blob, offset, unknown2.length);
+        System.arraycopy( unknown2, 0, blob, offset, unknown2.length );
         offset += unknown2.length;
         return blob;
     }
+
 
     /**
      * Creates a DES encryption key from the given key material.
@@ -767,21 +1390,23 @@ final class NTLMEngineImpl implements NTLMEngine {
      * @return A DES encryption key created from the key material starting at
      *         the specified offset in the given byte array.
      */
-    private static Key createDESKey(final byte[] bytes, final int offset) {
+    private static Key createDESKey( final byte[] bytes, final int offset )
+    {
         final byte[] keyBytes = new byte[7];
-        System.arraycopy(bytes, offset, keyBytes, 0, 7);
+        System.arraycopy( bytes, offset, keyBytes, 0, 7 );
         final byte[] material = new byte[8];
         material[0] = keyBytes[0];
-        material[1] = (byte) (keyBytes[0] << 7 | (keyBytes[1] & 0xff) >>> 1);
-        material[2] = (byte) (keyBytes[1] << 6 | (keyBytes[2] & 0xff) >>> 2);
-        material[3] = (byte) (keyBytes[2] << 5 | (keyBytes[3] & 0xff) >>> 3);
-        material[4] = (byte) (keyBytes[3] << 4 | (keyBytes[4] & 0xff) >>> 4);
-        material[5] = (byte) (keyBytes[4] << 3 | (keyBytes[5] & 0xff) >>> 5);
-        material[6] = (byte) (keyBytes[5] << 2 | (keyBytes[6] & 0xff) >>> 6);
-        material[7] = (byte) (keyBytes[6] << 1);
-        oddParity(material);
-        return new SecretKeySpec(material, "DES");
+        material[1] = ( byte ) ( keyBytes[0] << 7 | ( keyBytes[1] & 0xff ) >>> 1 );
+        material[2] = ( byte ) ( keyBytes[1] << 6 | ( keyBytes[2] & 0xff ) >>> 2 );
+        material[3] = ( byte ) ( keyBytes[2] << 5 | ( keyBytes[3] & 0xff ) >>> 3 );
+        material[4] = ( byte ) ( keyBytes[3] << 4 | ( keyBytes[4] & 0xff ) >>> 4 );
+        material[5] = ( byte ) ( keyBytes[4] << 3 | ( keyBytes[5] & 0xff ) >>> 5 );
+        material[6] = ( byte ) ( keyBytes[5] << 2 | ( keyBytes[6] & 0xff ) >>> 6 );
+        material[7] = ( byte ) ( keyBytes[6] << 1 );
+        oddParity( material );
+        return new SecretKeySpec( material, "DES" );
     }
+
 
     /**
      * Applies odd parity to the given byte array.
@@ -789,100 +1414,123 @@ final class NTLMEngineImpl implements NTLMEngine {
      * @param bytes
      *            The data whose parity bits are to be adjusted for odd parity.
      */
-    private static void oddParity(final byte[] bytes) {
-        for (int i = 0; i < bytes.length; i++) {
+    private static void oddParity( final byte[] bytes )
+    {
+        for ( int i = 0; i < bytes.length; i++ )
+        {
             final byte b = bytes[i];
-            final boolean needsParity = (((b >>> 7) ^ (b >>> 6) ^ (b >>> 5) ^ (b >>> 4) ^ (b >>> 3)
-                    ^ (b >>> 2) ^ (b >>> 1)) & 0x01) == 0;
-            if (needsParity) {
-                bytes[i] |= (byte) 0x01;
-            } else {
-                bytes[i] &= (byte) 0xfe;
+            final boolean needsParity = ( ( ( b >>> 7 ) ^ ( b >>> 6 ) ^ ( b >>> 5 ) ^ ( b >>> 4 ) ^ ( b >>> 3 )
+                ^ ( b >>> 2 ) ^ ( b >>> 1 ) ) & 0x01 ) == 0;
+            if ( needsParity )
+            {
+                bytes[i] |= ( byte ) 0x01;
+            }
+            else
+            {
+                bytes[i] &= ( byte ) 0xfe;
             }
         }
     }
 
+
+    private static Charset getCharset( final Integer flags ) throws NTLMEngineException
+    {
+        if ( flags != null && ( flags & FLAG_REQUEST_UNICODE_ENCODING ) == 0 )
+        {
+            return DEFAULT_CHARSET;
+        }
+        else
+        {
+            if ( UNICODE_LITTLE_UNMARKED == null )
+            {
+                throw new NTLMEngineException( "Unicode not supported" );
+            }
+            return UNICODE_LITTLE_UNMARKED;
+        }
+    }
+
     /** NTLM message generation, base class */
-    static class NTLMMessage {
+    static abstract class NTLMMessage
+    {
         /** The current response */
-        private byte[] messageContents = null;
+        protected byte[] messageContents = null;
 
-        /** The current output position */
-        private int currentOutputPosition = 0;
-
-        /** Constructor to use when message contents are not yet known */
-        NTLMMessage() {
-        }
-
-        /** Constructor to use when message contents are known */
-        NTLMMessage(final String messageBody, final int expectedType) throws NTLMEngineException {
-            messageContents = Base64.decodeBase64(messageBody.getBytes(DEFAULT_CHARSET));
-            // Look for NTLM message
-            if (messageContents.length < SIGNATURE.length) {
-                throw new NTLMEngineException("NTLM message decoding error - packet too short");
-            }
-            int i = 0;
-            while (i < SIGNATURE.length) {
-                if (messageContents[i] != SIGNATURE[i]) {
-                    throw new NTLMEngineException(
-                            "NTLM message expected - instead got unrecognized bytes");
-                }
-                i++;
-            }
-
-            // Check to be sure there's a type 2 message indicator next
-            final int type = readULong(SIGNATURE.length);
-            if (type != expectedType) {
-                throw new NTLMEngineException("NTLM type " + Integer.toString(expectedType)
-                        + " message expected - instead got type " + Integer.toString(type));
-            }
-
-            currentOutputPosition = messageContents.length;
-        }
 
         /**
          * Get the length of the signature and flags, so calculations can adjust
          * offsets accordingly.
          */
-        protected int getPreambleLength() {
+        protected int getPreambleLength()
+        {
             return SIGNATURE.length + 4;
         }
 
+
         /** Get the message length */
-        protected int getMessageLength() {
-            return currentOutputPosition;
-        }
+        protected abstract int getMessageLength();
+
 
         /** Read a byte from a position within the message buffer */
-        protected byte readByte(final int position) throws NTLMEngineException {
-            if (messageContents.length < position + 1) {
-                throw new NTLMEngineException("NTLM: Message too short");
+        protected byte readByte( final int position ) throws NTLMEngineException
+        {
+            if ( messageContents.length < position + 1 )
+            {
+                throw new NTLMEngineException( "NTLM: Message too short" );
             }
             return messageContents[position];
         }
 
+
         /** Read a bunch of bytes from a position in the message buffer */
-        protected void readBytes(final byte[] buffer, final int position) throws NTLMEngineException {
-            if (messageContents.length < position + buffer.length) {
-                throw new NTLMEngineException("NTLM: Message too short");
+        protected void readBytes( final byte[] buffer, final int position ) throws NTLMEngineException
+        {
+            if ( messageContents.length < position + buffer.length )
+            {
+                throw new NTLMEngineException( "NTLM: Message too short" );
             }
-            System.arraycopy(messageContents, position, buffer, 0, buffer.length);
+            System.arraycopy( messageContents, position, buffer, 0, buffer.length );
         }
+
 
         /** Read a ushort from a position within the message buffer */
-        protected int readUShort(final int position) throws NTLMEngineException {
-            return NTLMEngineImpl.readUShort(messageContents, position);
+        protected int readUShort( final int position ) throws NTLMEngineException
+        {
+            return NTLMEngineImpl.readUShort( messageContents, position );
         }
+
 
         /** Read a ulong from a position within the message buffer */
-        protected int readULong(final int position) throws NTLMEngineException {
-            return NTLMEngineImpl.readULong(messageContents, position);
+        protected int readULong( final int position ) throws NTLMEngineException
+        {
+            return NTLMEngineImpl.readULong( messageContents, position );
         }
 
+
         /** Read a security buffer from a position within the message buffer */
-        protected byte[] readSecurityBuffer(final int position) throws NTLMEngineException {
-            return NTLMEngineImpl.readSecurityBuffer(messageContents, position);
+        protected byte[] readSecurityBuffer( final int position ) throws NTLMEngineException
+        {
+            return NTLMEngineImpl.readSecurityBuffer( messageContents, position );
         }
+
+
+        public abstract byte[] getBytes();
+    }
+
+    /** NTLM output message base class. For messages that the client is sending. */
+    static abstract class NTLMOutputMessage extends NTLMMessage
+    {
+
+        /** The current output position */
+        private int currentOutputPosition = 0;
+        protected boolean messageEncoded = false;
+
+
+        /** Get the message length */
+        protected int getMessageLength()
+        {
+            return currentOutputPosition;
+        }
+
 
         /**
          * Prepares the object to create a response of the given length.
@@ -892,12 +1540,14 @@ final class NTLMEngineImpl implements NTLMEngine {
          *            including the type and the signature (which this method
          *            adds).
          */
-        protected void prepareResponse(final int maxlength, final int messageType) {
+        protected void prepareResponse( final int maxlength, final int messageType )
+        {
             messageContents = new byte[maxlength];
             currentOutputPosition = 0;
-            addBytes(SIGNATURE);
-            addULong(messageType);
+            addBytes( SIGNATURE );
+            addULong( messageType );
         }
+
 
         /**
          * Adds the given byte to the response.
@@ -905,10 +1555,24 @@ final class NTLMEngineImpl implements NTLMEngine {
          * @param b
          *            the byte to add.
          */
-        protected void addByte(final byte b) {
+        protected void addByte( final byte b )
+        {
             messageContents[currentOutputPosition] = b;
             currentOutputPosition++;
         }
+
+
+        protected int getCurrentOutputPosition()
+        {
+            return currentOutputPosition;
+        }
+
+
+        protected void skipBytes( final int size )
+        {
+            currentOutputPosition += size;
+        }
+
 
         /**
          * Adds the given bytes to the response.
@@ -916,29 +1580,37 @@ final class NTLMEngineImpl implements NTLMEngine {
          * @param bytes
          *            the bytes to add.
          */
-        protected void addBytes(final byte[] bytes) {
-            if (bytes == null) {
+        protected void addBytes( final byte[] bytes )
+        {
+            if ( bytes == null )
+            {
                 return;
             }
-            for (final byte b : bytes) {
+            for ( final byte b : bytes )
+            {
                 messageContents[currentOutputPosition] = b;
                 currentOutputPosition++;
             }
         }
 
+
         /** Adds a USHORT to the response */
-        protected void addUShort(final int value) {
-            addByte((byte) (value & 0xff));
-            addByte((byte) (value >> 8 & 0xff));
+        protected void addUShort( final int value )
+        {
+            addByte( ( byte ) ( value & 0xff ) );
+            addByte( ( byte ) ( value >> 8 & 0xff ) );
         }
 
+
         /** Adds a ULong to the response */
-        protected void addULong(final int value) {
-            addByte((byte) (value & 0xff));
-            addByte((byte) (value >> 8 & 0xff));
-            addByte((byte) (value >> 16 & 0xff));
-            addByte((byte) (value >> 24 & 0xff));
+        protected void addULong( final int value )
+        {
+            addByte( ( byte ) ( value & 0xff ) );
+            addByte( ( byte ) ( value >> 8 & 0xff ) );
+            addByte( ( byte ) ( value >> 16 & 0xff ) );
+            addByte( ( byte ) ( value >> 24 & 0xff ) );
         }
+
 
         /**
          * Returns the response that has been generated after shrinking the
@@ -946,130 +1618,262 @@ final class NTLMEngineImpl implements NTLMEngine {
          *
          * @return The response as above.
          */
-        String getResponse() {
-            final byte[] resp;
-            if (messageContents.length > currentOutputPosition) {
-                final byte[] tmp = new byte[currentOutputPosition];
-                System.arraycopy(messageContents, 0, tmp, 0, currentOutputPosition);
-                resp = tmp;
-            } else {
-                resp = messageContents;
+        String getResponse()
+        {
+            return EncodingUtils.getAsciiString( Base64.encodeBase64( getBytes() ) );
+        }
+
+
+        public byte[] getBytes()
+        {
+            if ( !messageEncoded )
+            {
+                encodeMessage();
+                final byte[] resp;
+                if ( messageContents.length > currentOutputPosition )
+                {
+                    final byte[] tmp = new byte[currentOutputPosition];
+                    System.arraycopy( messageContents, 0, tmp, 0, currentOutputPosition );
+                    messageContents = tmp;
+                }
             }
-            return EncodingUtils.getAsciiString(Base64.encodeBase64(resp));
+            return messageContents;
+        }
+
+
+        protected abstract void encodeMessage();
+    }
+
+    /** NTLM input message base class. For messages that the client is receiving. */
+    static abstract class NTLMInputMessage extends NTLMMessage
+    {
+
+        /** Constructor to use when message base64-encoded contents are known.*/
+        NTLMInputMessage( final String messageBody, final int expectedType ) throws NTLMEngineException
+        {
+            this( Base64.decodeBase64( messageBody.getBytes( DEFAULT_CHARSET ) ), expectedType );
+        }
+
+
+        /** Constructor to use when message binary contents are known */
+        NTLMInputMessage( final byte[] messageBytes, final int expectedType ) throws NTLMEngineException
+        {
+            messageContents = messageBytes;
+            // Look for NTLM message
+            if ( messageContents.length < SIGNATURE.length )
+            {
+                throw new NTLMEngineException( "NTLM message decoding error - packet too short" );
+            }
+            int i = 0;
+            while ( i < SIGNATURE.length )
+            {
+                if ( messageContents[i] != SIGNATURE[i] )
+                {
+                    throw new NTLMEngineException(
+                        "NTLM message expected - instead got unrecognized bytes" );
+                }
+                i++;
+            }
+
+            // Check to be sure there's a type 2 message indicator next
+            final int type = readULong( SIGNATURE.length );
+            if ( type != expectedType )
+            {
+                throw new NTLMEngineException( "NTLM type " + Integer.toString( expectedType )
+                    + " message expected - instead got type " + Integer.toString( type ) );
+            }
+        }
+
+
+        /** Get the message length */
+        protected int getMessageLength()
+        {
+            return messageContents.length;
+        }
+
+
+        public byte[] getBytes()
+        {
+            return messageContents;
         }
 
     }
 
-    /** Type 1 message assembly class */
-    static class Type1Message extends NTLMMessage {
+    /** Type 1 message assembly class.
+     * NEGOTIATE message: Section 2.2.1.1 of [MS-NLMP] */
+    static class Type1Message extends NTLMOutputMessage
+    {
 
         private final byte[] hostBytes;
         private final byte[] domainBytes;
+        private final Integer flags;
 
-        Type1Message(final String domain, final String host) throws NTLMEngineException {
+
+        Type1Message( final String domain, final String host, final Integer flags ) throws NTLMEngineException
+        {
             super();
-            if (UNICODE_LITTLE_UNMARKED == null) {
-                throw new NTLMEngineException("Unicode not supported");
-            }
             // Strip off domain name from the host!
-            final String unqualifiedHost = convertHost(host);
+            final String unqualifiedHost = convertHost( host );
             // Use only the base domain name!
-            final String unqualifiedDomain = convertDomain(domain);
+            final String unqualifiedDomain = convertDomain( domain );
 
-            hostBytes = unqualifiedHost != null ?
-                    unqualifiedHost.getBytes(UNICODE_LITTLE_UNMARKED) : null;
-            domainBytes = unqualifiedDomain != null ?
-                    unqualifiedDomain.toUpperCase(Locale.ROOT).getBytes(UNICODE_LITTLE_UNMARKED) : null;
+            final Charset charset = getCharset( flags );
+
+            hostBytes = unqualifiedHost != null ? unqualifiedHost.getBytes( charset ) : null;
+            domainBytes = unqualifiedDomain != null ? unqualifiedDomain.toUpperCase( Locale.ROOT ).getBytes( charset )
+                : null;
+            if ( flags == null )
+            {
+                this.flags = getDefaultFlags();
+            }
+            else
+            {
+                this.flags = flags;
+            }
         }
 
-        Type1Message() {
+
+        Type1Message( final String domain, final String host ) throws NTLMEngineException
+        {
+            this( domain, host, null );
+        }
+
+
+        Type1Message()
+        {
             super();
             hostBytes = null;
             domainBytes = null;
+            flags = getDefaultFlags();
         }
+
+
+        private static Integer getDefaultFlags()
+        {
+            return
+            //FLAG_WORKSTATION_PRESENT |
+            //FLAG_DOMAIN_PRESENT |
+
+            // Required flags
+            //FLAG_REQUEST_LAN_MANAGER_KEY |
+            FLAG_REQUEST_NTLMv1 |
+                FLAG_REQUEST_NTLM2_SESSION |
+
+                // Protocol version request
+                FLAG_REQUEST_VERSION |
+
+                // Recommended privacy settings
+                FLAG_REQUEST_ALWAYS_SIGN |
+                //FLAG_REQUEST_SEAL |
+                //FLAG_REQUEST_SIGN |
+
+                // These must be set according to documentation, based on use of SEAL above
+                FLAG_REQUEST_128BIT_KEY_EXCH |
+                FLAG_REQUEST_56BIT_ENCRYPTION |
+                //FLAG_REQUEST_EXPLICIT_KEY_EXCH |
+
+                FLAG_REQUEST_UNICODE_ENCODING;
+        }
+
+
         /**
          * Getting the response involves building the message before returning
          * it
          */
         @Override
-        String getResponse() {
+        protected void encodeMessage()
+        {
+            int domainBytesLength = 0;
+            if ( domainBytes != null )
+            {
+                domainBytesLength = domainBytes.length;
+            }
+            int hostBytesLength = 0;
+            if ( hostBytes != null )
+            {
+                hostBytesLength = hostBytes.length;
+            }
             // Now, build the message. Calculate its length first, including
             // signature or type.
-            final int finalLength = 32 + 8 /*+ hostBytes.length + domainBytes.length */;
+            final int finalLength = 32 + 8 + hostBytesLength + domainBytesLength;
 
             // Set up the response. This will initialize the signature, message
             // type, and flags.
-            prepareResponse(finalLength, 1);
+            prepareResponse( finalLength, 1 );
 
             // Flags. These are the complete set of flags we support.
-            addULong(
-                    //FLAG_WORKSTATION_PRESENT |
-                    //FLAG_DOMAIN_PRESENT |
-
-                    // Required flags
-                    //FLAG_REQUEST_LAN_MANAGER_KEY |
-                    FLAG_REQUEST_NTLMv1 |
-                    FLAG_REQUEST_NTLM2_SESSION |
-
-                    // Protocol version request
-                    FLAG_REQUEST_VERSION |
-
-                    // Recommended privacy settings
-                    FLAG_REQUEST_ALWAYS_SIGN |
-                    //FLAG_REQUEST_SEAL |
-                    //FLAG_REQUEST_SIGN |
-
-                    // These must be set according to documentation, based on use of SEAL above
-                    FLAG_REQUEST_128BIT_KEY_EXCH |
-                    FLAG_REQUEST_56BIT_ENCRYPTION |
-                    //FLAG_REQUEST_EXPLICIT_KEY_EXCH |
-
-                    FLAG_REQUEST_UNICODE_ENCODING);
+            addULong( flags );
 
             // Domain length (two times).
-            addUShort(/*domainBytes.length*/0);
-            addUShort(/*domainBytes.length*/0);
+            addUShort( domainBytesLength );
+            addUShort( domainBytesLength );
 
             // Domain offset.
-            addULong(/*hostBytes.length +*/ 32 + 8);
+            addULong( hostBytesLength + 32 + 8 );
 
             // Host length (two times).
-            addUShort(/*hostBytes.length*/0);
-            addUShort(/*hostBytes.length*/0);
+            addUShort( hostBytesLength );
+            addUShort( hostBytesLength );
 
             // Host offset (always 32 + 8).
-            addULong(32 + 8);
+            addULong( 32 + 8 );
 
             // Version
-            addUShort(0x0105);
+            addUShort( 0x0105 );
             // Build
-            addULong(2600);
+            addULong( 2600 );
             // NTLM revision
-            addUShort(0x0f00);
+            addUShort( 0x0f00 );
 
             // Host (workstation) String.
-            if (hostBytes != null) {
-                addBytes(hostBytes);
+            if ( hostBytes != null )
+            {
+                addBytes( hostBytes );
             }
             // Domain String.
-            if (domainBytes != null) {
-                addBytes(domainBytes);
+            if ( domainBytes != null )
+            {
+                addBytes( domainBytes );
             }
+        }
 
-            return super.getResponse();
+
+        public String debugDump()
+        {
+            final StringBuilder sb = new StringBuilder( "Type1Message\n" );
+            sb.append( "  flags:\n    " ).append( dumpFlags( flags ) ).append( "\n" );
+            sb.append( "  hostBytes:\n    " ).append( DebugUtil.dump( hostBytes ) ).append( "\n" );
+            sb.append( "  domainBytes:\n    " ).append( domainBytes );
+            return sb.toString();
         }
 
     }
 
     /** Type 2 message class */
-    static class Type2Message extends NTLMMessage {
+    static class Type2Message extends NTLMInputMessage
+    {
         protected byte[] challenge;
         protected String target;
         protected byte[] targetInfo;
         protected int flags;
 
-        Type2Message(final String message) throws NTLMEngineException {
-            super(message, 2);
+
+        Type2Message( final String message ) throws NTLMEngineException
+        {
+            super( message, 2 );
+            init();
+        }
+
+
+        Type2Message( final byte[] message ) throws NTLMEngineException
+        {
+            super( message, 2 );
+            init();
+        }
+
+
+        private void init() throws NTLMEngineException
+        {
 
             // Type 2 message is laid out as follows:
             // First 8 bytes: NTLMSSP[0]
@@ -1087,67 +1891,81 @@ final class NTLMEngineImpl implements NTLMEngine {
             // Parse out the rest of the info we need from the message
             // The nonce is the 8 bytes starting from the byte in position 24.
             challenge = new byte[8];
-            readBytes(challenge, 24);
+            readBytes( challenge, 24 );
 
-            flags = readULong(20);
-
-            if ((flags & FLAG_REQUEST_UNICODE_ENCODING) == 0) {
-                throw new NTLMEngineException(
-                        "NTLM type 2 message indicates no support for Unicode. Flags are: "
-                                + Integer.toString(flags));
-            }
+            flags = readULong( 20 );
 
             // Do the target!
             target = null;
             // The TARGET_DESIRED flag is said to not have understood semantics
             // in Type2 messages, so use the length of the packet to decide
             // how to proceed instead
-            if (getMessageLength() >= 12 + 8) {
-                final byte[] bytes = readSecurityBuffer(12);
-                if (bytes.length != 0) {
-                    try {
-                        target = new String(bytes, "UnicodeLittleUnmarked");
-                    } catch (final UnsupportedEncodingException e) {
-                        throw new NTLMEngineException(e.getMessage(), e);
-                    }
+            if ( getMessageLength() >= 12 + 8 )
+            {
+                final byte[] bytes = readSecurityBuffer( 12 );
+                if ( bytes.length != 0 )
+                {
+                    target = new String( bytes, getCharset( flags ) );
                 }
             }
 
             // Do the target info!
             targetInfo = null;
             // TARGET_DESIRED flag cannot be relied on, so use packet length
-            if (getMessageLength() >= 40 + 8) {
-                final byte[] bytes = readSecurityBuffer(40);
-                if (bytes.length != 0) {
+            if ( getMessageLength() >= 40 + 8 )
+            {
+                final byte[] bytes = readSecurityBuffer( 40 );
+                if ( bytes.length != 0 )
+                {
                     targetInfo = bytes;
                 }
             }
         }
 
+
         /** Retrieve the challenge */
-        byte[] getChallenge() {
+        byte[] getChallenge()
+        {
             return challenge;
         }
 
+
         /** Retrieve the target */
-        String getTarget() {
+        String getTarget()
+        {
             return target;
         }
 
+
         /** Retrieve the target info */
-        byte[] getTargetInfo() {
+        byte[] getTargetInfo()
+        {
             return targetInfo;
         }
 
+
         /** Retrieve the response flags */
-        int getFlags() {
+        int getFlags()
+        {
             return flags;
+        }
+
+
+        public String debugDump()
+        {
+            final StringBuilder sb = new StringBuilder( "Type2Message\n" );
+            sb.append( "  flags:\n    " ).append( dumpFlags( flags ) ).append( "\n" );
+            sb.append( "  challenge:\n    " ).append( DebugUtil.dump( challenge ) ).append( "\n" );
+            sb.append( "  target:\n    " ).append( target ).append( "\n" );
+            sb.append( "  targetInfo:\n    " ).append( DebugUtil.dump( targetInfo ) );
+            return sb.toString();
         }
 
     }
 
     /** Type 3 message assembly class */
-    static class Type3Message extends NTLMMessage {
+    static class Type3Message extends NTLMOutputMessage
+    {
         // Response flags from the type2 message
         protected int type2Flags;
 
@@ -1155,111 +1973,188 @@ final class NTLMEngineImpl implements NTLMEngine {
         protected byte[] hostBytes;
         protected byte[] userBytes;
 
-        protected byte[] lmResp;
-        protected byte[] ntResp;
-        protected byte[] sessionKey;
+        protected byte[] lmChallengeResponse;
+        protected byte[] ntChallengeResponse;
+        protected byte[] encryptedRandomSessionKey;
+        protected byte[] exportedSessionKey;
+
+        int micPosition = -1;
+        protected boolean computeMic = false;
 
 
         /** Constructor. Pass the arguments we will need */
-        Type3Message(final String domain, final String host, final String user, final String password, final byte[] nonce,
-                final int type2Flags, final String target, final byte[] targetInformation)
-                throws NTLMEngineException {
+        Type3Message( final String domain, final String host, final String user, final String password,
+            final byte[] nonce,
+            final int type2Flags, final String target, final byte[] targetInformation,
+            final X509Certificate peerServerCertificate )
+            throws NTLMEngineException
+        {
             // Save the flags
             this.type2Flags = type2Flags;
 
             // Strip off domain name from the host!
-            final String unqualifiedHost = convertHost(host);
+            final String unqualifiedHost = convertHost( host );
             // Use only the base domain name!
-            final String unqualifiedDomain = convertDomain(domain);
+            final String unqualifiedDomain = convertDomain( domain );
+
+            byte[] responseTargetInformation = targetInformation;
+            if ( peerServerCertificate != null )
+            {
+                responseTargetInformation = addGssMicAvsToTargetInfo( targetInformation, peerServerCertificate );
+            }
 
             // Create a cipher generator class.  Use domain BEFORE it gets modified!
-            final CipherGen gen = new CipherGen(unqualifiedDomain, user, password, nonce, target, targetInformation);
+            final CipherGen gen = new CipherGen( unqualifiedDomain, user, password, nonce, target,
+                responseTargetInformation );
 
             // Use the new code to calculate the responses, including v2 if that
             // seems warranted.
-            byte[] userSessionKey;
-            try {
+            byte[] sessionBaseKey;
+            try
+            {
                 // This conditional may not work on Windows Server 2008 R2 and above, where it has not yet
                 // been tested
-                if (((type2Flags & FLAG_TARGETINFO_PRESENT) != 0) &&
-                    targetInformation != null && target != null) {
+                if ( ( ( type2Flags & FLAG_TARGETINFO_PRESENT ) != 0 ) &&
+                    targetInformation != null && target != null )
+                {
                     // NTLMv2
-                    ntResp = gen.getNTLMv2Response();
-                    lmResp = gen.getLMv2Response();
-                    if ((type2Flags & FLAG_REQUEST_LAN_MANAGER_KEY) != 0) {
-                        userSessionKey = gen.getLanManagerSessionKey();
-                    } else {
-                        userSessionKey = gen.getNTLMv2UserSessionKey();
+                    ntChallengeResponse = gen.getNTLMv2Response();
+                    lmChallengeResponse = gen.getLMv2Response();
+                    if (develTrace)
+                    {
+                        log.trace( "ntChallengeResponse:\n" + DebugUtil.dump( ntChallengeResponse ) );
+                        log.trace( "lmChallengeResponse:\n" + DebugUtil.dump( lmChallengeResponse ) );
                     }
-                } else {
+                    if ( ( type2Flags & FLAG_REQUEST_LAN_MANAGER_KEY ) != 0 )
+                    {
+                        sessionBaseKey = gen.getLanManagerSessionKey();
+                    }
+                    else
+                    {
+                        sessionBaseKey = gen.getNTLMv2SessionBaseKey();
+                    }
+                }
+                else
+                {
                     // NTLMv1
-                    if ((type2Flags & FLAG_REQUEST_NTLM2_SESSION) != 0) {
+                    if ( ( type2Flags & FLAG_REQUEST_NTLM2_SESSION ) != 0 )
+                    {
                         // NTLM2 session stuff is requested
-                        ntResp = gen.getNTLM2SessionResponse();
-                        lmResp = gen.getLM2SessionResponse();
-                        if ((type2Flags & FLAG_REQUEST_LAN_MANAGER_KEY) != 0) {
-                            userSessionKey = gen.getLanManagerSessionKey();
-                        } else {
-                            userSessionKey = gen.getNTLM2SessionResponseUserSessionKey();
+                        ntChallengeResponse = gen.getNTLM2SessionResponse();
+                        lmChallengeResponse = gen.getLM2SessionResponse();
+                        if ( ( type2Flags & FLAG_REQUEST_LAN_MANAGER_KEY ) != 0 )
+                        {
+                            sessionBaseKey = gen.getLanManagerSessionKey();
                         }
-                    } else {
-                        ntResp = gen.getNTLMResponse();
-                        lmResp = gen.getLMResponse();
-                        if ((type2Flags & FLAG_REQUEST_LAN_MANAGER_KEY) != 0) {
-                            userSessionKey = gen.getLanManagerSessionKey();
-                        } else {
-                            userSessionKey = gen.getNTLMUserSessionKey();
+                        else
+                        {
+                            sessionBaseKey = gen.getNTLM2SessionResponseUserSessionKey();
+                        }
+                    }
+                    else
+                    {
+                        ntChallengeResponse = gen.getNTLMResponse();
+                        lmChallengeResponse = gen.getLMResponse();
+                        if ( ( type2Flags & FLAG_REQUEST_LAN_MANAGER_KEY ) != 0 )
+                        {
+                            sessionBaseKey = gen.getLanManagerSessionKey();
+                        }
+                        else
+                        {
+                            sessionBaseKey = gen.getNTLMUserSessionKey();
                         }
                     }
                 }
-            } catch (final NTLMEngineException e) {
+            }
+            catch ( final NTLMEngineException e )
+            {
                 // This likely means we couldn't find the MD4 hash algorithm -
                 // fail back to just using LM
-                ntResp = new byte[0];
-                lmResp = gen.getLMResponse();
-                if ((type2Flags & FLAG_REQUEST_LAN_MANAGER_KEY) != 0) {
-                    userSessionKey = gen.getLanManagerSessionKey();
-                } else {
-                    userSessionKey = gen.getLMUserSessionKey();
+                ntChallengeResponse = new byte[0];
+                lmChallengeResponse = gen.getLMResponse();
+                if ( ( type2Flags & FLAG_REQUEST_LAN_MANAGER_KEY ) != 0 )
+                {
+                    sessionBaseKey = gen.getLanManagerSessionKey();
                 }
+                else
+                {
+                    sessionBaseKey = gen.getLMUserSessionKey();
+                }
+            }
+            if (develTrace)
+            {
+                log.trace( "sessionBaseKey:" + DebugUtil.dump( sessionBaseKey ) );
             }
 
-            if ((type2Flags & FLAG_REQUEST_SIGN) != 0) {
-                if ((type2Flags & FLAG_REQUEST_EXPLICIT_KEY_EXCH) != 0) {
-                    sessionKey = RC4(gen.getSecondaryKey(), userSessionKey);
-                } else {
-                    sessionKey = userSessionKey;
+            // Strictly speaking we should transform sessionBaseKey to keyExchenageKey here.
+            // But in the two specific usecases implemented by this code that is not necessary.
+            // As the time is limited we simply don't implement that particular transformation code.
+
+            if ( ( type2Flags & FLAG_REQUEST_SIGN ) != 0 )
+            {
+                if ( ( type2Flags & FLAG_REQUEST_EXPLICIT_KEY_EXCH ) != 0 )
+                {
+                    exportedSessionKey = gen.getSecondaryKey();
+                    encryptedRandomSessionKey = RC4( exportedSessionKey, sessionBaseKey );
                 }
-            } else {
-                sessionKey = null;
+                else
+                {
+                    encryptedRandomSessionKey = sessionBaseKey;
+                    exportedSessionKey = encryptedRandomSessionKey;
+                }
+                if (develTrace)
+                {
+                    log.trace( "exportedSessionKey:\n" + DebugUtil.dump( exportedSessionKey ) );
+                    log.trace( "encryptedRandomSessionKey:\n" + DebugUtil.dump( encryptedRandomSessionKey ) );
+                }
             }
-            if (UNICODE_LITTLE_UNMARKED == null) {
-                throw new NTLMEngineException("Unicode not supported");
+            else
+            {
+                encryptedRandomSessionKey = null;
             }
-            hostBytes = unqualifiedHost != null ? unqualifiedHost.getBytes(UNICODE_LITTLE_UNMARKED) : null;
+            final Charset charset = getCharset( type2Flags );
+            hostBytes = unqualifiedHost != null ? unqualifiedHost.getBytes( charset ) : null;
             domainBytes = unqualifiedDomain != null ? unqualifiedDomain
-                    .toUpperCase(Locale.ROOT).getBytes(UNICODE_LITTLE_UNMARKED) : null;
-            userBytes = user.getBytes(UNICODE_LITTLE_UNMARKED);
+                .toUpperCase( Locale.ROOT ).getBytes( charset ) : null;
+            userBytes = user.getBytes( charset );
         }
+
+
+        public byte[] getEncryptedRandomSessionKey()
+        {
+            return encryptedRandomSessionKey;
+        }
+
+
+        public byte[] getExportedSessionKey()
+        {
+            return exportedSessionKey;
+        }
+
 
         /** Assemble the response */
         @Override
-        String getResponse() {
-            final int ntRespLen = ntResp.length;
-            final int lmRespLen = lmResp.length;
+        protected void encodeMessage()
+        {
+            final int ntRespLen = ntChallengeResponse.length;
+            final int lmRespLen = lmChallengeResponse.length;
 
             final int domainLen = domainBytes != null ? domainBytes.length : 0;
-            final int hostLen = hostBytes != null ? hostBytes.length: 0;
+            final int hostLen = hostBytes != null ? hostBytes.length : 0;
             final int userLen = userBytes.length;
             final int sessionKeyLen;
-            if (sessionKey != null) {
-                sessionKeyLen = sessionKey.length;
-            } else {
+            if ( encryptedRandomSessionKey != null )
+            {
+                sessionKeyLen = encryptedRandomSessionKey.length;
+            }
+            else
+            {
                 sessionKeyLen = 0;
             }
 
             // Calculate the layout within the packet
-            final int lmRespOffset = 72;  // allocate space for the version
+            final int lmRespOffset = 72 + // allocate space for the version
+                ( computeMic ? 16 : 0 ); // and MIC
             final int ntRespOffset = lmRespOffset + lmRespLen;
             final int domainOffset = ntRespOffset + ntRespLen;
             final int userOffset = domainOffset + domainLen;
@@ -1268,120 +2163,225 @@ final class NTLMEngineImpl implements NTLMEngine {
             final int finalLength = sessionKeyOffset + sessionKeyLen;
 
             // Start the response. Length includes signature and type
-            prepareResponse(finalLength, 3);
+            prepareResponse( finalLength, 3 );
 
             // LM Resp Length (twice)
-            addUShort(lmRespLen);
-            addUShort(lmRespLen);
+            addUShort( lmRespLen );
+            addUShort( lmRespLen );
 
             // LM Resp Offset
-            addULong(lmRespOffset);
+            addULong( lmRespOffset );
 
             // NT Resp Length (twice)
-            addUShort(ntRespLen);
-            addUShort(ntRespLen);
+            addUShort( ntRespLen );
+            addUShort( ntRespLen );
 
             // NT Resp Offset
-            addULong(ntRespOffset);
+            addULong( ntRespOffset );
 
             // Domain length (twice)
-            addUShort(domainLen);
-            addUShort(domainLen);
+            addUShort( domainLen );
+            addUShort( domainLen );
 
             // Domain offset.
-            addULong(domainOffset);
+            addULong( domainOffset );
 
             // User Length (twice)
-            addUShort(userLen);
-            addUShort(userLen);
+            addUShort( userLen );
+            addUShort( userLen );
 
             // User offset
-            addULong(userOffset);
+            addULong( userOffset );
 
             // Host length (twice)
-            addUShort(hostLen);
-            addUShort(hostLen);
+            addUShort( hostLen );
+            addUShort( hostLen );
 
             // Host offset
-            addULong(hostOffset);
+            addULong( hostOffset );
 
             // Session key length (twice)
-            addUShort(sessionKeyLen);
-            addUShort(sessionKeyLen);
+            addUShort( sessionKeyLen );
+            addUShort( sessionKeyLen );
 
             // Session key offset
-            addULong(sessionKeyOffset);
+            addULong( sessionKeyOffset );
 
             // Flags.
             addULong(
-                    //FLAG_WORKSTATION_PRESENT |
-                    //FLAG_DOMAIN_PRESENT |
-
-                    // Required flags
-                    (type2Flags & FLAG_REQUEST_LAN_MANAGER_KEY) |
-                    (type2Flags & FLAG_REQUEST_NTLMv1) |
-                    (type2Flags & FLAG_REQUEST_NTLM2_SESSION) |
-
-                    // Protocol version request
-                    FLAG_REQUEST_VERSION |
-
-                    // Recommended privacy settings
-                    (type2Flags & FLAG_REQUEST_ALWAYS_SIGN) |
-                    (type2Flags & FLAG_REQUEST_SEAL) |
-                    (type2Flags & FLAG_REQUEST_SIGN) |
-
-                    // These must be set according to documentation, based on use of SEAL above
-                    (type2Flags & FLAG_REQUEST_128BIT_KEY_EXCH) |
-                    (type2Flags & FLAG_REQUEST_56BIT_ENCRYPTION) |
-                    (type2Flags & FLAG_REQUEST_EXPLICIT_KEY_EXCH) |
-
-                    (type2Flags & FLAG_TARGETINFO_PRESENT) |
-                    (type2Flags & FLAG_REQUEST_UNICODE_ENCODING) |
-                    (type2Flags & FLAG_REQUEST_TARGET)
+                type2Flags
             );
 
             // Version
-            addUShort(0x0105);
+            addUShort( 0x0105 );
             // Build
-            addULong(2600);
+            addULong( 2600 );
             // NTLM revision
-            addUShort(0x0f00);
+            addUShort( 0x0f00 );
 
-            // Add the actual data
-            addBytes(lmResp);
-            addBytes(ntResp);
-            addBytes(domainBytes);
-            addBytes(userBytes);
-            addBytes(hostBytes);
-            if (sessionKey != null) {
-                addBytes(sessionKey);
+            if ( computeMic )
+            {
+                micPosition = getCurrentOutputPosition();
+                skipBytes( 16 );
             }
 
-            return super.getResponse();
+            // Add the actual data
+            addBytes( lmChallengeResponse );
+            addBytes( ntChallengeResponse );
+            addBytes( domainBytes );
+            addBytes( userBytes );
+            addBytes( hostBytes );
+            if ( encryptedRandomSessionKey != null )
+            {
+                addBytes( encryptedRandomSessionKey );
+            }
         }
+
+
+        /**
+         * Computation of message integrity code (MIC) as specified in [MS-NLMP] section 3.2.5.1.2.
+         * The MIC is computed from all the messages in the exchange. Therefore it can be added to the
+         * last message only after it is encoded.
+         */
+        void addMic( final byte[] type1MessageBytes, final byte[] type2MessageBytes ) throws NTLMEngineException
+        {
+            if ( computeMic )
+            {
+                if ( micPosition == -1 )
+                {
+                    encodeMessage();
+                    messageEncoded = true;
+                }
+                if ( exportedSessionKey == null )
+                {
+                    throw new NTLMEngineException( "Cannot add MIC: no exported session key" );
+                }
+                final HMACMD5 hmacMD5 = new HMACMD5( exportedSessionKey );
+                hmacMD5.update( type1MessageBytes );
+                hmacMD5.update( type2MessageBytes );
+                hmacMD5.update( messageContents );
+                final byte[] mic = hmacMD5.getOutput();
+                System.arraycopy( mic, 0, messageContents, micPosition, mic.length );
+                if (develTrace) {
+                    log.trace( "mic:\n" + DebugUtil.dump( mic ) );
+                }
+            }
+        }
+
+
+        /**
+         * Add GSS channel binding hash and MIC flag to the targetInfo.
+         * Looks like this is needed if we want to use exported session key for GSS wrapping.
+         */
+        private byte[] addGssMicAvsToTargetInfo( final byte[] originalTargetInfo,
+            final X509Certificate peerServerCertificate ) throws NTLMEngineException
+        {
+            final byte[] newTargetInfo = new byte[originalTargetInfo.length + 8 + 20];
+            final int appendLength = originalTargetInfo.length - 4; // last tag is MSV_AV_EOL, do not copy that
+            System.arraycopy( originalTargetInfo, 0, newTargetInfo, 0, appendLength );
+            writeUShort( newTargetInfo, MSV_AV_FLAGS, appendLength );
+            writeUShort( newTargetInfo, 4, appendLength + 2 );
+            writeULong( newTargetInfo, MSV_AV_FLAGS_MIC, appendLength + 4 );
+            computeMic = true;
+            writeUShort( newTargetInfo, MSV_AV_CHANNEL_BINDINGS, appendLength + 8 );
+            writeUShort( newTargetInfo, 16, appendLength + 10 );
+
+            byte[] channelBindingsHash;
+            try
+            {
+                final byte[] certBytes = peerServerCertificate.getEncoded();
+                final MessageDigest sha256 = MessageDigest.getInstance( "SHA-256" );
+                final byte[] certHashBytes = sha256.digest( certBytes );
+                final byte[] channelBindingStruct = new byte[16 + 4 + MAGIC_TLS_SERVER_ENDPOINT.length
+                    + certHashBytes.length];
+                writeULong( channelBindingStruct, 0x00000035, 16 );
+                System.arraycopy( MAGIC_TLS_SERVER_ENDPOINT, 0, channelBindingStruct, 20,
+                    MAGIC_TLS_SERVER_ENDPOINT.length );
+                System.arraycopy( certHashBytes, 0, channelBindingStruct, 20 + MAGIC_TLS_SERVER_ENDPOINT.length,
+                    certHashBytes.length );
+                final MessageDigest md5 = MessageDigest.getInstance( "MD5" );
+                channelBindingsHash = md5.digest( channelBindingStruct );
+            }
+            catch ( CertificateEncodingException e )
+            {
+                throw new NTLMEngineException( e.getMessage(), e );
+            }
+            catch ( NoSuchAlgorithmException e )
+            {
+                throw new NTLMEngineException( e.getMessage(), e );
+            }
+
+            System.arraycopy( channelBindingsHash, 0, newTargetInfo, appendLength + 12, 16 );
+            return newTargetInfo;
+        }
+
+
+        public String debugDump()
+        {
+            final StringBuilder sb = new StringBuilder( "Type3Message\n" );
+            sb.append( "  flags:\n    " ).append( dumpFlags( type2Flags ) ).append( "\n" );
+            sb.append( "  domainBytes:\n    " ).append( DebugUtil.dump( domainBytes ) ).append( "\n" );
+            sb.append( "  hostBytes:\n    " ).append( DebugUtil.dump( hostBytes ) ).append( "\n" );
+            sb.append( "  userBytes:\n    " ).append( DebugUtil.dump( userBytes ) ).append( "\n" );
+            sb.append( "  lmResp:\n    " ).append( DebugUtil.dump( lmChallengeResponse ) ).append( "\n" );
+            sb.append( "  ntResp:\n    " ).append( DebugUtil.dump( ntChallengeResponse ) ).append( "\n" );
+            sb.append( "  encryptedRandomSessionKey:\n    " ).append( DebugUtil.dump( encryptedRandomSessionKey ) )
+                .append( "\n" );
+            sb.append( "  exportedSessionKey:\n    " ).append( DebugUtil.dump( exportedSessionKey ) );
+            return sb.toString();
+        }
+
     }
 
-    static void writeULong(final byte[] buffer, final int value, final int offset) {
-        buffer[offset] = (byte) (value & 0xff);
-        buffer[offset + 1] = (byte) (value >> 8 & 0xff);
-        buffer[offset + 2] = (byte) (value >> 16 & 0xff);
-        buffer[offset + 3] = (byte) (value >> 24 & 0xff);
+
+    static void writeUShort( final byte[] buffer, final int value, final int offset )
+    {
+        buffer[offset] = ( byte ) ( value & 0xff );
+        buffer[offset + 1] = ( byte ) ( value >> 8 & 0xff );
     }
 
-    static int F(final int x, final int y, final int z) {
-        return ((x & y) | (~x & z));
+
+    static void writeULong( final byte[] buffer, final int value, final int offset )
+    {
+        buffer[offset] = ( byte ) ( value & 0xff );
+        buffer[offset + 1] = ( byte ) ( value >> 8 & 0xff );
+        buffer[offset + 2] = ( byte ) ( value >> 16 & 0xff );
+        buffer[offset + 3] = ( byte ) ( value >> 24 & 0xff );
     }
 
-    static int G(final int x, final int y, final int z) {
-        return ((x & y) | (x & z) | (y & z));
+
+    static String toHexString( final byte[] bytes )
+    {
+        final StringBuilder sb = new StringBuilder();
+        for ( int i = 0; i < bytes.length; i++ )
+        {
+            sb.append( String.format( "%02X", bytes[i] ) );
+        }
+        return sb.toString();
     }
 
-    static int H(final int x, final int y, final int z) {
-        return (x ^ y ^ z);
+
+    static int F( final int x, final int y, final int z )
+    {
+        return ( ( x & y ) | ( ~x & z ) );
     }
 
-    static int rotintlft(final int val, final int numbits) {
-        return ((val << numbits) | (val >>> (32 - numbits)));
+
+    static int G( final int x, final int y, final int z )
+    {
+        return ( ( x & y ) | ( x & z ) | ( y & z ) );
+    }
+
+
+    static int H( final int x, final int y, final int z )
+    {
+        return ( x ^ y ^ z );
+    }
+
+
+    static int rotintlft( final int val, final int numbits )
+    {
+        return ( ( val << numbits ) | ( val >>> ( 32 - numbits ) ) );
     }
 
     /**
@@ -1391,7 +2391,8 @@ final class NTLMEngineImpl implements NTLMEngine {
      * library (http://jcifs.samba.org). It was massaged extensively to the
      * final form found here by Karl Wright (kwright@metacarta.com).
      */
-    static class MD4 {
+    static class MD4
+    {
         protected int A = 0x67452301;
         protected int B = 0xefcdab89;
         protected int C = 0x98badcfe;
@@ -1399,21 +2400,26 @@ final class NTLMEngineImpl implements NTLMEngine {
         protected long count = 0L;
         protected byte[] dataBuffer = new byte[64];
 
-        MD4() {
+
+        MD4()
+        {
         }
 
-        void update(final byte[] input) {
+
+        void update( final byte[] input )
+        {
             // We always deal with 512 bits at a time. Correspondingly, there is
             // a buffer 64 bytes long that we write data into until it gets
             // full.
-            int curBufferPos = (int) (count & 63L);
+            int curBufferPos = ( int ) ( count & 63L );
             int inputIndex = 0;
-            while (input.length - inputIndex + curBufferPos >= dataBuffer.length) {
+            while ( input.length - inputIndex + curBufferPos >= dataBuffer.length )
+            {
                 // We have enough data to do the next step. Do a partial copy
                 // and a transform, updating inputIndex and curBufferPos
                 // accordingly
                 final int transferAmt = dataBuffer.length - curBufferPos;
-                System.arraycopy(input, inputIndex, dataBuffer, curBufferPos, transferAmt);
+                System.arraycopy( input, inputIndex, dataBuffer, curBufferPos, transferAmt );
                 count += transferAmt;
                 curBufferPos = 0;
                 inputIndex += transferAmt;
@@ -1422,48 +2428,55 @@ final class NTLMEngineImpl implements NTLMEngine {
 
             // If there's anything left, copy it into the buffer and leave it.
             // We know there's not enough left to process.
-            if (inputIndex < input.length) {
+            if ( inputIndex < input.length )
+            {
                 final int transferAmt = input.length - inputIndex;
-                System.arraycopy(input, inputIndex, dataBuffer, curBufferPos, transferAmt);
+                System.arraycopy( input, inputIndex, dataBuffer, curBufferPos, transferAmt );
                 count += transferAmt;
                 curBufferPos += transferAmt;
             }
         }
 
-        byte[] getOutput() {
+
+        byte[] getOutput()
+        {
             // Feed pad/length data into engine. This must round out the input
             // to a multiple of 512 bits.
-            final int bufferIndex = (int) (count & 63L);
-            final int padLen = (bufferIndex < 56) ? (56 - bufferIndex) : (120 - bufferIndex);
+            final int bufferIndex = ( int ) ( count & 63L );
+            final int padLen = ( bufferIndex < 56 ) ? ( 56 - bufferIndex ) : ( 120 - bufferIndex );
             final byte[] postBytes = new byte[padLen + 8];
             // Leading 0x80, specified amount of zero padding, then length in
             // bits.
-            postBytes[0] = (byte) 0x80;
+            postBytes[0] = ( byte ) 0x80;
             // Fill out the last 8 bytes with the length
-            for (int i = 0; i < 8; i++) {
-                postBytes[padLen + i] = (byte) ((count * 8) >>> (8 * i));
+            for ( int i = 0; i < 8; i++ )
+            {
+                postBytes[padLen + i] = ( byte ) ( ( count * 8 ) >>> ( 8 * i ) );
             }
 
             // Update the engine
-            update(postBytes);
+            update( postBytes );
 
             // Calculate final result
             final byte[] result = new byte[16];
-            writeULong(result, A, 0);
-            writeULong(result, B, 4);
-            writeULong(result, C, 8);
-            writeULong(result, D, 12);
+            writeULong( result, A, 0 );
+            writeULong( result, B, 4 );
+            writeULong( result, C, 8 );
+            writeULong( result, D, 12 );
             return result;
         }
 
-        protected void processBuffer() {
+
+        protected void processBuffer()
+        {
             // Convert current buffer to 16 ulongs
             final int[] d = new int[16];
 
-            for (int i = 0; i < 16; i++) {
-                d[i] = (dataBuffer[i * 4] & 0xff) + ((dataBuffer[i * 4 + 1] & 0xff) << 8)
-                        + ((dataBuffer[i * 4 + 2] & 0xff) << 16)
-                        + ((dataBuffer[i * 4 + 3] & 0xff) << 24);
+            for ( int i = 0; i < 16; i++ )
+            {
+                d[i] = ( dataBuffer[i * 4] & 0xff ) + ( ( dataBuffer[i * 4 + 1] & 0xff ) << 8 )
+                    + ( ( dataBuffer[i * 4 + 2] & 0xff ) << 16 )
+                    + ( ( dataBuffer[i * 4 + 3] & 0xff ) << 24 );
             }
 
             // Do a round of processing
@@ -1471,9 +2484,9 @@ final class NTLMEngineImpl implements NTLMEngine {
             final int BB = B;
             final int CC = C;
             final int DD = D;
-            round1(d);
-            round2(d);
-            round3(d);
+            round1( d );
+            round2( d );
+            round3( d );
             A += AA;
             B += BB;
             C += CC;
@@ -1481,71 +2494,77 @@ final class NTLMEngineImpl implements NTLMEngine {
 
         }
 
-        protected void round1(final int[] d) {
-            A = rotintlft((A + F(B, C, D) + d[0]), 3);
-            D = rotintlft((D + F(A, B, C) + d[1]), 7);
-            C = rotintlft((C + F(D, A, B) + d[2]), 11);
-            B = rotintlft((B + F(C, D, A) + d[3]), 19);
 
-            A = rotintlft((A + F(B, C, D) + d[4]), 3);
-            D = rotintlft((D + F(A, B, C) + d[5]), 7);
-            C = rotintlft((C + F(D, A, B) + d[6]), 11);
-            B = rotintlft((B + F(C, D, A) + d[7]), 19);
+        protected void round1( final int[] d )
+        {
+            A = rotintlft( ( A + F( B, C, D ) + d[0] ), 3 );
+            D = rotintlft( ( D + F( A, B, C ) + d[1] ), 7 );
+            C = rotintlft( ( C + F( D, A, B ) + d[2] ), 11 );
+            B = rotintlft( ( B + F( C, D, A ) + d[3] ), 19 );
 
-            A = rotintlft((A + F(B, C, D) + d[8]), 3);
-            D = rotintlft((D + F(A, B, C) + d[9]), 7);
-            C = rotintlft((C + F(D, A, B) + d[10]), 11);
-            B = rotintlft((B + F(C, D, A) + d[11]), 19);
+            A = rotintlft( ( A + F( B, C, D ) + d[4] ), 3 );
+            D = rotintlft( ( D + F( A, B, C ) + d[5] ), 7 );
+            C = rotintlft( ( C + F( D, A, B ) + d[6] ), 11 );
+            B = rotintlft( ( B + F( C, D, A ) + d[7] ), 19 );
 
-            A = rotintlft((A + F(B, C, D) + d[12]), 3);
-            D = rotintlft((D + F(A, B, C) + d[13]), 7);
-            C = rotintlft((C + F(D, A, B) + d[14]), 11);
-            B = rotintlft((B + F(C, D, A) + d[15]), 19);
+            A = rotintlft( ( A + F( B, C, D ) + d[8] ), 3 );
+            D = rotintlft( ( D + F( A, B, C ) + d[9] ), 7 );
+            C = rotintlft( ( C + F( D, A, B ) + d[10] ), 11 );
+            B = rotintlft( ( B + F( C, D, A ) + d[11] ), 19 );
+
+            A = rotintlft( ( A + F( B, C, D ) + d[12] ), 3 );
+            D = rotintlft( ( D + F( A, B, C ) + d[13] ), 7 );
+            C = rotintlft( ( C + F( D, A, B ) + d[14] ), 11 );
+            B = rotintlft( ( B + F( C, D, A ) + d[15] ), 19 );
         }
 
-        protected void round2(final int[] d) {
-            A = rotintlft((A + G(B, C, D) + d[0] + 0x5a827999), 3);
-            D = rotintlft((D + G(A, B, C) + d[4] + 0x5a827999), 5);
-            C = rotintlft((C + G(D, A, B) + d[8] + 0x5a827999), 9);
-            B = rotintlft((B + G(C, D, A) + d[12] + 0x5a827999), 13);
 
-            A = rotintlft((A + G(B, C, D) + d[1] + 0x5a827999), 3);
-            D = rotintlft((D + G(A, B, C) + d[5] + 0x5a827999), 5);
-            C = rotintlft((C + G(D, A, B) + d[9] + 0x5a827999), 9);
-            B = rotintlft((B + G(C, D, A) + d[13] + 0x5a827999), 13);
+        protected void round2( final int[] d )
+        {
+            A = rotintlft( ( A + G( B, C, D ) + d[0] + 0x5a827999 ), 3 );
+            D = rotintlft( ( D + G( A, B, C ) + d[4] + 0x5a827999 ), 5 );
+            C = rotintlft( ( C + G( D, A, B ) + d[8] + 0x5a827999 ), 9 );
+            B = rotintlft( ( B + G( C, D, A ) + d[12] + 0x5a827999 ), 13 );
 
-            A = rotintlft((A + G(B, C, D) + d[2] + 0x5a827999), 3);
-            D = rotintlft((D + G(A, B, C) + d[6] + 0x5a827999), 5);
-            C = rotintlft((C + G(D, A, B) + d[10] + 0x5a827999), 9);
-            B = rotintlft((B + G(C, D, A) + d[14] + 0x5a827999), 13);
+            A = rotintlft( ( A + G( B, C, D ) + d[1] + 0x5a827999 ), 3 );
+            D = rotintlft( ( D + G( A, B, C ) + d[5] + 0x5a827999 ), 5 );
+            C = rotintlft( ( C + G( D, A, B ) + d[9] + 0x5a827999 ), 9 );
+            B = rotintlft( ( B + G( C, D, A ) + d[13] + 0x5a827999 ), 13 );
 
-            A = rotintlft((A + G(B, C, D) + d[3] + 0x5a827999), 3);
-            D = rotintlft((D + G(A, B, C) + d[7] + 0x5a827999), 5);
-            C = rotintlft((C + G(D, A, B) + d[11] + 0x5a827999), 9);
-            B = rotintlft((B + G(C, D, A) + d[15] + 0x5a827999), 13);
+            A = rotintlft( ( A + G( B, C, D ) + d[2] + 0x5a827999 ), 3 );
+            D = rotintlft( ( D + G( A, B, C ) + d[6] + 0x5a827999 ), 5 );
+            C = rotintlft( ( C + G( D, A, B ) + d[10] + 0x5a827999 ), 9 );
+            B = rotintlft( ( B + G( C, D, A ) + d[14] + 0x5a827999 ), 13 );
+
+            A = rotintlft( ( A + G( B, C, D ) + d[3] + 0x5a827999 ), 3 );
+            D = rotintlft( ( D + G( A, B, C ) + d[7] + 0x5a827999 ), 5 );
+            C = rotintlft( ( C + G( D, A, B ) + d[11] + 0x5a827999 ), 9 );
+            B = rotintlft( ( B + G( C, D, A ) + d[15] + 0x5a827999 ), 13 );
 
         }
 
-        protected void round3(final int[] d) {
-            A = rotintlft((A + H(B, C, D) + d[0] + 0x6ed9eba1), 3);
-            D = rotintlft((D + H(A, B, C) + d[8] + 0x6ed9eba1), 9);
-            C = rotintlft((C + H(D, A, B) + d[4] + 0x6ed9eba1), 11);
-            B = rotintlft((B + H(C, D, A) + d[12] + 0x6ed9eba1), 15);
 
-            A = rotintlft((A + H(B, C, D) + d[2] + 0x6ed9eba1), 3);
-            D = rotintlft((D + H(A, B, C) + d[10] + 0x6ed9eba1), 9);
-            C = rotintlft((C + H(D, A, B) + d[6] + 0x6ed9eba1), 11);
-            B = rotintlft((B + H(C, D, A) + d[14] + 0x6ed9eba1), 15);
+        protected void round3( final int[] d )
+        {
+            A = rotintlft( ( A + H( B, C, D ) + d[0] + 0x6ed9eba1 ), 3 );
+            D = rotintlft( ( D + H( A, B, C ) + d[8] + 0x6ed9eba1 ), 9 );
+            C = rotintlft( ( C + H( D, A, B ) + d[4] + 0x6ed9eba1 ), 11 );
+            B = rotintlft( ( B + H( C, D, A ) + d[12] + 0x6ed9eba1 ), 15 );
 
-            A = rotintlft((A + H(B, C, D) + d[1] + 0x6ed9eba1), 3);
-            D = rotintlft((D + H(A, B, C) + d[9] + 0x6ed9eba1), 9);
-            C = rotintlft((C + H(D, A, B) + d[5] + 0x6ed9eba1), 11);
-            B = rotintlft((B + H(C, D, A) + d[13] + 0x6ed9eba1), 15);
+            A = rotintlft( ( A + H( B, C, D ) + d[2] + 0x6ed9eba1 ), 3 );
+            D = rotintlft( ( D + H( A, B, C ) + d[10] + 0x6ed9eba1 ), 9 );
+            C = rotintlft( ( C + H( D, A, B ) + d[6] + 0x6ed9eba1 ), 11 );
+            B = rotintlft( ( B + H( C, D, A ) + d[14] + 0x6ed9eba1 ), 15 );
 
-            A = rotintlft((A + H(B, C, D) + d[3] + 0x6ed9eba1), 3);
-            D = rotintlft((D + H(A, B, C) + d[11] + 0x6ed9eba1), 9);
-            C = rotintlft((C + H(D, A, B) + d[7] + 0x6ed9eba1), 11);
-            B = rotintlft((B + H(C, D, A) + d[15] + 0x6ed9eba1), 15);
+            A = rotintlft( ( A + H( B, C, D ) + d[1] + 0x6ed9eba1 ), 3 );
+            D = rotintlft( ( D + H( A, B, C ) + d[9] + 0x6ed9eba1 ), 9 );
+            C = rotintlft( ( C + H( D, A, B ) + d[5] + 0x6ed9eba1 ), 11 );
+            B = rotintlft( ( B + H( C, D, A ) + d[13] + 0x6ed9eba1 ), 15 );
+
+            A = rotintlft( ( A + H( B, C, D ) + d[3] + 0x6ed9eba1 ), 3 );
+            D = rotintlft( ( D + H( A, B, C ) + d[11] + 0x6ed9eba1 ), 9 );
+            C = rotintlft( ( C + H( D, A, B ) + d[7] + 0x6ed9eba1 ), 11 );
+            B = rotintlft( ( B + H( C, D, A ) + d[15] + 0x6ed9eba1 ), 15 );
 
         }
 
@@ -1555,20 +2574,26 @@ final class NTLMEngineImpl implements NTLMEngine {
      * Cryptography support - HMACMD5 - algorithmically based on various web
      * resources by Karl Wright
      */
-    static class HMACMD5 {
+    static class HMACMD5
+    {
         protected byte[] ipad;
         protected byte[] opad;
         protected MessageDigest md5;
 
-        HMACMD5(final byte[] input) throws NTLMEngineException {
+
+        HMACMD5( final byte[] input ) throws NTLMEngineException
+        {
             byte[] key = input;
-            try {
-                md5 = MessageDigest.getInstance("MD5");
-            } catch (final Exception ex) {
+            try
+            {
+                md5 = MessageDigest.getInstance( "MD5" );
+            }
+            catch ( final Exception ex )
+            {
                 // Umm, the algorithm doesn't exist - throw an
                 // NTLMEngineException!
                 throw new NTLMEngineException(
-                        "Error getting md5 message digest implementation: " + ex.getMessage(), ex);
+                    "Error getting md5 message digest implementation: " + ex.getMessage(), ex );
             }
 
             // Initialize the pad buffers with the key
@@ -1576,73 +2601,119 @@ final class NTLMEngineImpl implements NTLMEngine {
             opad = new byte[64];
 
             int keyLength = key.length;
-            if (keyLength > 64) {
+            if ( keyLength > 64 )
+            {
                 // Use MD5 of the key instead, as described in RFC 2104
-                md5.update(key);
+                md5.update( key );
                 key = md5.digest();
                 keyLength = key.length;
             }
             int i = 0;
-            while (i < keyLength) {
-                ipad[i] = (byte) (key[i] ^ (byte) 0x36);
-                opad[i] = (byte) (key[i] ^ (byte) 0x5c);
+            while ( i < keyLength )
+            {
+                ipad[i] = ( byte ) ( key[i] ^ ( byte ) 0x36 );
+                opad[i] = ( byte ) ( key[i] ^ ( byte ) 0x5c );
                 i++;
             }
-            while (i < 64) {
-                ipad[i] = (byte) 0x36;
-                opad[i] = (byte) 0x5c;
+            while ( i < 64 )
+            {
+                ipad[i] = ( byte ) 0x36;
+                opad[i] = ( byte ) 0x5c;
                 i++;
             }
 
             // Very important: update the digest with the ipad buffer
             md5.reset();
-            md5.update(ipad);
+            md5.update( ipad );
 
         }
+
 
         /** Grab the current digest. This is the "answer". */
-        byte[] getOutput() {
+        byte[] getOutput()
+        {
             final byte[] digest = md5.digest();
-            md5.update(opad);
-            return md5.digest(digest);
+            md5.update( opad );
+            return md5.digest( digest );
         }
+
 
         /** Update by adding a complete array */
-        void update(final byte[] input) {
-            md5.update(input);
+        void update( final byte[] input )
+        {
+            md5.update( input );
         }
 
+
         /** Update the algorithm */
-        void update(final byte[] input, final int offset, final int length) {
-            md5.update(input, offset, length);
+        void update( final byte[] input, final int offset, final int length )
+        {
+            md5.update( input, offset, length );
         }
 
     }
+
 
     @Override
     public String generateType1Msg(
-            final String domain,
-            final String workstation) throws NTLMEngineException {
-        return getType1Message(workstation, domain);
+        final String domain,
+        final String workstation ) throws NTLMEngineException
+    {
+        return getType1Message( workstation, domain );
     }
+
 
     @Override
     public String generateType3Msg(
-            final String username,
-            final String password,
-            final String domain,
-            final String workstation,
-            final String challenge) throws NTLMEngineException {
-        final Type2Message t2m = new Type2Message(challenge);
+        final String username,
+        final String password,
+        final String domain,
+        final String workstation,
+        final String challenge ) throws NTLMEngineException
+    {
+        final Type2Message t2m = new Type2Message( challenge );
         return getType3Message(
-                username,
-                password,
-                workstation,
-                domain,
-                t2m.getChallenge(),
-                t2m.getFlags(),
-                t2m.getTarget(),
-                t2m.getTargetInfo());
+            username,
+            password,
+            workstation,
+            domain,
+            t2m.getChallenge(),
+            t2m.getFlags(),
+            t2m.getTarget(),
+            t2m.getTargetInfo() );
     }
 
+
+    private static String dumpFlags( final int flags )
+    {
+        final StringBuilder sb = new StringBuilder();
+        sb.append( String.format( "[%04X:", flags ) );
+        dumpFlag( sb, flags, FLAG_REQUEST_UNICODE_ENCODING, "REQUEST_UNICODE_ENCODING" );
+        dumpFlag( sb, flags, FLAG_REQUEST_OEM_ENCODING, "REQUEST_OEM_ENCODING" );
+        dumpFlag( sb, flags, FLAG_REQUEST_TARGET, "REQUEST_TARGET" );
+        dumpFlag( sb, flags, FLAG_REQUEST_SIGN, "REQUEST_SIGN" );
+        dumpFlag( sb, flags, FLAG_REQUEST_SEAL, "REQUEST_SEAL" );
+        dumpFlag( sb, flags, FLAG_REQUEST_LAN_MANAGER_KEY, "REQUEST_LAN_MANAGER_KEY" );
+        dumpFlag( sb, flags, FLAG_REQUEST_NTLMv1, "REQUEST_NTLMv1" );
+        dumpFlag( sb, flags, FLAG_DOMAIN_PRESENT, "DOMAIN_PRESENT" );
+        dumpFlag( sb, flags, FLAG_WORKSTATION_PRESENT, "WORKSTATION_PRESENT" );
+        dumpFlag( sb, flags, FLAG_REQUEST_ALWAYS_SIGN, "REQUEST_ALWAYS_SIGN" );
+        dumpFlag( sb, flags, FLAG_REQUEST_NTLM2_SESSION, "REQUEST_NTLM2_SESSION" );
+        dumpFlag( sb, flags, FLAG_REQUEST_VERSION, "REQUEST_VERSION" );
+        dumpFlag( sb, flags, FLAG_TARGETINFO_PRESENT, "TARGETINFO_PRESENT" );
+        dumpFlag( sb, flags, FLAG_REQUEST_128BIT_KEY_EXCH, "REQUEST_128BIT_KEY_EXCH" );
+        dumpFlag( sb, flags, FLAG_REQUEST_EXPLICIT_KEY_EXCH, "REQUEST_EXPLICIT_KEY_EXCH" );
+        dumpFlag( sb, flags, FLAG_REQUEST_56BIT_ENCRYPTION, "REQUEST_56BIT_ENCRYPTION" );
+        sb.append( "]" );
+        return sb.toString();
+    }
+
+
+    private static void dumpFlag( final StringBuilder sb, final int flags, final int flagMask, final String name )
+    {
+        if ( ( flags & flagMask ) == flagMask )
+        {
+            sb.append( name ).append( "," );
+        }
+    }
 }

--- a/httpclient/src/main/java/org/apache/http/impl/client/AuthenticationStrategyImpl.java
+++ b/httpclient/src/main/java/org/apache/http/impl/client/AuthenticationStrategyImpl.java
@@ -73,6 +73,7 @@ abstract class AuthenticationStrategyImpl implements AuthenticationStrategy {
                 AuthSchemes.SPNEGO,
                 AuthSchemes.KERBEROS,
                 AuthSchemes.NTLM,
+                AuthSchemes.CREDSSP,
                 AuthSchemes.DIGEST,
                 AuthSchemes.BASIC));
 


### PR DESCRIPTION
I have also significantly improved NTLM implementation in the HTTP client. It is not better aligned with Microsoft specifications and it supports more protocol options. I had to do it because CredSSP requires NTLM support for GSS API wrapping/unwrapping. So I have implemented it. The description, motivation and limitations are in the source code javadoc.

The code is tested with several different Windows servers.