### PR TITLE
HTTPCLIENT-1690: Avoid updating the cache entry with Content-Encoding header 

### DIFF
--- a/httpclient5-cache/pom.xml
+++ b/httpclient5-cache/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache.httpcomponents.client5</groupId>
     <artifactId>httpclient5-parent</artifactId>
-    <version>5.0-alpha4-SNAPSHOT</version>
+    <version>5.0-beta1</version>
   </parent>
   <artifactId>httpclient5-cache</artifactId>
   <name>Apache HttpClient Cache</name>

--- a/httpclient5-fluent/pom.xml
+++ b/httpclient5-fluent/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache.httpcomponents.client5</groupId>
     <artifactId>httpclient5-parent</artifactId>
-    <version>5.0-alpha4-SNAPSHOT</version>
+    <version>5.0-beta1</version>
   </parent>
   <artifactId>httpclient5-fluent</artifactId>
   <name>Apache HttpClient Fluent</name>

--- a/httpclient5-osgi/pom.xml
+++ b/httpclient5-osgi/pom.xml
@@ -28,7 +28,7 @@
   <parent>
       <groupId>org.apache.httpcomponents.client5</groupId>
       <artifactId>httpclient5-parent</artifactId>
-      <version>5.0-alpha4-SNAPSHOT</version>
+      <version>5.0-beta1</version>
   </parent>
   <artifactId>httpclient5-osgi</artifactId>
   <name>Apache HttpClient OSGi bundle</name>

--- a/httpclient5-testing/pom.xml
+++ b/httpclient5-testing/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache.httpcomponents.client5</groupId>
     <artifactId>httpclient5-parent</artifactId>
-    <version>5.0-alpha4-SNAPSHOT</version>
+    <version>5.0-beta1</version>
   </parent>
   <artifactId>httpclient5-testing</artifactId>
   <name>Apache HttpClient Integration Tests</name>

--- a/httpclient5-win/pom.xml
+++ b/httpclient5-win/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache.httpcomponents.client5</groupId>
     <artifactId>httpclient5-parent</artifactId>
-    <version>5.0-alpha4-SNAPSHOT</version>
+    <version>5.0-beta1</version>
   </parent>
   <artifactId>httpclient5-win</artifactId>
   <name>Apache HttpClient Windows features</name>

--- a/httpclient5/pom.xml
+++ b/httpclient5/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache.httpcomponents.client5</groupId>
     <artifactId>httpclient5-parent</artifactId>
-    <version>5.0-alpha4-SNAPSHOT</version>
+    <version>5.0-beta1</version>
   </parent>
   <artifactId>httpclient5</artifactId>
   <name>Apache HttpClient</name>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
   <groupId>org.apache.httpcomponents.client5</groupId>
   <artifactId>httpclient5-parent</artifactId>
   <name>Apache HttpComponents Client Parent</name>
-  <version>5.0-alpha4-SNAPSHOT</version>
+  <version>5.0-beta1</version>
   <description>Apache HttpComponents Client is a library of components for building client side HTTP services</description>
   <url>http://hc.apache.org/httpcomponents-client</url>
   <inceptionYear>1999</inceptionYear>
@@ -62,7 +62,7 @@
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/httpcomponents-client.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/httpcomponents-client.git</developerConnection>
     <url>https://github.com/apache/httpcomponents-client/tree/${project.scm.tag}</url>
-    <tag>5.0-alpha4-SNAPSHOT</tag>
+    <tag>5.0-beta1</tag>
   </scm>
 
   <properties>


### PR DESCRIPTION
Avoid updating the cache entry with Content-Encoding headers too. (missing piece from last commit). Updated the test case