### PR TITLE
HTTPCLIENT-1904: check cookie domain for null

### DIFF
--- a/httpclient/src/main/java/org/apache/http/impl/cookie/PublicSuffixDomainFilter.java
+++ b/httpclient/src/main/java/org/apache/http/impl/cookie/PublicSuffixDomainFilter.java
@@ -90,6 +90,9 @@ public class PublicSuffixDomainFilter implements CommonCookieAttributeHandler {
     @Override
     public boolean match(final Cookie cookie, final CookieOrigin origin) {
         final String host = cookie.getDomain();
+        if (host == null) {
+            return false;
+        }
         final int i = host.indexOf('.');
         if (i >= 0) {
             final String domain = host.substring(i);


### PR DESCRIPTION
Ok, second try. Now it seems to be correct.
The fix matches the behaviour of the BasicDomainHandler.
Hans-Peter