### PR TITLE
HTTPCLIENT-1969: Filter out weak cipher suites

### DIFF
--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestSSLSocketFactory.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestSSLSocketFactory.java
@@ -359,4 +359,59 @@ public class TestSSLSocketFactory {
             socketFactory.connectSocket(TimeValue.ZERO_MILLISECONDS, socket, target, remoteAddress, null, context);
         }
     }
+
+    @Test
+    public void testWeakCiphersDisabledByDefault() {
+        final String[] weakCiphersSuites = {
+                "SSL_RSA_WITH_RC4_128_SHA",
+                "SSL_RSA_WITH_3DES_EDE_CBC_SHA",
+                "TLS_DH_anon_WITH_AES_128_CBC_SHA",
+                "SSL_RSA_EXPORT_WITH_DES40_CBC_SHA",
+                "SSL_RSA_WITH_NULL_SHA",
+                "SSL_RSA_WITH_3DES_EDE_CBC_SHA",
+                "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA",
+                "TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA",
+                "TLS_DH_anon_WITH_AES_256_GCM_SHA384",
+                "TLS_ECDH_anon_WITH_AES_256_CBC_SHA",
+                "TLS_RSA_WITH_NULL_SHA256",
+                "SSL_RSA_EXPORT_WITH_RC4_40_MD5",
+                "SSL_DH_anon_EXPORT_WITH_RC4_40_MD5",
+                "TLS_KRB5_EXPORT_WITH_RC4_40_SHA",
+                "SSL_RSA_EXPORT_WITH_RC2_CBC_40_MD5"
+        };
+        for (final String cipherSuite : weakCiphersSuites) {
+            try {
+                testWeakCipherDisabledByDefault(cipherSuite);
+                Assert.fail("IOException expected");
+            } catch (final Exception e) {
+                Assert.assertTrue(e instanceof IOException || e instanceof IllegalArgumentException);
+            }
+        }
+    }
+
+    private void testWeakCipherDisabledByDefault(final String cipherSuite) throws Exception {
+        // @formatter:off
+        this.server = ServerBootstrap.bootstrap()
+                .setSslContext(SSLTestContexts.createServerSSLContext())
+                .setSslSetupHandler(new SSLServerSetupHandler() {
+
+                    @Override
+                    public void initialize(final SSLServerSocket socket) {
+                        socket.setEnabledCipherSuites(new String[] {cipherSuite});
+                    }
+
+                })
+                .create();
+        // @formatter:on
+        this.server.start();
+
+        final HttpContext context = new BasicHttpContext();
+        final SSLConnectionSocketFactory socketFactory = new SSLConnectionSocketFactory(
+                SSLTestContexts.createClientSSLContext());
+        try (final Socket socket = socketFactory.createSocket(context)) {
+            final InetSocketAddress remoteAddress = new InetSocketAddress("localhost", this.server.getLocalPort());
+            final HttpHost target = new HttpHost("https", "localhost", this.server.getLocalPort());
+            socketFactory.connectSocket(TimeValue.ZERO_MILLISECONDS, socket, target, remoteAddress, null, context);
+        }
+    }
 }

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/ssl/TestSSLSocketFactory.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/ssl/TestSSLSocketFactory.java
@@ -1,0 +1,77 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.hc.client5.http.ssl;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link SSLConnectionSocketFactory}.
+ */
+public class TestSSLSocketFactory {
+
+    @Test
+    public void testStrongCipherSuites() {
+        final String[] strongCipherSuites = {
+                "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",
+                "TLS_RSA_WITH_AES_256_CBC_SHA256",
+                "TLS_DHE_RSA_WITH_AES_256_CBC_SHA256",
+                "TLS_RSA_WITH_AES_128_CBC_SHA",
+                "TLS_DHE_DSS_WITH_AES_128_CBC_SHA",
+                "TLS_RSA_WITH_AES_256_GCM_SHA384"
+        };
+        for (final String cipherSuite : strongCipherSuites) {
+            Assert.assertFalse(SSLConnectionSocketFactory.isWeakCipherSuite(cipherSuite));
+        }
+    }
+
+    @Test
+    public void testWeakCiphersDisabledByDefault() {
+        final String[] weakCiphersSuites = {
+                "SSL_RSA_WITH_RC4_128_SHA",
+                "SSL_RSA_WITH_3DES_EDE_CBC_SHA",
+                "TLS_DH_anon_WITH_AES_128_CBC_SHA",
+                "SSL_RSA_EXPORT_WITH_DES40_CBC_SHA",
+                "SSL_RSA_WITH_NULL_SHA",
+                "SSL_RSA_WITH_3DES_EDE_CBC_SHA",
+                "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA",
+                "TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA",
+                "TLS_DH_anon_WITH_AES_256_GCM_SHA384",
+                "TLS_ECDH_anon_WITH_AES_256_CBC_SHA",
+                "TLS_RSA_WITH_NULL_SHA256",
+                "SSL_RSA_EXPORT_WITH_RC4_40_MD5",
+                "SSL_DH_anon_EXPORT_WITH_RC4_40_MD5",
+                "TLS_KRB5_EXPORT_WITH_RC4_40_SHA",
+                "SSL_RSA_EXPORT_WITH_RC2_CBC_40_MD5"
+        };
+        for (final String cipherSuite : weakCiphersSuites) {
+            Assert.assertTrue(SSLConnectionSocketFactory.isWeakCipherSuite(cipherSuite));
+        }
+    }
+
+}


### PR DESCRIPTION
This is a port of #140 to the master branch:
- The changes in SSLConnectionSocketFactory.java are the same
- I see that httpclient5 has slightly different structure for tests. I have updated `org.apache.hc.client5.testing.sync.TestSSLSocketFactory` with new test cases with a local server but could not add tests for `isWeakCipherSuite()` method because of different package name. The test for this method have been added to new `org.apache.hc.client5.http.ssl.TestSSLSocketFactory` test. Another options is to make `isWeakCipherSuite()` method public, and them move all test cases to `org.apache.hc.client5.testing.sync.TestSSLSocketFactory`. But not sure if `isWeakCipherSuite()` method should be public. Let me know if it needs to be updated.