### PR TITLE
Overload Request's execute method to allow custom CloseableHttpClient

### DIFF
--- a/httpclient5-fluent/src/main/java/org/apache/hc/client5/http/fluent/Request.java
+++ b/httpclient5-fluent/src/main/java/org/apache/hc/client5/http/fluent/Request.java
@@ -181,7 +181,11 @@ public class Request {
     }
 
     public Response execute() throws IOException {
-        return new Response(internalExecute(Executor.CLIENT, HttpClientContext.create()));
+        return execute(Executor.CLIENT);
+    }
+
+    public Response execute(final CloseableHttpClient client) throws IOException {
+        return new Response(internalExecute(client, HttpClientContext.create()));
     }
 
     //// HTTP header operations


### PR DESCRIPTION
Hi,

It's a really minor improvement. The idea is to enable a user to specify a custom client to execute fluent Requests with. The final goal in my case is to being able to change the KeepAlivePolicy easily, without using a custom Executor.

I will explain my specific case now. We build a lib which uses fluent Requests. Everything was working fine, but at some point we changed our firewall setup. The firewall is killing open connections (which are, obviously, not transmitting data) without warning after an hour. By default, the keep alive policy used by HttpClient permits connections to stay alive forever. We need to change that. However, we built some code around the fluent api already, adding a custom executor in there wouldn't be trivial.

I guess there is other cases where a custom client could be helpful.

If I missed something, like another way to set a keepAlivePolicy on a fluent Request, please tell me.