### PR TITLE
HTTPCLIENT-1969: Filter out weak cipher suites

### DIFF
--- a/httpclient/src/test/java/org/apache/http/conn/ssl/TestSSLSocketFactory.java
+++ b/httpclient/src/test/java/org/apache/http/conn/ssl/TestSSLSocketFactory.java
@@ -376,4 +376,79 @@ public class TestSSLSocketFactory {
             inputStream.close();
         }
     }
+
+    @Test
+    public void testStrongCipherSuites() {
+        final String[] strongCipherSuites = {
+                "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",
+                "TLS_RSA_WITH_AES_256_CBC_SHA256",
+                "TLS_DHE_RSA_WITH_AES_256_CBC_SHA256",
+                "TLS_RSA_WITH_AES_128_CBC_SHA",
+                "TLS_DHE_DSS_WITH_AES_128_CBC_SHA",
+                "TLS_RSA_WITH_AES_256_GCM_SHA384"
+        };
+        for (final String cipherSuite : strongCipherSuites) {
+            Assert.assertFalse(SSLConnectionSocketFactory.isWeakCipherSuite(cipherSuite));
+        }
+    }
+
+    @Test
+    public void testWeakCiphersDisabledByDefault() {
+        final String[] weakCiphersSuites = {
+                "SSL_RSA_WITH_RC4_128_SHA",
+                "SSL_RSA_WITH_3DES_EDE_CBC_SHA",
+                "TLS_DH_anon_WITH_AES_128_CBC_SHA",
+                "SSL_RSA_EXPORT_WITH_DES40_CBC_SHA",
+                "SSL_RSA_WITH_NULL_SHA",
+                "SSL_RSA_WITH_3DES_EDE_CBC_SHA",
+                "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA",
+                "TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA",
+                "TLS_DH_anon_WITH_AES_256_GCM_SHA384",
+                "TLS_ECDH_anon_WITH_AES_256_CBC_SHA",
+                "TLS_RSA_WITH_NULL_SHA256",
+                "SSL_RSA_EXPORT_WITH_RC4_40_MD5",
+                "SSL_DH_anon_EXPORT_WITH_RC4_40_MD5",
+                "TLS_KRB5_EXPORT_WITH_RC4_40_SHA",
+                "SSL_RSA_EXPORT_WITH_RC2_CBC_40_MD5"
+        };
+        for (final String cipherSuite : weakCiphersSuites) {
+            Assert.assertTrue(SSLConnectionSocketFactory.isWeakCipherSuite(cipherSuite));
+            try {
+                testWeakCipherDisabledByDefault(cipherSuite);
+                Assert.fail("IOException expected");
+            } catch (final Exception e) {
+                Assert.assertTrue(e instanceof IOException || e instanceof IllegalArgumentException);
+            }
+        }
+    }
+
+    private void testWeakCipherDisabledByDefault(final String cipherSuite) throws Exception {
+        // @formatter:off
+        this.server = ServerBootstrap.bootstrap()
+                .setServerInfo(LocalServerTestBase.ORIGIN)
+                .setSslContext(SSLTestContexts.createServerSSLContext())
+                .setSslSetupHandler(new SSLServerSetupHandler() {
+
+                    @Override
+                    public void initialize(final SSLServerSocket socket) {
+                        socket.setEnabledCipherSuites(new String[] {cipherSuite});
+                    }
+
+                })
+                .create();
+        // @formatter:on
+        this.server.start();
+
+        final HttpContext context = new BasicHttpContext();
+        final SSLConnectionSocketFactory socketFactory = new SSLConnectionSocketFactory(
+                SSLTestContexts.createClientSSLContext());
+        final Socket socket = socketFactory.createSocket(context);
+        try {
+            final InetSocketAddress remoteAddress = new InetSocketAddress("localhost", this.server.getLocalPort());
+            final HttpHost target = new HttpHost("localhost", this.server.getLocalPort(), "https");
+            socketFactory.connectSocket(0, socket, target, remoteAddress, null, context);
+        } finally {
+            socket.close();
+        }
+    }
 }


### PR DESCRIPTION
Please consider a patch for [HTTPCLIENT-1969](https://issues.apache.org/jira/browse/HTTPCLIENT-1969):
- Defined a list of weak algorithms which may be used in a TLS connection. The list is based on the latest settings in modern OpenJDK, see [java.security](https://hg.openjdk.java.net/jdk/jdk/file/1019c97e1bde/src/java.base/share/conf/security/java.security#l678) file (EXPORT ciphers are also disabled in modern OpenJDK by default)
- Updated `SSLConnectionSocketFactory` to filter out weak ciphers if cipher suites are not explicitly set.

Please note that the test passes with latest Java versions even without patching `SSLConnectionSocketFactory` because latest Java versions disable weak ciphers by default. The filtering mechanism blocks weak ciphers in case older Java versions are used.