### PR TITLE
Improve HttpResponseException#getMessage()

### DIFF
--- a/httpclient/src/main/java/org/apache/http/client/HttpResponseException.java
+++ b/httpclient/src/main/java/org/apache/http/client/HttpResponseException.java
@@ -38,14 +38,21 @@ public class HttpResponseException extends ClientProtocolException {
     private static final long serialVersionUID = -7186627969477257933L;
 
     private final int statusCode;
+    private final String reasonPhrase;
 
-    public HttpResponseException(final int statusCode, final String s) {
-        super(TextUtils.isBlank(s) ? Integer.toString(statusCode) : s);
+    public HttpResponseException(final int statusCode, final String reasonPhrase) {
+        super(String.format("status code: %d" +
+                (TextUtils.isBlank(reasonPhrase) ? "" : ", reason phrase: %s"), statusCode, reasonPhrase));
         this.statusCode = statusCode;
+        this.reasonPhrase = reasonPhrase;
     }
 
     public int getStatusCode() {
         return this.statusCode;
+    }
+
+    public String getReasonPhrase() {
+        return this.reasonPhrase;
     }
 
 }

--- a/httpclient/src/test/java/org/apache/http/impl/client/TestAbstractResponseHandler.java
+++ b/httpclient/src/test/java/org/apache/http/impl/client/TestAbstractResponseHandler.java
@@ -84,7 +84,8 @@ public class TestAbstractResponseHandler {
             Assert.fail("HttpResponseException expected");
         } catch (final HttpResponseException ex) {
             Assert.assertEquals(404, ex.getStatusCode());
-            Assert.assertEquals("Not Found", ex.getMessage());
+            Assert.assertEquals("Not Found", ex.getReasonPhrase());
+            Assert.assertEquals("status code: 404, reason phrase: Not Found", ex.getMessage());
         }
         Mockito.verify(entity).getContent();
         Mockito.verify(inStream).close();
@@ -97,7 +98,7 @@ public class TestAbstractResponseHandler {
         final HttpEntity entity = Mockito.mock(HttpEntity.class);
         Mockito.when(entity.isStreaming()).thenReturn(true);
         Mockito.when(entity.getContent()).thenReturn(inStream);
-        final StatusLine sl = new BasicStatusLine(HttpVersion.HTTP_1_1, 404, "");
+        final StatusLine sl = new BasicStatusLine(HttpVersion.HTTP_1_1, 404, null);
         final HttpResponse response = Mockito.mock(HttpResponse.class);
         Mockito.when(response.getStatusLine()).thenReturn(sl);
         Mockito.when(response.getEntity()).thenReturn(entity);
@@ -108,7 +109,8 @@ public class TestAbstractResponseHandler {
             Assert.fail("HttpResponseException expected");
         } catch (final HttpResponseException ex) {
             Assert.assertEquals(404, ex.getStatusCode());
-            Assert.assertEquals("404", ex.getMessage());
+            Assert.assertNull(ex.getReasonPhrase());
+            Assert.assertEquals("status code: 404", ex.getMessage());
         }
         Mockito.verify(entity).getContent();
         Mockito.verify(inStream).close();

--- a/httpclient/src/test/java/org/apache/http/impl/client/TestBasicResponseHandler.java
+++ b/httpclient/src/test/java/org/apache/http/impl/client/TestBasicResponseHandler.java
@@ -76,7 +76,7 @@ public class TestBasicResponseHandler {
             Assert.fail("HttpResponseException expected");
         } catch (final HttpResponseException ex) {
             Assert.assertEquals(404, ex.getStatusCode());
-            Assert.assertEquals("Not Found", ex.getMessage());
+            Assert.assertEquals("status code: 404, reason phrase: Not Found", ex.getMessage());
         }
         Mockito.verify(entity).getContent();
         Mockito.verify(inStream).close();


### PR DESCRIPTION
The #getMessage() now properly consists of the status code as such and the
optional reason phrase. Moreover, the pure reason phrase can be retrieved
via #getReasonPhrase.