### PR TITLE
Avoid fetching entity from cache's datastore twice (master)

### DIFF
--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingExec.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingExec.java
@@ -246,10 +246,9 @@ public class CachingExec implements ExecChainHandler {
         requestCompliance.makeRequestCompliant(request);
         request.addHeader("Via",via);
 
-        flushEntriesInvalidatedByRequest(target, request);
-
         if (!cacheableRequestPolicy.isServableFromCache(request)) {
             log.debug("Request is not servable from cache");
+            flushEntriesInvalidatedByRequest(target, request);
             return callBackend(target, request, scope, chain);
         }
 

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestCachingExec.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestCachingExec.java
@@ -386,6 +386,26 @@ public class TestCachingExec extends TestCachingExecChain {
         verifyMocks();
     }
 
+    @Test
+    public void testDoesNotFlushCachesOnCacheHit() throws Exception {
+        requestPolicyAllowsCaching(true);
+        requestIsFatallyNonCompliant(null);
+
+        getCacheEntryReturns(mockCacheEntry);
+        doesNotFlushCache();
+        cacheEntrySuitable(true);
+        cacheEntryValidatable(true);
+
+        expect(mockResponseGenerator.generateResponse(isA(HttpRequest.class), isA(HttpCacheEntry.class)))
+                .andReturn(mockBackendResponse);
+
+        replayMocks();
+        final HttpResponse result = impl.execute(request, scope, mockExecChain);
+        verifyMocks();
+
+        Assert.assertSame(mockBackendResponse, result);
+    }
+
     private IExpectationSetters<ClassicHttpResponse> implExpectsAnyRequestAndReturn(
             final ClassicHttpResponse response) throws Exception {
         final ClassicHttpResponse resp = impl.callBackend(

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestCachingExecChain.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestCachingExecChain.java
@@ -1673,4 +1673,9 @@ public abstract class TestCachingExecChain {
             .andReturn(mockCachedResponse);
     }
 
+    protected void doesNotFlushCache() throws IOException {
+        mockCache.flushInvalidatedCacheEntriesFor(isA(HttpHost.class), isA(HttpRequest.class));
+        EasyMock.expectLastCall().andThrow(new AssertionError("flushInvalidatedCacheEntriesFor should not have been called")).anyTimes();
+    }
+
 }


### PR DESCRIPTION
Same changes from https://github.com/apache/httpcomponents-client/pull/77 applied to master