### PR TITLE
replace empty HttpResponseException.message with statusCode

### DIFF
--- a/httpclient/src/main/java/org/apache/http/client/HttpResponseException.java
+++ b/httpclient/src/main/java/org/apache/http/client/HttpResponseException.java
@@ -26,6 +26,8 @@
  */
 package org.apache.http.client;
 
+import org.apache.http.util.TextUtils;
+
 /**
  * Signals a non 2xx HTTP response.
  *
@@ -38,7 +40,7 @@ public class HttpResponseException extends ClientProtocolException {
     private final int statusCode;
 
     public HttpResponseException(final int statusCode, final String s) {
-        super(s);
+        super(TextUtils.isBlank(s) ? Integer.toString(statusCode) : s);
         this.statusCode = statusCode;
     }
 

--- a/httpclient/src/test/java/org/apache/http/impl/client/TestAbstractResponseHandler.java
+++ b/httpclient/src/test/java/org/apache/http/impl/client/TestAbstractResponseHandler.java
@@ -90,4 +90,27 @@ public class TestAbstractResponseHandler {
         Mockito.verify(inStream).close();
     }
 
+    @SuppressWarnings("boxing")
+    @Test
+    public void testUnsuccessfulResponseEmptyReason() throws Exception {
+        final InputStream inStream = Mockito.mock(InputStream.class);
+        final HttpEntity entity = Mockito.mock(HttpEntity.class);
+        Mockito.when(entity.isStreaming()).thenReturn(true);
+        Mockito.when(entity.getContent()).thenReturn(inStream);
+        final StatusLine sl = new BasicStatusLine(HttpVersion.HTTP_1_1, 404, "");
+        final HttpResponse response = Mockito.mock(HttpResponse.class);
+        Mockito.when(response.getStatusLine()).thenReturn(sl);
+        Mockito.when(response.getEntity()).thenReturn(entity);
+
+        final BasicResponseHandler handler = new BasicResponseHandler();
+        try {
+            handler.handleResponse(response);
+            Assert.fail("HttpResponseException expected");
+        } catch (final HttpResponseException ex) {
+            Assert.assertEquals(404, ex.getStatusCode());
+            Assert.assertEquals("404", ex.getMessage());
+        }
+        Mockito.verify(entity).getContent();
+        Mockito.verify(inStream).close();
+    }
 }


### PR DESCRIPTION
Tomcat 8.5 omits reason phrase. 
So in order to have more informative logs I would suggest using statusCode instead.
It can happen either in the constructor or when passing parameters to it (in AbstractResponseHandler)
