### PR TITLE
Ignore cached ETag and Last-Modified headers of HEAD cache entries

### DIFF
--- a/httpclient-cache/src/test/java/org/apache/http/impl/client/cache/TestConditionalRequestBuilder.java
+++ b/httpclient-cache/src/test/java/org/apache/http/impl/client/cache/TestConditionalRequestBuilder.java
@@ -150,6 +150,38 @@ public class TestConditionalRequestBuilder {
     }
 
     @Test
+    public void testBuildConditionalRequestFromHeadCacheEntry() throws ProtocolException {
+        final String theMethod = "GET";
+        final String theUri = "/theuri";
+        final String theETag = "this is my eTag";
+
+        final HttpRequest basicRequest = new BasicHttpRequest(theMethod, theUri);
+        basicRequest.addHeader("Accept-Encoding", "gzip");
+        final HttpRequestWrapper requestWrapper = HttpRequestWrapper.wrap(basicRequest);
+
+        final Header[] headers = new Header[] {
+                new BasicHeader("Date", DateUtils.formatDate(new Date())),
+                new BasicHeader("Last-Modified", DateUtils.formatDate(new Date())),
+                new BasicHeader("ETag", theETag) };
+
+        final HttpCacheEntry cacheEntry = HttpTestUtils.makeHeadCacheEntry(headers);
+
+        final HttpRequest newRequest = impl.buildConditionalRequest(requestWrapper, cacheEntry);
+
+        Assert.assertNotSame(basicRequest, newRequest);
+
+        Assert.assertEquals(theMethod, newRequest.getRequestLine().getMethod());
+        Assert.assertEquals(theUri, newRequest.getRequestLine().getUri());
+        Assert.assertEquals(basicRequest.getRequestLine().getProtocolVersion(),
+                            newRequest.getRequestLine().getProtocolVersion());
+
+        Assert.assertEquals(1, newRequest.getAllHeaders().length);
+
+        Assert.assertEquals("Accept-Encoding", newRequest.getAllHeaders()[0].getName());
+        Assert.assertEquals("gzip", newRequest.getAllHeaders()[0].getValue());
+    }
+
+    @Test
     public void testCacheEntryWithMustRevalidateDoesEndToEndRevalidation() throws Exception {
         final HttpRequest basicRequest = new BasicHttpRequest("GET","/",HttpVersion.HTTP_1_1);
         final HttpRequestWrapper requestWrapper = HttpRequestWrapper.wrap(basicRequest);


### PR DESCRIPTION
Since httpclient-cache 4.4 `HEAD` requests can be cached with a `null` response body. Subsequent `GET` requests to the same target then use the headers "If-None-Match" and "If-Modified-Since" to leverage caching via HTTP protocol. In that case a server can respond with status code 304 and an empty response body, which leads to an invalid cache entry.

The issue seems to be introduced with PR #13. The repo https://github.com/gesellix/httpclient-cache-demo shows the behaviour for HttpClients 4.3, 4.4, and 4.5. 

This PR, based on the 4.5.x tag, tries to recognise the described invalid state and suppresses caching on the HTTP layer, so that the server has to return the complete response.

JIRA issue: https://issues.apache.org/jira/browse/HTTPCLIENT-1920

Signed-off-by: Tobias Gesellchen <tobias@gesellix.de>
