### PR TITLE
AsyncPushConsumer now also accepts a HttpContext

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/async/methods/AbstractBinPushConsumer.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/async/methods/AbstractBinPushConsumer.java
@@ -37,6 +37,7 @@ import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.nio.AsyncPushConsumer;
 import org.apache.hc.core5.http.nio.entity.AbstractBinDataConsumer;
+import org.apache.hc.core5.http.protocol.HttpContext;
 
 public abstract class AbstractBinPushConsumer extends AbstractBinDataConsumer implements AsyncPushConsumer {
 
@@ -46,7 +47,8 @@ public abstract class AbstractBinPushConsumer extends AbstractBinDataConsumer im
     public final void consumePromise(
             final HttpRequest promise,
             final HttpResponse response,
-            final EntityDetails entityDetails) throws HttpException, IOException {
+            final EntityDetails entityDetails,
+            final HttpContext context) throws HttpException, IOException {
         if (entityDetails != null) {
             final ContentType contentType;
             try {

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/async/methods/AbstractCharPushConsumer.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/async/methods/AbstractCharPushConsumer.java
@@ -39,6 +39,7 @@ import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.nio.AsyncPushConsumer;
 import org.apache.hc.core5.http.nio.entity.AbstractCharDataConsumer;
+import org.apache.hc.core5.http.protocol.HttpContext;
 
 public abstract class AbstractCharPushConsumer extends AbstractCharDataConsumer implements AsyncPushConsumer {
 
@@ -48,7 +49,8 @@ public abstract class AbstractCharPushConsumer extends AbstractCharDataConsumer 
     public final void consumePromise(
             final HttpRequest promise,
             final HttpResponse response,
-            final EntityDetails entityDetails) throws HttpException, IOException {
+            final EntityDetails entityDetails,
+            final HttpContext context) throws HttpException, IOException {
         if (entityDetails != null) {
             final ContentType contentType;
             try {


### PR DESCRIPTION
These are the corresponding client changes for the core interface change in apache/httpcomponents-core#70.

This patch is not expected to compile without the corresponding core patch.

@ok2c should I add context as a parameter to start() as well and update the push example? Or would you prefer to keep the change minimal like this and let user code which needs access to the context override consumePromise() themselves?