### PR TITLE
Avoid fetching entity from cache's datastore twice

### DIFF
--- a/httpclient-cache/src/main/java/org/apache/http/impl/client/cache/CachingExec.java
+++ b/httpclient-cache/src/main/java/org/apache/http/impl/client/cache/CachingExec.java
@@ -263,10 +263,9 @@ public class CachingExec implements ClientExecChain {
         requestCompliance.makeRequestCompliant(request);
         request.addHeader("Via",via);
 
-        flushEntriesInvalidatedByRequest(context.getTargetHost(), request);
-
         if (!cacheableRequestPolicy.isServableFromCache(request)) {
             log.debug("Request is not servable from cache");
+            flushEntriesInvalidatedByRequest(context.getTargetHost(), request);
             return callBackend(route, request, context, execAware);
         }
 

--- a/httpclient-cache/src/test/java/org/apache/http/impl/client/cache/TestCachingExec.java
+++ b/httpclient-cache/src/test/java/org/apache/http/impl/client/cache/TestCachingExec.java
@@ -402,6 +402,26 @@ public class TestCachingExec extends TestCachingExecChain {
         verifyMocks();
     }
 
+    @Test
+    public void testDoesNotFlushCachesOnCacheHit() throws Exception {
+        requestPolicyAllowsCaching(true);
+        requestIsFatallyNonCompliant(null);
+
+        getCacheEntryReturns(mockCacheEntry);
+        doesNotFlushCache();
+        cacheEntrySuitable(true);
+        cacheEntryValidatable(true);
+
+        expect(mockResponseGenerator.generateResponse(isA(HttpRequestWrapper.class), isA(HttpCacheEntry.class)))
+                .andReturn(mockBackendResponse);
+
+        replayMocks();
+        final HttpResponse result = impl.execute(route, request, context);
+        verifyMocks();
+
+        Assert.assertSame(mockBackendResponse, result);
+    }
+
     private IExpectationSetters<CloseableHttpResponse> implExpectsAnyRequestAndReturn(
             final CloseableHttpResponse response) throws Exception {
         final CloseableHttpResponse resp = impl.callBackend(

--- a/httpclient-cache/src/test/java/org/apache/http/impl/client/cache/TestCachingExec.java
+++ b/httpclient-cache/src/test/java/org/apache/http/impl/client/cache/TestCachingExec.java
@@ -170,7 +170,6 @@ public class TestCachingExec extends TestCachingExecChain {
     @Test
     public void testCacheMissCausesBackendRequest() throws Exception {
         mockImplMethods(CALL_BACKEND);
-        cacheInvalidatorWasCalled();
         requestPolicyAllowsCaching(true);
         getCacheEntryReturns(null);
         getVariantCacheEntriesReturns(new HashMap<String,Variant>());
@@ -192,7 +191,6 @@ public class TestCachingExec extends TestCachingExecChain {
     @Test
     public void testUnsuitableUnvalidatableCacheEntryCausesBackendRequest() throws Exception {
         mockImplMethods(CALL_BACKEND);
-        cacheInvalidatorWasCalled();
         requestPolicyAllowsCaching(true);
         requestIsFatallyNonCompliant(null);
 
@@ -219,7 +217,6 @@ public class TestCachingExec extends TestCachingExecChain {
     @Test
     public void testUnsuitableValidatableCacheEntryCausesRevalidation() throws Exception {
         mockImplMethods(REVALIDATE_CACHE_ENTRY);
-        cacheInvalidatorWasCalled();
         requestPolicyAllowsCaching(true);
         requestIsFatallyNonCompliant(null);
 

--- a/httpclient-cache/src/test/java/org/apache/http/impl/client/cache/TestCachingExecChain.java
+++ b/httpclient-cache/src/test/java/org/apache/http/impl/client/cache/TestCachingExecChain.java
@@ -311,7 +311,6 @@ public abstract class TestCachingExecChain {
 
     @Test
     public void testSuitableCacheEntryDoesNotCauseBackendRequest() throws Exception {
-        cacheInvalidatorWasCalled();
         requestPolicyAllowsCaching(true);
         getCacheEntryReturns(mockCacheEntry);
         cacheEntrySuitable(true);
@@ -352,7 +351,6 @@ public abstract class TestCachingExecChain {
     public void testResponseIsGeneratedWhenCacheEntryIsUsable() throws Exception {
 
         requestIsFatallyNonCompliant(null);
-        cacheInvalidatorWasCalled();
         requestPolicyAllowsCaching(true);
         cacheEntrySuitable(true);
         getCacheEntryReturns(mockCacheEntry);
@@ -1385,7 +1383,6 @@ public abstract class TestCachingExecChain {
             "must-revalidate") });
 
         requestIsFatallyNonCompliant(null);
-        cacheInvalidatorWasCalled();
         requestPolicyAllowsCaching(true);
         getCacheEntryReturns(entry);
         cacheEntrySuitable(false);
@@ -1403,7 +1400,6 @@ public abstract class TestCachingExecChain {
         request.setHeader("Cache-Control", "only-if-cached");
 
         requestIsFatallyNonCompliant(null);
-        cacheInvalidatorWasCalled();
         requestPolicyAllowsCaching(true);
         getCacheEntryReturns(entry);
         cacheEntrySuitable(true);
@@ -1731,11 +1727,6 @@ public abstract class TestCachingExecChain {
 
     protected void getCacheEntryReturns(final HttpCacheEntry result) throws IOException {
         expect(mockCache.getCacheEntry(eq(host), eqRequest(request))).andReturn(result);
-    }
-
-    private void cacheInvalidatorWasCalled() throws IOException {
-        mockCache
-            .flushInvalidatedCacheEntriesFor((HttpHost) anyObject(), (HttpRequest) anyObject());
     }
 
     protected void cacheEntryValidatable(final boolean b) {

--- a/httpclient-cache/src/test/java/org/apache/http/impl/client/cache/TestCachingExecChain.java
+++ b/httpclient-cache/src/test/java/org/apache/http/impl/client/cache/TestCachingExecChain.java
@@ -1777,4 +1777,9 @@ public abstract class TestCachingExecChain {
             .andReturn(mockCachedResponse);
     }
 
+    protected void doesNotFlushCache() throws IOException {
+        mockCache.flushInvalidatedCacheEntriesFor(isA(HttpHost.class), isA(HttpRequest.class));
+        EasyMock.expectLastCall().andThrow(new AssertionError("flushInvalidatedCacheEntriesFor should not have been called")).anyTimes();
+    }
+
 }

--- a/httpclient-cache/src/test/java/org/apache/http/impl/client/cache/TestProtocolRequirements.java
+++ b/httpclient-cache/src/test/java/org/apache/http/impl/client/cache/TestProtocolRequirements.java
@@ -2504,8 +2504,6 @@ public class TestProtocolRequirements extends AbstractProtocolTest {
         notModified.setHeader("Date", DateUtils.formatDate(now));
         notModified.setHeader("ETag", "\"etag\"");
 
-        mockCache.flushInvalidatedCacheEntriesFor(EasyMock.eq(host),
-                eqRequest(request));
         EasyMock.expect(
                 mockCache.getCacheEntry(EasyMock.eq(host), eqRequest(request)))
                 .andReturn(entry);
@@ -2551,7 +2549,6 @@ public class TestProtocolRequirements extends AbstractProtocolTest {
         impl = new CachingExec(mockBackend, mockCache, config);
         request = HttpRequestWrapper.wrap(new BasicHttpRequest("GET", "/thing", HttpVersion.HTTP_1_1));
 
-        mockCache.flushInvalidatedCacheEntriesFor(EasyMock.eq(host), eqRequest(request));
         EasyMock.expect(mockCache.getCacheEntry(EasyMock.eq(host), eqRequest(request))).andReturn(entry);
 
         replayMocks();
@@ -2599,7 +2596,6 @@ public class TestProtocolRequirements extends AbstractProtocolTest {
         impl = new CachingExec(mockBackend, mockCache, config);
         request = HttpRequestWrapper.wrap(new BasicHttpRequest("GET", "/thing", HttpVersion.HTTP_1_1));
 
-        mockCache.flushInvalidatedCacheEntriesFor(EasyMock.eq(host), eqRequest(request));
         EasyMock.expect(mockCache.getCacheEntry(EasyMock.eq(host), eqRequest(request))).andReturn(entry);
         EasyMock.expect(
                 mockBackend.execute(
@@ -2818,7 +2814,6 @@ public class TestProtocolRequirements extends AbstractProtocolTest {
         impl = new CachingExec(mockBackend, mockCache, config);
         request = HttpRequestWrapper.wrap(new BasicHttpRequest("GET", "/thing", HttpVersion.HTTP_1_1));
 
-        mockCache.flushInvalidatedCacheEntriesFor(EasyMock.eq(host), eqRequest(request));
         EasyMock.expect(mockCache.getCacheEntry(EasyMock.eq(host), eqRequest(request))).andReturn(entry);
 
         replayMocks();
@@ -2881,7 +2876,6 @@ public class TestProtocolRequirements extends AbstractProtocolTest {
 
         final Capture<HttpRequestWrapper> cap = new Capture<HttpRequestWrapper>();
 
-        mockCache.flushInvalidatedCacheEntriesFor(EasyMock.eq(host), eqRequest(request));
         mockCache.flushInvalidatedCacheEntriesFor(
                 EasyMock.isA(HttpHost.class),
                 EasyMock.isA(HttpRequestWrapper.class),


### PR DESCRIPTION
This is just a simple fix for the problem being discussed in the mailing list (subject of the thread is "HttpCacheStorage#getEntry called twice on cache hit"). 

I applied the fix proposal on branch 4.5.x because that's the version I'm using and opened this PR just to get some feedback on the changes before patching other branches (4.6.x and master). 

I separated the patch in two different commits:

- 10ab37b ("Removing unnecessary checks for cache invalidation calls."): removed a few references to "cacheInvalidatorWasCalled()" from tests where this didn't seem to be the primary focus of the test (basically after applying the change to the production code all these tests went red for no apparent reason).
- f59181e ("Avoid fetching the cached entity twice on cache hit."): actual change and unit test to avoid regression. If the changes to the tests in 10ab37b are correct then the change to production code should not have broken anything :).


Notes: 
1. Locally I cannot simply run "mvn install" as there's some problems reported by maven-javadoc-plugin (had to comment it out to try this locally but didn't commit those changes for obvious reasons). Am I missing some configuration to be able to run this?
2. Probably this module deserved a big refactor but as this is the first time I'm contributing to ASF I wanted to keep things simple and the changes as small as possible.
3. I'm not sure about what the process to contributing to this project is, so I'm trying this approach. Please correct me if this is not the way to go.