### PR TITLE
Fix HttpClient 4.5.4 regression in BasicCookieStore serialization.

### DIFF
--- a/httpclient/src/main/java/org/apache/http/impl/client/BasicCookieStore.java
+++ b/httpclient/src/main/java/org/apache/http/impl/client/BasicCookieStore.java
@@ -26,6 +26,8 @@
  */
 package org.apache.http.impl.client;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Date;
@@ -53,11 +55,18 @@ public class BasicCookieStore implements CookieStore, Serializable {
     private static final long serialVersionUID = -7581093305228232025L;
 
     private final TreeSet<Cookie> cookies;
-    private final ReadWriteLock lock;
+    private transient ReadWriteLock lock;
 
     public BasicCookieStore() {
         super();
         this.cookies = new TreeSet<Cookie>(new CookieIdentityComparator());
+        this.lock = new ReentrantReadWriteLock();
+    }
+
+    private void readObject(final ObjectInputStream stream) throws IOException, ClassNotFoundException {
+        stream.defaultReadObject();
+
+        /* Reinstantiate transient fields. */
         this.lock = new ReentrantReadWriteLock();
     }
 


### PR DESCRIPTION
HttpClient 4.5.4 modified BasicCookieStore to introduce a new
ReadWriteLock field to improve performance. Unfortunately this
also changed the serialized data structure, and any objects
serialized using HttpClient 4.5.3 and before would be unusable
after restore in HttpClient 4.5.4 due to the new "lock" field
being null.

The fix is to change "lock" to be transient, and ensure it is
correctly instantiated upon object restore. This restores
compatibility with HttpClient 4.5.3, as well as maintaining
compatible with the intermediate versions containing the
regression. This also avoids unnecessary serialization of
the new "lock" field, which does not need to be persisted.