### PR TITLE
WIP: OpenTracing integration

### DIFF
--- a/httpclient5-testing/pom.xml
+++ b/httpclient5-testing/pom.xml
@@ -80,6 +80,11 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-mock</artifactId>
+      <version>0.22.0</version>
+    </dependency>
   </dependencies>
 
   <reporting>

--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/AsyncTracingTest.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/AsyncTracingTest.java
@@ -1,0 +1,115 @@
+package org.apache.hc.client5.testing.async;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.hc.client5.http.async.methods.SimpleHttpRequest;
+import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
+import org.apache.hc.client5.http.impl.async.TracingAsyncExec;
+import org.apache.hc.client5.http.impl.sync.ChainElements;
+import org.apache.hc.core5.http.HttpHost;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.opentracing.contrib.spanmanager.DefaultSpanManager;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.tag.Tags;
+
+/**
+ * @author Pavol Loffay
+ */
+public class AsyncTracingTest extends IntegrationTestBase {
+
+  private static MockTracer mockTracer = new MockTracer(MockTracer.Propagator.TEXT_MAP);
+
+  @Before
+  public void before() {
+    mockTracer.reset();
+    clientBuilder
+        .addExecInterceptorBefore(ChainElements.PROTOCOL.name(), "tracing", new TracingAsyncExec(mockTracer));
+  }
+
+  @Test
+  public void testStandardTags() throws Exception {
+    HttpHost httpHost = start();
+    Future<SimpleHttpResponse> future = httpclient.execute(
+            SimpleHttpRequest.get(httpHost, "/echo/"), null);
+
+    SimpleHttpResponse simpleHttpResponse = future.get();
+
+    Thread.sleep(1000);
+    List<MockSpan> mockSpans = mockTracer.finishedSpans();
+    Assert.assertEquals(1, mockSpans.size());
+    assertGeneratedErrors(mockSpans);
+  }
+
+  @Test
+  public void testMultipleRequests() throws Exception {
+    final HttpHost httpHost = start();
+
+    final String url = "/echo/";
+    int numberOfCalls = 22;
+    Map<Long, MockSpan> parentSpans = new LinkedHashMap<>(numberOfCalls);
+
+    ExecutorService executorService = Executors.newFixedThreadPool(10);
+    List<Future<?>> futures = new ArrayList<>(numberOfCalls);
+    for (int i = 0; i < numberOfCalls; i++) {
+      final String requestUrl = url + i;
+
+      final MockSpan parentSpan = mockTracer.buildSpan("foo").start();
+      parentSpan.setTag("request-url", httpHost.toURI().toString() + requestUrl);
+      parentSpans.put(parentSpan.context().spanId(), parentSpan);
+
+      futures.add(executorService.submit(new Runnable() {
+        @Override
+        public void run() {
+          DefaultSpanManager.getInstance().activate(parentSpan);
+          try {
+            httpclient.execute(SimpleHttpRequest.get(httpHost, requestUrl), null).get();
+          } catch (InterruptedException | ExecutionException e) {
+            e.printStackTrace();
+          }
+        }
+      }));
+    }
+
+    // wait to finish all calls
+    for (Future<?> future: futures) {
+      future.get();
+    }
+
+    executorService.awaitTermination(1, TimeUnit.SECONDS);
+    executorService.shutdown();
+
+    List<MockSpan> mockSpans = mockTracer.finishedSpans();
+    Assert.assertEquals(numberOfCalls, mockSpans.size());
+    assertGeneratedErrors(mockSpans);
+
+    for (int i = 0; i < numberOfCalls; i++) {
+      MockSpan childSpan = mockSpans.get(i);
+      MockSpan parentSpan = parentSpans.get(childSpan.parentId());
+
+      Assert.assertEquals(parentSpan.tags().get("request-url"), childSpan.tags().get(Tags.HTTP_URL.getKey()));
+
+      Assert.assertEquals(parentSpan.context().traceId(), childSpan.context().traceId());
+      Assert.assertEquals(parentSpan.context().spanId(), childSpan.parentId());
+      Assert.assertEquals(0, childSpan.generatedErrors().size());
+      Assert.assertEquals(0, parentSpan.generatedErrors().size());
+    }
+  }
+
+  private void assertGeneratedErrors(List<MockSpan> mockSpans) {
+    for (MockSpan mockSpan: mockSpans){
+      Assert.assertEquals(mockSpan.generatedErrors().toString(), 0, mockSpan.generatedErrors().size());
+    }
+  }
+}

--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestTracing.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestTracing.java
@@ -1,0 +1,282 @@
+package org.apache.hc.client5.testing.sync;
+
+
+import io.opentracing.Span;
+import io.opentracing.contrib.spanmanager.DefaultSpanManager;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.tag.Tags;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.UnknownHostException;
+import java.util.List;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.sync.ChainElements;
+import org.apache.hc.client5.http.impl.sync.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.sync.HttpClientBuilder;
+import org.apache.hc.client5.http.impl.sync.TracingExec;
+import org.apache.hc.client5.http.sync.HttpClient;
+import org.apache.hc.client5.http.sync.methods.HttpGet;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.HttpException;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.io.HttpRequestHandler;
+import org.apache.hc.core5.http.protocol.HttpContext;
+import org.apache.hc.core5.io.ShutdownType;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Pavol Loffay
+ */
+public class TestTracing extends LocalServerTestBase {
+
+    private static MockTracer mockTracer = new MockTracer(MockTracer.Propagator.TEXT_MAP);
+
+    private HttpHost serverHost;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        this.clientBuilder = HttpClientBuilder.create()
+            .addExecInterceptorAfter(ChainElements.PROTOCOL.name(), "tracing",
+                new TracingExec(mockTracer));
+
+        this.serverBootstrap.registerHandler(RedirectHandler.MAPPING, new RedirectHandler())
+                .registerHandler(PropagationHandler.MAPPING, new PropagationHandler());
+        this.serverHost = super.start();
+    }
+
+    @After
+    public void shutDown() throws Exception {
+        if(this.httpclient != null) {
+            this.httpclient.close();
+        }
+        if(this.server != null) {
+            this.server.shutdown(ShutdownType.IMMEDIATE);
+        }
+        mockTracer.reset();
+    }
+
+    @Test
+    public void testStandardTags() throws IOException {
+        {
+            CloseableHttpClient client = clientBuilder.build();
+            client.execute(new HttpGet(serverUrl("/echo/a")));
+        }
+
+        List<MockSpan> mockSpans = mockTracer.finishedSpans();
+        Assert.assertEquals(2, mockSpans.size());
+
+        MockSpan mockSpan = mockSpans.get(0);
+        Assert.assertEquals("GET", mockSpan.operationName());
+
+        Assert.assertEquals(6, mockSpan.tags().size());
+        Assert.assertEquals(Tags.SPAN_KIND_CLIENT, mockSpan.tags().get(Tags.SPAN_KIND.getKey()));
+        Assert.assertEquals("GET", mockSpan.tags().get(Tags.HTTP_METHOD.getKey()));
+        Assert.assertEquals(serverUrl("/echo/a"), mockSpan.tags().get(Tags.HTTP_URL.getKey()));
+        Assert.assertEquals(200, mockSpan.tags().get(Tags.HTTP_STATUS.getKey()));
+        Assert.assertEquals(serverHost.getPort(), mockSpan.tags().get(Tags.PEER_PORT.getKey()));
+        Assert.assertEquals(serverHost.getHostName(), mockSpan.tags().get(Tags.PEER_HOSTNAME.getKey()));
+        Assert.assertEquals(0, mockSpan.logEntries().size());
+
+        assertLocalSpan(mockSpans.get(1));
+    }
+
+    @Test
+    public void testRedirect() throws URISyntaxException, IOException {
+        {
+            HttpClient client = clientBuilder.build();
+            client.execute(new HttpGet(serverUrl(RedirectHandler.MAPPING)));
+        }
+
+        List<MockSpan> mockSpans = mockTracer.finishedSpans();
+        Assert.assertEquals(3, mockSpans.size());
+
+        MockSpan mockSpan = mockSpans.get(0);
+        Assert.assertEquals("GET", mockSpan.operationName());
+        Assert.assertEquals(6, mockSpan.tags().size());
+        Assert.assertEquals(Tags.SPAN_KIND_CLIENT, mockSpan.tags().get(Tags.SPAN_KIND.getKey()));
+        Assert.assertEquals("GET", mockSpan.tags().get(Tags.HTTP_METHOD.getKey()));
+        Assert.assertEquals(serverUrl("/redirect"), mockSpan.tags().get(Tags.HTTP_URL.getKey()));
+        Assert.assertEquals(301, mockSpan.tags().get(Tags.HTTP_STATUS.getKey()));
+        Assert.assertEquals(serverHost.getPort(), mockSpan.tags().get(Tags.PEER_PORT.getKey()));
+        Assert.assertEquals(serverHost.getHostName(), mockSpan.tags().get(Tags.PEER_HOSTNAME.getKey()));
+
+        mockSpan = mockSpans.get(1);
+        Assert.assertEquals("GET", mockSpan.operationName());
+        Assert.assertEquals(6, mockSpan.tags().size());
+        Assert.assertEquals(Tags.SPAN_KIND_CLIENT, mockSpan.tags().get(Tags.SPAN_KIND.getKey()));
+        Assert.assertEquals("GET", mockSpan.tags().get(Tags.HTTP_METHOD.getKey()));
+        Assert.assertEquals(serverUrl("/propagation"), mockSpan.tags().get(Tags.HTTP_URL.getKey()));
+        Assert.assertEquals(200, mockSpan.tags().get(Tags.HTTP_STATUS.getKey()));
+        Assert.assertEquals(serverHost.getPort(), mockSpan.tags().get(Tags.PEER_PORT.getKey()));
+        Assert.assertEquals(serverHost.getHostName(), mockSpan.tags().get(Tags.PEER_HOSTNAME.getKey()));
+
+        assertLocalSpan(mockSpans.get(2));
+    }
+
+    @Test
+    public void testDisableRedirectHandling() throws URISyntaxException, IOException {
+        {
+//            HttpClient client = new TracingHttpClientBuilder(DefaultRedirectStrategy.INSTANCE, true, mockTracer,
+//                    Collections.<ApacheClientSpanDecorator>singletonList(new ApacheClientSpanDecorator.StandardTags()))
+//                    .build();
+//
+//            client.execute(new HttpGet(serverUrl(RedirectHandler.MAPPING)));
+        }
+
+        List<MockSpan> mockSpans = mockTracer.finishedSpans();
+        Assert.assertEquals(2, mockSpans.size());
+
+        MockSpan mockSpan = mockSpans.get(0);
+        Assert.assertEquals("GET", mockSpan.operationName());
+
+        Assert.assertEquals(6, mockSpan.tags().size());
+        Assert.assertEquals(Tags.SPAN_KIND_CLIENT, mockSpan.tags().get(Tags.SPAN_KIND.getKey()));
+        Assert.assertEquals("GET", mockSpan.tags().get(Tags.HTTP_METHOD.getKey()));
+        Assert.assertEquals(serverUrl("/redirect"), mockSpan.tags().get(Tags.HTTP_URL.getKey()));
+        Assert.assertEquals(301, mockSpan.tags().get(Tags.HTTP_STATUS.getKey()));
+        Assert.assertEquals(serverHost.getPort(), mockSpan.tags().get(Tags.PEER_PORT.getKey()));
+        Assert.assertEquals(serverHost.getHostName(), mockSpan.tags().get(Tags.PEER_HOSTNAME.getKey()));
+        Assert.assertEquals(0, mockSpan.logEntries().size());
+
+        assertLocalSpan(mockSpans.get(1));
+    }
+
+    @Test
+    public void testRequestConfigDisabledRedirects() throws URISyntaxException, IOException {
+        {
+            HttpClient client = clientBuilder
+                    .setDefaultRequestConfig(RequestConfig.custom()
+                                .setRedirectsEnabled(false)
+                                .build())
+                    .build();
+            client.execute(new HttpGet(serverUrl(RedirectHandler.MAPPING)));
+        }
+
+        List<MockSpan> mockSpans = mockTracer.finishedSpans();
+        Assert.assertEquals(2, mockSpans.size());
+
+        MockSpan mockSpan = mockSpans.get(0);
+        Assert.assertEquals("GET", mockSpan.operationName());
+
+        Assert.assertEquals(6, mockSpan.tags().size());
+        Assert.assertEquals(Tags.SPAN_KIND_CLIENT, mockSpan.tags().get(Tags.SPAN_KIND.getKey()));
+        Assert.assertEquals("GET", mockSpan.tags().get(Tags.HTTP_METHOD.getKey()));
+        Assert.assertEquals(serverUrl("/redirect"), mockSpan.tags().get(Tags.HTTP_URL.getKey()));
+        Assert.assertEquals(301, mockSpan.tags().get(Tags.HTTP_STATUS.getKey()));
+        Assert.assertEquals(serverHost.getPort(), mockSpan.tags().get(Tags.PEER_PORT.getKey()));
+        Assert.assertEquals(serverHost.getHostName(), mockSpan.tags().get(Tags.PEER_HOSTNAME.getKey()));
+        Assert.assertEquals(0, mockSpan.logEntries().size());
+
+        assertLocalSpan(mockSpans.get(1));
+    }
+
+    @Test
+    public void testParentSpan() throws IOException {
+        {
+            Span parentSpan = mockTracer.buildSpan("parent")
+                    .start();
+            DefaultSpanManager.getInstance().activate(parentSpan);
+
+            CloseableHttpClient client = clientBuilder.build();
+            client.execute(new HttpGet(serverUrl("/echo/a")));
+
+            parentSpan.finish();
+        }
+
+        List<MockSpan> mockSpans = mockTracer.finishedSpans();
+        Assert.assertEquals(3, mockSpans.size());
+
+        Assert.assertEquals(mockSpans.get(0).context().traceId(), mockSpans.get(1).context().traceId());
+        Assert.assertEquals(mockSpans.get(0).parentId(), mockSpans.get(1).context().spanId());
+
+        assertLocalSpan(mockSpans.get(1));
+    }
+
+    @Test
+    public void testPropagationAfterRedirect() throws IOException {
+        {
+            HttpClient client = clientBuilder.build();
+            client.execute(new HttpGet(serverUrl(RedirectHandler.MAPPING)));
+        }
+
+        List<MockSpan> mockSpans = mockTracer.finishedSpans();
+        Assert.assertEquals(3, mockSpans.size());
+
+        // the last one is for redirect
+        MockSpan mockSpan = mockSpans.get(1);
+        Assert.assertEquals(PropagationHandler.lastRequest.getFirstHeader("traceId").getValue(),
+                String.valueOf(mockSpan.context().traceId()));
+        Assert.assertEquals(PropagationHandler.lastRequest.getFirstHeader("spanId").getValue(),
+                String.valueOf(mockSpan.context().spanId()));
+
+        assertLocalSpan(mockSpans.get(2));
+    }
+
+    @Test
+    public void testUnknownHostException() throws IOException {
+        CloseableHttpClient client = clientBuilder.build();
+
+        try {
+            client.execute(new HttpGet("http://notexisting.example.com"));
+        } catch (UnknownHostException ex) {
+        }
+
+        List<MockSpan> mockSpans = mockTracer.finishedSpans();
+        Assert.assertEquals(2, mockSpans.size());
+
+        MockSpan mockSpan = mockSpans.get(0);
+        Assert.assertEquals(Boolean.TRUE, mockSpan.tags().get(Tags.ERROR.getKey()));
+
+        // logs
+        Assert.assertEquals(1, mockSpan.logEntries().size());
+        Assert.assertEquals(2, mockSpan.logEntries().get(0).fields().size());
+        Assert.assertEquals(Tags.ERROR.getKey(), mockSpan.logEntries().get(0).fields().get("event"));
+        Assert.assertNotNull(mockSpan.logEntries().get(0).fields().get("error.object"));
+    }
+
+    public void assertLocalSpan(MockSpan mockSpan) {
+        Assert.assertEquals(1, mockSpan.tags().size());
+//        Assert.assertEquals(TracingClientExec.COMPONENT_NAME, mockSpan.tags().get(Tags.COMPONENT.getKey()));
+    }
+
+    protected String serverUrl(String path) {
+        return serverHost.toString() + path;
+    }
+
+    public static class RedirectHandler implements HttpRequestHandler {
+
+        public static final String MAPPING = "/redirect";
+
+        @Override
+        public void handle(ClassicHttpRequest classicHttpRequest,
+            ClassicHttpResponse response,
+            HttpContext httpContext) throws HttpException, IOException {
+
+            response.setCode(HttpStatus.SC_MOVED_PERMANENTLY);
+            response.addHeader("Location", PropagationHandler.MAPPING);
+        }
+    }
+
+    public static class PropagationHandler implements HttpRequestHandler {
+        public static final String MAPPING = "/propagation";
+        public static HttpRequest lastRequest;
+
+        @Override
+        public void handle(ClassicHttpRequest request,
+            ClassicHttpResponse response,
+            HttpContext httpContext) throws HttpException, IOException {
+
+            // TODO this is ugly...
+            lastRequest = request;
+            response.setCode(HttpStatus.SC_OK);
+        }
+    }
+}

--- a/httpclient5/pom.xml
+++ b/httpclient5/pom.xml
@@ -64,6 +64,16 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-api</artifactId>
+      <version>0.22.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing.contrib</groupId>
+      <artifactId>opentracing-spanmanager</artifactId>
+      <version>0.0.4</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/TracingAsyncExec.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/TracingAsyncExec.java
@@ -1,0 +1,80 @@
+package org.apache.hc.client5.http.impl.async;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import org.apache.hc.client5.http.async.AsyncExecCallback;
+import org.apache.hc.client5.http.async.AsyncExecChain;
+import org.apache.hc.client5.http.async.AsyncExecChain.Scope;
+import org.apache.hc.client5.http.async.AsyncExecChainHandler;
+import org.apache.hc.core5.http.EntityDetails;
+import org.apache.hc.core5.http.HttpException;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.nio.AsyncDataConsumer;
+import org.apache.hc.core5.http.nio.AsyncEntityProducer;
+
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import io.opentracing.Tracer.SpanBuilder;
+import io.opentracing.contrib.spanmanager.DefaultSpanManager;
+import io.opentracing.contrib.spanmanager.SpanManager.ManagedSpan;
+import io.opentracing.tag.Tags;
+
+/**
+ * @author Pavol Loffay
+ */
+public class TracingAsyncExec implements AsyncExecChainHandler {
+
+  private Tracer tracer;
+
+  public TracingAsyncExec(Tracer tracer) {
+    this.tracer = tracer;
+  }
+
+  @Override
+  public void execute(HttpRequest request, AsyncEntityProducer entityProducer, final Scope scope,
+      AsyncExecChain chain, final AsyncExecCallback asyncExecCallback) throws HttpException, IOException {
+
+    SpanBuilder spanBuilder = tracer.buildSpan(request.getMethod())
+        .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CLIENT);
+
+    ManagedSpan current = DefaultSpanManager.getInstance().current();
+    if (current.getSpan() != null) {
+      spanBuilder.asChildOf(current.getSpan());
+    }
+
+    final Span span = spanBuilder.start();
+    // TODO add request tags
+    try {
+      Tags.HTTP_URL.set(span, request.getUri().toString());
+    } catch (URISyntaxException e) {
+      e.printStackTrace();
+    }
+
+    chain.proceed(request, entityProducer, scope, new AsyncExecCallback() {
+      @Override
+      public AsyncDataConsumer handleResponse(HttpResponse response, EntityDetails entityDetails)
+          throws HttpException, IOException {
+        //activate for usage in user defined callbacks
+        DefaultSpanManager.getInstance().activate(span);
+        AsyncDataConsumer asyncDataConsumer = asyncExecCallback.handleResponse(response, entityDetails);
+        // TODO add response tags
+//        span.finish();
+        return asyncDataConsumer;
+      }
+
+      @Override
+      public void completed() {
+        asyncExecCallback.completed();
+        span.finish();
+      }
+
+      @Override
+      public void failed(Exception cause) {
+        asyncExecCallback.failed(cause);
+        span.finish();
+      }
+    });
+  }
+}

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/sync/TracingExec.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/sync/TracingExec.java
@@ -1,0 +1,94 @@
+package org.apache.hc.client5.http.impl.sync;
+
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.contrib.spanmanager.DefaultSpanManager;
+import io.opentracing.contrib.spanmanager.SpanManager;
+import io.opentracing.propagation.Format;
+import io.opentracing.propagation.TextMap;
+import io.opentracing.tag.Tags;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map.Entry;
+import org.apache.hc.client5.http.sync.ExecChain;
+import org.apache.hc.client5.http.sync.ExecChain.Scope;
+import org.apache.hc.client5.http.sync.ExecChainHandler;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.HttpException;
+import org.apache.hc.core5.http.HttpRequest;
+
+/**
+ * @author Pavol Loffay
+ */
+public class TracingExec implements ExecChainHandler {
+  /**
+   * SpanContext which will be used as a parent for created client span.
+   */
+  public static final String PARENT_CONTEXT = TracingExec.class.getName() + ".parentSpanContext";
+
+  private final Tracer tracer;
+  private final SpanManager spanManager = DefaultSpanManager.getInstance();
+
+  public static HttpClientBuilder addTracing(HttpClientBuilder clientBuilder, Tracer tracer) {
+    clientBuilder.addExecInterceptorAfter(ChainElements.MAIN_TRANSPORT.name(), "tracing", new TracingExec(tracer));
+
+    return clientBuilder;
+  }
+
+  public TracingExec(Tracer tracer) {
+    this.tracer = tracer;
+  }
+
+  @Override
+  public ClassicHttpResponse execute(ClassicHttpRequest request, Scope scope, ExecChain chain)
+      throws IOException, HttpException {
+    Span span = null;
+    try {
+      Tracer.SpanBuilder spanBuilder = tracer.buildSpan(request.getMethod())
+          .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CLIENT);
+
+      if (scope.clientContext.getAttribute(PARENT_CONTEXT, SpanContext.class) != null) {
+        spanBuilder.asChildOf(scope.clientContext.getAttribute(PARENT_CONTEXT, SpanContext.class));
+      } else if (spanManager.current().getSpan() != null) {
+        spanBuilder.asChildOf(spanManager.current().getSpan());
+      }
+
+      span = spanBuilder.start();
+      tracer.inject(span.context(), Format.Builtin.HTTP_HEADERS,
+          new HttpHeadersInjectAdapter(request));
+      // TODO add request tags
+
+      ClassicHttpResponse response = chain.proceed(request, scope);
+      // TODO add response tags
+      return response;
+    } catch (IOException | HttpException | RuntimeException e) {
+      // TODO add error tags
+      throw e;
+    } finally {
+      if (span != null) {
+      }
+    }
+
+  }
+
+  class HttpHeadersInjectAdapter implements TextMap {
+      private HttpRequest httpRequest;
+
+      public HttpHeadersInjectAdapter(HttpRequest httpRequest) {
+        this.httpRequest = httpRequest;
+      }
+
+      @Override
+      public void put(String key, String value) {
+        httpRequest.addHeader(key, value);
+      }
+
+      @Override
+      public Iterator<Entry<String, String>> iterator() {
+        throw new UnsupportedOperationException(
+            "This class should be used only with tracer#inject()");
+      }
+    }
+}

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/TestTracing.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/TestTracing.java
@@ -1,0 +1,8 @@
+package org.apache.hc.client5.http;
+
+/**
+ * @author Pavol Loffay
+ */
+public class TestTracing {
+
+}


### PR DESCRIPTION
OpenTracing integration.

Tracing `ClientExecChain` has to be registered as the last one. It should wrap all the client invocation.

There will be probably one more class - `SpanDecorator` to add tags to span (onRequest, onResponse, onError).

cc @ok2c 

(`mvn clean install -Dcheckstyle.skip=true -Dmaven.javadoc.skip=true -Drat.skip=true  -DskipTests`)