### PR TITLE
Improve HttpResponseException#getMessage()

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/HttpResponseException.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/HttpResponseException.java
@@ -38,14 +38,21 @@ public class HttpResponseException extends ClientProtocolException {
     private static final long serialVersionUID = -7186627969477257933L;
 
     private final int statusCode;
+    private final String reasonPhrase;
 
-    public HttpResponseException(final int statusCode, final String s) {
-        super(TextUtils.isBlank(s) ? Integer.toString(statusCode) : s);
+    public HttpResponseException(final int statusCode, final String reasonPhrase) {
+        super(String.format("status code: %d" +
+                (TextUtils.isBlank(reasonPhrase) ? "" : ", reason phrase: %s"), statusCode, reasonPhrase));
         this.statusCode = statusCode;
+        this.reasonPhrase = reasonPhrase;
     }
 
     public int getStatusCode() {
         return this.statusCode;
+    }
+
+    public String getReasonPhrase() {
+        return this.reasonPhrase;
     }
 
 }

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/classic/TestAbstractHttpClientResponseHandler.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/classic/TestAbstractHttpClientResponseHandler.java
@@ -80,7 +80,8 @@ public class TestAbstractHttpClientResponseHandler {
             Assert.fail("HttpResponseException expected");
         } catch (final HttpResponseException ex) {
             Assert.assertEquals(404, ex.getStatusCode());
-            Assert.assertEquals("NOT FOUND", ex.getMessage());
+            Assert.assertEquals("NOT FOUND", ex.getReasonPhrase());
+            Assert.assertEquals("status code: 404, reason phrase: NOT FOUND", ex.getMessage());
         }
         Mockito.verify(entity).getContent();
         Mockito.verify(inStream).close();
@@ -103,7 +104,8 @@ public class TestAbstractHttpClientResponseHandler {
             Assert.fail("HttpResponseException expected");
         } catch (final HttpResponseException ex) {
             Assert.assertEquals(404, ex.getStatusCode());
-            Assert.assertEquals("404", ex.getMessage());
+            Assert.assertNull(ex.getReasonPhrase());
+            Assert.assertEquals("status code: 404", ex.getMessage());
         }
         Mockito.verify(entity).getContent();
         Mockito.verify(inStream).close();


### PR DESCRIPTION
The #getMessage() now properly consists of the status code as such and the
optional reason phrase. Moreover, the pure reason phrase can be retrieved
via #getReasonPhrase.

This is an improved version of #126.