### PR TITLE
trunk

### DIFF
--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/ResponseCachingPolicy.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/ResponseCachingPolicy.java
@@ -129,7 +129,7 @@ class ResponseCachingPolicy {
 
         final Header contentLength = response.getFirstHeader(HttpHeaders.CONTENT_LENGTH);
         if (contentLength != null) {
-            final int contentLengthValue = Integer.parseInt(contentLength.getValue());
+            final long contentLengthValue = Long.parseLong(contentLength.getValue());
             if (contentLengthValue > this.maxObjectSizeBytes) {
                 return false;
             }


### PR DESCRIPTION
Fix NFE for big content, parse contentLength to long, since maxObjectSizeBytes is long also.
This is very usefull when using httpclient-cache as a cache, for caching big files as well.