### PR TITLE
HTTPCLIENT-293 Fix proposal based on RFC 7578

### DIFF
--- a/httpmime/src/main/java/org/apache/http/entity/mime/FormBodyPartBuilder.java
+++ b/httpmime/src/main/java/org/apache/http/entity/mime/FormBodyPartBuilder.java
@@ -27,14 +27,15 @@
 
 package org.apache.http.entity.mime;
 
+import java.util.List;
+import java.util.Map;
+
+import java.util.TreeMap;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.mime.content.AbstractContentBody;
 import org.apache.http.entity.mime.content.ContentBody;
 import org.apache.http.util.Args;
 import org.apache.http.util.Asserts;
-
-import java.util.List;
-import java.util.Map;
 
 /**
  * Builder for individual {@link org.apache.http.entity.mime.FormBodyPart}s.
@@ -77,19 +78,15 @@ public class FormBodyPartBuilder {
 
     public FormBodyPartBuilder addField(final String name, final String value, final Map<MIME.HeaderFieldParam, String> parameters) {
         Args.notNull(name, "Field name");
-		MinimalField minimalField = new MinimalField(name, value);
-		if(parameters != null) {
-			minimalField.setParameters(parameters);
-		}
-		this.header.addField(minimalField);
+        this.header.addField(new MinimalField(name, value, parameters));
         return this;
     }
 
-	public FormBodyPartBuilder addField(final String name, final String value) {
-		Args.notNull(name, "Field name");
-		this.header.addField(new MinimalField(name, value));
-		return this;
-	}
+    public FormBodyPartBuilder addField(final String name, final String value) {
+        Args.notNull(name, "Field name");
+        this.header.addField(new MinimalField(name, value));
+        return this;
+    }
 
     public FormBodyPartBuilder setField(final String name, final String value) {
         Args.notNull(name, "Field name");
@@ -112,12 +109,12 @@ public class FormBodyPartBuilder {
             headerCopy.addField(field);
         }
         if (headerCopy.getField(MIME.CONTENT_DISPOSITION) == null) {
-			MinimalField cp = new MinimalField(MIME.CONTENT_DISPOSITION, "form-data");
-			cp.addParameter(MIME.HeaderFieldParam.NAME, this.name);
-			if(this.body.getFilename() != null) {
-				cp.addParameter(MIME.HeaderFieldParam.FILENAME, this.body.getFilename());
-			}
-			headerCopy.addField(cp);
+            final Map<MIME.HeaderFieldParam, String> fieldParameters = new TreeMap<MIME.HeaderFieldParam, String>();
+            fieldParameters.put(MIME.HeaderFieldParam.NAME, this.name);
+            if (this.body.getFilename() != null) {
+                fieldParameters.put(MIME.HeaderFieldParam.FILENAME, this.body.getFilename());
+            }
+            headerCopy.addField(new MinimalField(MIME.CONTENT_DISPOSITION, "form-data", fieldParameters));
         }
         if (headerCopy.getField(MIME.CONTENT_TYPE) == null) {
             final ContentType contentType;
@@ -143,21 +140,6 @@ public class FormBodyPartBuilder {
             headerCopy.addField(new MinimalField(MIME.CONTENT_TRANSFER_ENC, body.getTransferEncoding()));
         }
         return new FormBodyPart(this.name, this.body, headerCopy);
-    }
-
-    private static String encodeForHeader(final String headerName) {
-        if (headerName == null) {
-            return null;
-        }
-        final StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < headerName.length(); i++) {
-            final char x = headerName.charAt(i);
-            if (x == '"' || x == '\\' || x == '\r') {
-                sb.append("\\");
-            }
-            sb.append(x);
-        }
-        return sb.toString();
     }
 
 }

--- a/httpmime/src/main/java/org/apache/http/entity/mime/HttpMultipartMode.java
+++ b/httpmime/src/main/java/org/apache/http/entity/mime/HttpMultipartMode.java
@@ -38,6 +38,8 @@ public enum HttpMultipartMode {
     /** browser-compatible mode, i.e. only write Content-Disposition; use content charset */
     BROWSER_COMPATIBLE,
     /** RFC 6532 compliant */
-    RFC6532
+    RFC6532,
+	/** RFC 7578 compliant */
+	RFC7578
 
 }

--- a/httpmime/src/main/java/org/apache/http/entity/mime/HttpMultipartMode.java
+++ b/httpmime/src/main/java/org/apache/http/entity/mime/HttpMultipartMode.java
@@ -39,7 +39,7 @@ public enum HttpMultipartMode {
     BROWSER_COMPATIBLE,
     /** RFC 6532 compliant */
     RFC6532,
-	/** RFC 7578 compliant */
-	RFC7578
+    /** RFC 7578 compliant */
+    RFC7578
 
 }

--- a/httpmime/src/main/java/org/apache/http/entity/mime/HttpRFC7578Multipart.java
+++ b/httpmime/src/main/java/org/apache/http/entity/mime/HttpRFC7578Multipart.java
@@ -1,3 +1,30 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
 package org.apache.http.entity.mime;
 
 import org.apache.commons.codec.DecoderException;
@@ -14,145 +41,141 @@ import java.util.Map;
 
 public class HttpRFC7578Multipart extends AbstractMultipartForm {
 
-	private final List<FormBodyPart> parts;
+    private final List<FormBodyPart> parts;
 
-	public HttpRFC7578Multipart(
-		final Charset charset,
-		final String boundary,
-		final List<FormBodyPart> parts) {
-		super(Charset.forName("UTF-8"), boundary);
-		this.parts = parts;
-	}
+    public HttpRFC7578Multipart(
+        final String boundary,
+        final List<FormBodyPart> parts) {
+        super(Charset.forName("UTF-8"), boundary);
+        this.parts = parts;
+    }
 
-	@Override
-	public List<FormBodyPart> getBodyParts() {
-		return parts;
-	}
+    @Override
+    public List<FormBodyPart> getBodyParts() {
+        return parts;
+    }
 
-	@Override
-	protected void formatMultipartHeader(FormBodyPart part, OutputStream out) throws IOException {
-		for (final MinimalField field: part.getHeader()) {
-			if(MIME.CONTENT_DISPOSITION.equals(field.getName()) && field.getParameters() != null) {
-				//need to create a copy of field to perform encoding on, because this might happen multiple times
-				MinimalField fieldCopy = new MinimalField(field);
-				for (Iterator<Map.Entry<MIME.HeaderFieldParam, String>> it = fieldCopy.getParameters().entrySet().iterator(); it.hasNext(); ) {
-					Map.Entry<MIME.HeaderFieldParam, String> next = it.next();
-					if(MIME.HeaderFieldParam.FILENAME.equals(next.getKey())) {
-						String encodedFilenameValue = encodeWithPercentEncoding(next.getValue());
-						fieldCopy.getParameters().put(next.getKey(), encodedFilenameValue);
-					}
-				}
-				writeField(fieldCopy, charset, out);
-			} else {
-				writeField(field, charset, out);
-			}
-		}
-	}
+    @Override
+    protected void formatMultipartHeader(final FormBodyPart part, final OutputStream out) throws IOException {
+        for (final MinimalField field : part.getHeader()) {
+            if (MIME.CONTENT_DISPOSITION.equals(field.getName()) && field.getParameters() != null) {
+                //need to create a copy of field to perform encoding on, because this might happen multiple times
+                final MinimalField fieldCopy = new MinimalField(field);
+                for (final Iterator<Map.Entry<MIME.HeaderFieldParam, String>> it = fieldCopy.getParameters().entrySet().iterator(); it.hasNext(); ) {
+                    final Map.Entry<MIME.HeaderFieldParam, String> next = it.next();
+                    if (MIME.HeaderFieldParam.FILENAME.equals(next.getKey())) {
+                        final String encodedFilenameValue = encodeWithPercentEncoding(next.getValue());
+                        fieldCopy.getParameters().put(next.getKey(), encodedFilenameValue);
+                    }
+                }
+                writeField(fieldCopy, charset, out);
+            } else {
+                writeField(field, charset, out);
+            }
+        }
+    }
 
-	private String encodeWithPercentEncoding(String str) {
-		PercentCodec percentCodec = new PercentCodec();
-		byte[] percentEncodeResult = percentCodec.encode(str.getBytes(charset));
-		return new String(percentEncodeResult, charset);
-	}
+    private String encodeWithPercentEncoding(final String str) {
+        final PercentCodec percentCodec = new PercentCodec();
+        final byte[] percentEncodeResult = percentCodec.encode(str.getBytes(charset));
+        return new String(percentEncodeResult, charset);
+    }
 
-	static class PercentCodec {
+    static class PercentCodec {
 
-		protected static final byte ESCAPE_CHAR = '%';
+        protected static final byte ESCAPE_CHAR = '%';
 
-		private static BitSet alwaysEncodeChars = new BitSet();
+        private static BitSet alwaysEncodeChars = new BitSet();
 
-		static {
-			alwaysEncodeChars.set(' ');
-			alwaysEncodeChars.set('%');
-		}
+        static {
+            alwaysEncodeChars.set(' ');
+            alwaysEncodeChars.set('%');
+        }
 
-		/**
-		 * Percent-Encoding implementation based on RFC 3986
-		 */
-		public byte[] encode(final byte[] bytes) {
-			if (bytes == null) {
-				return null;
-			}
+        /**
+         * Percent-Encoding implementation based on RFC 3986
+         */
+        public byte[] encode(final byte[] bytes) {
+            if (bytes == null) {
+                return null;
+            }
 
-			CharsetEncoder characterSetEncoder = Charset.forName("US-ASCII").newEncoder();
+            final CharsetEncoder characterSetEncoder = Charset.forName("US-ASCII").newEncoder();
 
-			final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-			for (final byte c : bytes) {
-				int b = c;
-				if (b < 0) {
-					b = 256 + b;
-				}
-				if (characterSetEncoder.canEncode((char) b) && !alwaysEncodeChars.get(c)) {
-					buffer.write(b);
-				} else {
-					buffer.write(ESCAPE_CHAR);
-					final char hex1 = Utils.hexDigit(b >> 4);
-					final char hex2 = Utils.hexDigit(b);
-					buffer.write(hex1);
-					buffer.write(hex2);
-				}
-			}
-			return buffer.toByteArray();
-		}
+            final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+            for (final byte c : bytes) {
+                int b = c;
+                if (b < 0) {
+                    b = 256 + b;
+                }
+                if (characterSetEncoder.canEncode((char) b) && !alwaysEncodeChars.get(c)) {
+                    buffer.write(b);
+                } else {
+                    buffer.write(ESCAPE_CHAR);
+                    final char hex1 = Utils.hexDigit(b >> 4);
+                    final char hex2 = Utils.hexDigit(b);
+                    buffer.write(hex1);
+                    buffer.write(hex2);
+                }
+            }
+            return buffer.toByteArray();
+        }
 
-		public byte[] decode(final byte[] bytes) throws DecoderException {
-			if (bytes == null) {
-				return null;
-			}
-			final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-			for (int i = 0; i < bytes.length; i++) {
-				final int b = bytes[i];
-				if (b == ESCAPE_CHAR) {
-					try {
-						final int u = Utils.digit16(bytes[++i]);
-						final int l = Utils.digit16(bytes[++i]);
-						buffer.write((char) ((u << 4) + l));
-					} catch (final ArrayIndexOutOfBoundsException e) {
-						throw new DecoderException("Invalid URL encoding: ", e);
-					}
-				} else {
-					buffer.write(b);
-				}
-			}
-			return buffer.toByteArray();
-		}
-	}
+        public byte[] decode(final byte[] bytes) throws DecoderException {
+            if (bytes == null) {
+                return null;
+            }
+            final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+            for (int i = 0; i < bytes.length; i++) {
+                final int b = bytes[i];
+                if (b == ESCAPE_CHAR) {
+                    try {
+                        final int u = Utils.digit16(bytes[++i]);
+                        final int l = Utils.digit16(bytes[++i]);
+                        buffer.write((char) ((u << 4) + l));
+                    } catch (final ArrayIndexOutOfBoundsException e) {
+                        throw new DecoderException("Invalid URL encoding: ", e);
+                    }
+                } else {
+                    buffer.write(b);
+                }
+            }
+            return buffer.toByteArray();
+        }
+    }
 
-	static class Utils {
+    static class Utils {
 
-		/**
-		 * Radix used in encoding and decoding.
-		 */
-		private static final int RADIX = 16;
+        /**
+         * Radix used in encoding and decoding.
+         */
+        private static final int RADIX = 16;
 
-		/**
-		 * Returns the numeric value of the character <code>b</code> in radix 16.
-		 *
-		 * @param b
-		 *            The byte to be converted.
-		 * @return The numeric value represented by the character in radix 16.
-		 *
-		 * @throws DecoderException
-		 *             Thrown when the byte is not valid per {@link Character#digit(char,int)}
-		 */
-		static int digit16(final byte b) throws DecoderException {
-			final int i = Character.digit((char) b, RADIX);
-			if (i == -1) {
-				throw new DecoderException("Invalid URL encoding: not a valid digit (radix " + RADIX + "): " + b);
-			}
-			return i;
-		}
+        /**
+         * Returns the numeric value of the character <code>b</code> in radix 16.
+         *
+         * @param b The byte to be converted.
+         * @return The numeric value represented by the character in radix 16.
+         * @throws DecoderException Thrown when the byte is not valid per {@link Character#digit(char, int)}
+         */
+        static int digit16(final byte b) throws DecoderException {
+            final int i = Character.digit((char) b, RADIX);
+            if (i == -1) {
+                throw new DecoderException("Invalid URL encoding: not a valid digit (radix " + RADIX + "): " + b);
+            }
+            return i;
+        }
 
-		/**
-		 * Returns the upper case hex digit of the lower 4 bits of the int.
-		 *
-		 * @param b the input int
-		 * @return the upper case hex digit of the lower 4 bits of the int.
-		 */
-		static char hexDigit(int b) {
-			return Character.toUpperCase(Character.forDigit(b & 0xF, RADIX));
-		}
+        /**
+         * Returns the upper case hex digit of the lower 4 bits of the int.
+         *
+         * @param b the input int
+         * @return the upper case hex digit of the lower 4 bits of the int.
+         */
+        static char hexDigit(final int b) {
+            return Character.toUpperCase(Character.forDigit(b & 0xF, RADIX));
+        }
 
-	}
+    }
 
 }

--- a/httpmime/src/main/java/org/apache/http/entity/mime/HttpRFC7578Multipart.java
+++ b/httpmime/src/main/java/org/apache/http/entity/mime/HttpRFC7578Multipart.java
@@ -1,0 +1,158 @@
+package org.apache.http.entity.mime;
+
+import org.apache.commons.codec.DecoderException;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetEncoder;
+import java.util.BitSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+public class HttpRFC7578Multipart extends AbstractMultipartForm {
+
+	private final List<FormBodyPart> parts;
+
+	public HttpRFC7578Multipart(
+		final Charset charset,
+		final String boundary,
+		final List<FormBodyPart> parts) {
+		super(Charset.forName("UTF-8"), boundary);
+		this.parts = parts;
+	}
+
+	@Override
+	public List<FormBodyPart> getBodyParts() {
+		return parts;
+	}
+
+	@Override
+	protected void formatMultipartHeader(FormBodyPart part, OutputStream out) throws IOException {
+		for (final MinimalField field: part.getHeader()) {
+			if(MIME.CONTENT_DISPOSITION.equals(field.getName()) && field.getParameters() != null) {
+				//need to create a copy of field to perform encoding on, because this might happen multiple times
+				MinimalField fieldCopy = new MinimalField(field);
+				for (Iterator<Map.Entry<MIME.HeaderFieldParam, String>> it = fieldCopy.getParameters().entrySet().iterator(); it.hasNext(); ) {
+					Map.Entry<MIME.HeaderFieldParam, String> next = it.next();
+					if(MIME.HeaderFieldParam.FILENAME.equals(next.getKey())) {
+						String encodedFilenameValue = encodeWithPercentEncoding(next.getValue());
+						fieldCopy.getParameters().put(next.getKey(), encodedFilenameValue);
+					}
+				}
+				writeField(fieldCopy, charset, out);
+			} else {
+				writeField(field, charset, out);
+			}
+		}
+	}
+
+	private String encodeWithPercentEncoding(String str) {
+		PercentCodec percentCodec = new PercentCodec();
+		byte[] percentEncodeResult = percentCodec.encode(str.getBytes(charset));
+		return new String(percentEncodeResult, charset);
+	}
+
+	static class PercentCodec {
+
+		protected static final byte ESCAPE_CHAR = '%';
+
+		private static BitSet alwaysEncodeChars = new BitSet();
+
+		static {
+			alwaysEncodeChars.set(' ');
+			alwaysEncodeChars.set('%');
+		}
+
+		/**
+		 * Percent-Encoding implementation based on RFC 3986
+		 */
+		public byte[] encode(final byte[] bytes) {
+			if (bytes == null) {
+				return null;
+			}
+
+			CharsetEncoder characterSetEncoder = Charset.forName("US-ASCII").newEncoder();
+
+			final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+			for (final byte c : bytes) {
+				int b = c;
+				if (b < 0) {
+					b = 256 + b;
+				}
+				if (characterSetEncoder.canEncode((char) b) && !alwaysEncodeChars.get(c)) {
+					buffer.write(b);
+				} else {
+					buffer.write(ESCAPE_CHAR);
+					final char hex1 = Utils.hexDigit(b >> 4);
+					final char hex2 = Utils.hexDigit(b);
+					buffer.write(hex1);
+					buffer.write(hex2);
+				}
+			}
+			return buffer.toByteArray();
+		}
+
+		public byte[] decode(final byte[] bytes) throws DecoderException {
+			if (bytes == null) {
+				return null;
+			}
+			final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+			for (int i = 0; i < bytes.length; i++) {
+				final int b = bytes[i];
+				if (b == ESCAPE_CHAR) {
+					try {
+						final int u = Utils.digit16(bytes[++i]);
+						final int l = Utils.digit16(bytes[++i]);
+						buffer.write((char) ((u << 4) + l));
+					} catch (final ArrayIndexOutOfBoundsException e) {
+						throw new DecoderException("Invalid URL encoding: ", e);
+					}
+				} else {
+					buffer.write(b);
+				}
+			}
+			return buffer.toByteArray();
+		}
+	}
+
+	static class Utils {
+
+		/**
+		 * Radix used in encoding and decoding.
+		 */
+		private static final int RADIX = 16;
+
+		/**
+		 * Returns the numeric value of the character <code>b</code> in radix 16.
+		 *
+		 * @param b
+		 *            The byte to be converted.
+		 * @return The numeric value represented by the character in radix 16.
+		 *
+		 * @throws DecoderException
+		 *             Thrown when the byte is not valid per {@link Character#digit(char,int)}
+		 */
+		static int digit16(final byte b) throws DecoderException {
+			final int i = Character.digit((char) b, RADIX);
+			if (i == -1) {
+				throw new DecoderException("Invalid URL encoding: not a valid digit (radix " + RADIX + "): " + b);
+			}
+			return i;
+		}
+
+		/**
+		 * Returns the upper case hex digit of the lower 4 bits of the int.
+		 *
+		 * @param b the input int
+		 * @return the upper case hex digit of the lower 4 bits of the int.
+		 */
+		static char hexDigit(int b) {
+			return Character.toUpperCase(Character.forDigit(b & 0xF, RADIX));
+		}
+
+	}
+
+}

--- a/httpmime/src/main/java/org/apache/http/entity/mime/MIME.java
+++ b/httpmime/src/main/java/org/apache/http/entity/mime/MIME.java
@@ -41,6 +41,21 @@ public final class MIME {
     public static final String CONTENT_TRANSFER_ENC  = "Content-Transfer-Encoding";
     public static final String CONTENT_DISPOSITION   = "Content-Disposition";
 
+    public enum HeaderFieldParam {
+    	NAME("name"),
+		FILENAME("filename");
+
+    	private String name;
+
+		public String getName() {
+			return name;
+		}
+
+		HeaderFieldParam(String name) {
+			this.name = name;
+		}
+	}
+
     public static final String ENC_8BIT              = "8bit";
     public static final String ENC_BINARY            = "binary";
 

--- a/httpmime/src/main/java/org/apache/http/entity/mime/MIME.java
+++ b/httpmime/src/main/java/org/apache/http/entity/mime/MIME.java
@@ -40,21 +40,19 @@ public final class MIME {
     public static final String CONTENT_TYPE          = "Content-Type";
     public static final String CONTENT_TRANSFER_ENC  = "Content-Transfer-Encoding";
     public static final String CONTENT_DISPOSITION   = "Content-Disposition";
-
     public enum HeaderFieldParam {
-    	NAME("name"),
-		FILENAME("filename");
+        NAME("name"),
+        FILENAME("filename");
 
-    	private String name;
+        private String name;
 
-		public String getName() {
-			return name;
-		}
-
-		HeaderFieldParam(String name) {
-			this.name = name;
-		}
-	}
+        public String getName() {
+            return name;
+        }
+        HeaderFieldParam(final String name) {
+            this.name = name;
+        }
+    }
 
     public static final String ENC_8BIT              = "8bit";
     public static final String ENC_BINARY            = "binary";

--- a/httpmime/src/main/java/org/apache/http/entity/mime/MinimalField.java
+++ b/httpmime/src/main/java/org/apache/http/entity/mime/MinimalField.java
@@ -27,6 +27,10 @@
 
 package org.apache.http.entity.mime;
 
+import java.util.Iterator;
+import java.util.Map;
+import java.util.TreeMap;
+
 /**
  * Minimal MIME field.
  *
@@ -35,28 +39,58 @@ package org.apache.http.entity.mime;
 public class MinimalField {
 
     private final String name;
-    private final String value;
+	private final String value;
+    private Map<MIME.HeaderFieldParam, String> parameters;
 
     public MinimalField(final String name, final String value) {
         super();
         this.name = name;
         this.value = value;
+        this.parameters = new TreeMap<MIME.HeaderFieldParam, String>();
     }
 
-    public String getName() {
+	public MinimalField(MinimalField from) {
+		this.name = from.name;
+		this.value = from.value;
+		this.parameters = new TreeMap<MIME.HeaderFieldParam, String>(from.parameters);
+	}
+
+	public String getName() {
         return this.name;
     }
 
     public String getBody() {
-        return this.value;
+		StringBuilder sb = new StringBuilder();
+		sb.append(this.value);
+		for (Iterator<Map.Entry<MIME.HeaderFieldParam, String>> it = this.parameters.entrySet().iterator(); it.hasNext(); ) {
+			Map.Entry<MIME.HeaderFieldParam, String> next = it.next();
+			sb.append("; ");
+			sb.append(next.getKey().getName());
+			sb.append("=\"");
+			sb.append(next.getValue());
+			sb.append("\"");
+		}
+		return sb.toString();
     }
+
+	public Map<MIME.HeaderFieldParam, String> getParameters() {
+		return parameters;
+	}
+
+	public void setParameters(Map<MIME.HeaderFieldParam, String> parameters) {
+    	this.parameters = parameters;
+	}
+
+	public void addParameter(MIME.HeaderFieldParam paramName, String paramValue) {
+    	parameters.put(paramName, paramValue);
+	}
 
     @Override
     public String toString() {
         final StringBuilder buffer = new StringBuilder();
         buffer.append(this.name);
         buffer.append(": ");
-        buffer.append(this.value);
+        buffer.append(this.getBody());
         return buffer.toString();
     }
 

--- a/httpmime/src/main/java/org/apache/http/entity/mime/MinimalField.java
+++ b/httpmime/src/main/java/org/apache/http/entity/mime/MinimalField.java
@@ -39,7 +39,7 @@ import java.util.TreeMap;
 public class MinimalField {
 
     private final String name;
-	private final String value;
+    private final String value;
     private Map<MIME.HeaderFieldParam, String> parameters;
 
     public MinimalField(final String name, final String value) {
@@ -49,41 +49,37 @@ public class MinimalField {
         this.parameters = new TreeMap<MIME.HeaderFieldParam, String>();
     }
 
-	public MinimalField(MinimalField from) {
-		this.name = from.name;
-		this.value = from.value;
-		this.parameters = new TreeMap<MIME.HeaderFieldParam, String>(from.parameters);
-	}
+    public MinimalField(final String name, final String value, final Map<MIME.HeaderFieldParam, String> parameters) {
+        this.name = name;
+        this.value = value;
+        this.parameters = new TreeMap<MIME.HeaderFieldParam, String>(parameters);
+    }
 
-	public String getName() {
+    public MinimalField(final MinimalField from) {
+        this(from.name, from.value, from.parameters);
+    }
+
+    public String getName() {
         return this.name;
     }
 
     public String getBody() {
-		StringBuilder sb = new StringBuilder();
-		sb.append(this.value);
-		for (Iterator<Map.Entry<MIME.HeaderFieldParam, String>> it = this.parameters.entrySet().iterator(); it.hasNext(); ) {
-			Map.Entry<MIME.HeaderFieldParam, String> next = it.next();
-			sb.append("; ");
-			sb.append(next.getKey().getName());
-			sb.append("=\"");
-			sb.append(next.getValue());
-			sb.append("\"");
-		}
-		return sb.toString();
+        final StringBuilder sb = new StringBuilder();
+        sb.append(this.value);
+        for (final Iterator<Map.Entry<MIME.HeaderFieldParam, String>> it = this.parameters.entrySet().iterator(); it.hasNext(); ) {
+            final Map.Entry<MIME.HeaderFieldParam, String> next = it.next();
+            sb.append("; ");
+            sb.append(next.getKey().getName());
+            sb.append("=\"");
+            sb.append(next.getValue());
+            sb.append("\"");
+        }
+        return sb.toString();
     }
 
-	public Map<MIME.HeaderFieldParam, String> getParameters() {
-		return parameters;
-	}
-
-	public void setParameters(Map<MIME.HeaderFieldParam, String> parameters) {
-    	this.parameters = parameters;
-	}
-
-	public void addParameter(MIME.HeaderFieldParam paramName, String paramValue) {
-    	parameters.put(paramName, paramValue);
-	}
+    public Map<MIME.HeaderFieldParam, String> getParameters() {
+        return parameters;
+    }
 
     @Override
     public String toString() {

--- a/httpmime/src/main/java/org/apache/http/entity/mime/MultipartEntityBuilder.java
+++ b/httpmime/src/main/java/org/apache/http/entity/mime/MultipartEntityBuilder.java
@@ -230,6 +230,9 @@ public class MultipartEntityBuilder {
             case RFC6532:
                 form = new HttpRFC6532Multipart(charsetCopy, boundaryCopy, bodyPartsCopy);
                 break;
+			case RFC7578:
+				form = new HttpRFC7578Multipart(charsetCopy, boundaryCopy, bodyPartsCopy);
+				break;
             default:
                 form = new HttpStrictMultipart(charsetCopy, boundaryCopy, bodyPartsCopy);
         }

--- a/httpmime/src/main/java/org/apache/http/entity/mime/MultipartEntityBuilder.java
+++ b/httpmime/src/main/java/org/apache/http/entity/mime/MultipartEntityBuilder.java
@@ -230,9 +230,9 @@ public class MultipartEntityBuilder {
             case RFC6532:
                 form = new HttpRFC6532Multipart(charsetCopy, boundaryCopy, bodyPartsCopy);
                 break;
-			case RFC7578:
-				form = new HttpRFC7578Multipart(charsetCopy, boundaryCopy, bodyPartsCopy);
-				break;
+            case RFC7578:
+                form = new HttpRFC7578Multipart(boundaryCopy, bodyPartsCopy);
+                break;
             default:
                 form = new HttpStrictMultipart(charsetCopy, boundaryCopy, bodyPartsCopy);
         }

--- a/httpmime/src/test/java/org/apache/http/entity/mime/TestFormBodyPartBuilder.java
+++ b/httpmime/src/test/java/org/apache/http/entity/mime/TestFormBodyPartBuilder.java
@@ -27,14 +27,11 @@
 
 package org.apache.http.entity.mime;
 
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.util.Arrays;
 import java.util.List;
-
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.mime.content.FileBody;
-import org.apache.http.entity.mime.content.InputStreamBody;
 import org.apache.http.entity.mime.content.StringBody;
 import org.junit.Assert;
 import org.junit.Test;
@@ -58,29 +55,6 @@ public class TestFormBodyPartBuilder {
                         new MinimalField("Content-Type", "text/plain; charset=ISO-8859-1"),
                         new MinimalField("Content-Transfer-Encoding", "8bit")),
                 header.getFields());
-    }
-
-    @Test
-    public void testCharacterStuffing() throws Exception {
-        final FormBodyPartBuilder builder = FormBodyPartBuilder.create();
-        final InputStreamBody fileBody = new InputStreamBody(new ByteArrayInputStream(
-                "hello world".getBytes("UTF-8")), "stuff_with \"quotes\" and \\slashes\\.bin");
-        final FormBodyPart bodyPart2 = builder
-                .setName("yada_with \"quotes\" and \\slashes\\")
-                .setBody(fileBody)
-                .build();
-
-        Assert.assertNotNull(bodyPart2);
-        Assert.assertEquals("yada_with \"quotes\" and \\slashes\\", bodyPart2.getName());
-        Assert.assertEquals(fileBody, bodyPart2.getBody());
-        final Header header2 = bodyPart2.getHeader();
-        Assert.assertNotNull(header2);
-        assertFields(Arrays.asList(
-                        new MinimalField("Content-Disposition", "form-data; name=\"yada_with \\\"quotes\\\" " +
-                                "and \\\\slashes\\\\\"; filename=\"stuff_with \\\"quotes\\\" and \\\\slashes\\\\.bin\""),
-                        new MinimalField("Content-Type", "application/octet-stream"),
-                        new MinimalField("Content-Transfer-Encoding", "binary")),
-                header2.getFields());
     }
 
     @Test

--- a/httpmime/src/test/java/org/apache/http/entity/mime/TestMultipartEntityBuilder.java
+++ b/httpmime/src/test/java/org/apache/http/entity/mime/TestMultipartEntityBuilder.java
@@ -27,6 +27,13 @@
 
 package org.apache.http.entity.mime;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.util.List;
+
+import java.util.Map;
+import java.util.TreeMap;
 import org.apache.http.Consts;
 import org.apache.http.Header;
 import org.apache.http.entity.ContentType;
@@ -34,13 +41,6 @@ import org.apache.http.entity.mime.content.StringBody;
 import org.apache.http.message.BasicNameValuePair;
 import org.junit.Assert;
 import org.junit.Test;
-
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
 
 public class TestMultipartEntityBuilder {
 
@@ -128,26 +128,26 @@ public class TestMultipartEntityBuilder {
     }
 
     @Test
-	public void testMultipartContentDispositionFollowingRFC7578() throws Exception {
-    	Map<MIME.HeaderFieldParam, String> cpParams = new TreeMap<MIME.HeaderFieldParam, String>();
-    	cpParams.put(MIME.HeaderFieldParam.NAME, "test");
-    	cpParams.put(MIME.HeaderFieldParam.FILENAME, "hello κόσμε!%");
+    public void testMultipartContentDispositionFollowingRFC7578() throws Exception {
+        final Map<MIME.HeaderFieldParam, String> cpParams = new TreeMap<MIME.HeaderFieldParam, String>();
+        cpParams.put(MIME.HeaderFieldParam.NAME, "test");
+        cpParams.put(MIME.HeaderFieldParam.FILENAME, "hello κόσμε!%");
 
-    	final MultipartFormEntity entity = MultipartEntityBuilder.create()
-			.setMode(HttpMultipartMode.RFC7578)
-			.addPart(new FormBodyPartBuilder()
-				.setName("test")
-				.setBody(new StringBody("hello world", ContentType.TEXT_PLAIN))
-				.addField("Content-Disposition", "multipart/form-data", cpParams)
-				.build())
-			.buildEntity();
+        final MultipartFormEntity entity = MultipartEntityBuilder.create()
+            .setMode(HttpMultipartMode.RFC7578)
+            .addPart(new FormBodyPartBuilder()
+                .setName("test")
+                .setBody(new StringBody("hello world", ContentType.TEXT_PLAIN))
+                .addField("Content-Disposition", "multipart/form-data", cpParams)
+                .build())
+            .buildEntity();
 
 
-		final ByteArrayOutputStream out = new ByteArrayOutputStream();
-		entity.getMultipart().writeTo(out);
-		out.close();
-		String result = out.toString(Consts.ASCII.name());
-		Assert.assertTrue(result, result.contains("filename=\"hello%20%CE%BA%CF%8C%CF%83%CE%BC%CE%B5!%25\""));
-	}
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        entity.getMultipart().writeTo(out);
+        out.close();
+        final String result = out.toString(Consts.ASCII.name());
+        Assert.assertTrue(result, result.contains("filename=\"hello%20%CE%BA%CF%8C%CF%83%CE%BC%CE%B5!%25\""));
+    }
 
 }

--- a/httpmime/src/test/java/org/apache/http/entity/mime/TestMultipartEntityBuilder.java
+++ b/httpmime/src/test/java/org/apache/http/entity/mime/TestMultipartEntityBuilder.java
@@ -134,6 +134,7 @@ public class TestMultipartEntityBuilder {
     	cpParams.put(MIME.HeaderFieldParam.FILENAME, "hello κόσμε!%");
 
     	final MultipartFormEntity entity = MultipartEntityBuilder.create()
+			.setMode(HttpMultipartMode.RFC7578)
 			.addPart(new FormBodyPartBuilder()
 				.setName("test")
 				.setBody(new StringBody("hello world", ContentType.TEXT_PLAIN))
@@ -146,7 +147,7 @@ public class TestMultipartEntityBuilder {
 		entity.getMultipart().writeTo(out);
 		out.close();
 		String result = out.toString(Consts.ASCII.name());
-		Assert.assertTrue(result, result.contains("filename=hello%20%CE%BA%CF%8C%CF%83%CE%BC%CE%B5!%25"));
+		Assert.assertTrue(result, result.contains("filename=\"hello%20%CE%BA%CF%8C%CF%83%CE%BC%CE%B5!%25\""));
 	}
 
 }

--- a/httpmime/src/test/java/org/apache/http/entity/mime/TestMultipartEntityBuilder.java
+++ b/httpmime/src/test/java/org/apache/http/entity/mime/TestMultipartEntityBuilder.java
@@ -27,16 +27,20 @@
 
 package org.apache.http.entity.mime;
 
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.util.List;
-
 import org.apache.http.Consts;
 import org.apache.http.Header;
 import org.apache.http.entity.ContentType;
+import org.apache.http.entity.mime.content.StringBody;
 import org.apache.http.message.BasicNameValuePair;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 public class TestMultipartEntityBuilder {
 
@@ -122,5 +126,27 @@ public class TestMultipartEntityBuilder {
         Assert.assertEquals("multipart/form-data; boundary=blah-blah; charset=UTF-8; my=stuff",
                 contentType.getValue());
     }
+
+    @Test
+	public void testMultipartContentDispositionFollowingRFC7578() throws Exception {
+    	Map<MIME.HeaderFieldParam, String> cpParams = new TreeMap<MIME.HeaderFieldParam, String>();
+    	cpParams.put(MIME.HeaderFieldParam.NAME, "test");
+    	cpParams.put(MIME.HeaderFieldParam.FILENAME, "hello κόσμε!%");
+
+    	final MultipartFormEntity entity = MultipartEntityBuilder.create()
+			.addPart(new FormBodyPartBuilder()
+				.setName("test")
+				.setBody(new StringBody("hello world", ContentType.TEXT_PLAIN))
+				.addField("Content-Disposition", "multipart/form-data", cpParams)
+				.build())
+			.buildEntity();
+
+
+		final ByteArrayOutputStream out = new ByteArrayOutputStream();
+		entity.getMultipart().writeTo(out);
+		out.close();
+		String result = out.toString(Consts.ASCII.name());
+		Assert.assertTrue(result, result.contains("filename=hello%20%CE%BA%CF%8C%CF%83%CE%BC%CE%B5!%25"));
+	}
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
   <properties>
     <maven.compiler.source>1.6</maven.compiler.source>
     <maven.compiler.target>1.6</maven.compiler.target>
-    <httpcore.version>4.4.6</httpcore.version>
+    <httpcore.version>4.4.7</httpcore.version>
     <commons-logging.version>1.2</commons-logging.version>
     <commons-codec.version>1.10</commons-codec.version>
     <ehcache.version>2.6.11</ehcache.version>


### PR DESCRIPTION
I implemented the fix in two commits, because I believe that some refactoring was required in order to handle the part header field parameters (name, filename) properly in the Content-Disposition part header field. Also a unit test was implemented that fails on the first commit but succeeds on the second that includes the actual patch.

I did some research about the percent encoding, which as I can understand is quite loose concerning the characters that it should always encode depending on the context. The actual percent character encoding implementation was copied from the common-codecs' URLCodec but it could not be reused as it was implemented, because that class includes URL specific encoding (e.g. ' ' -> '+')