### PR TITLE
Changed route tracking of proxy to not default to false

### DIFF
--- a/httpclient/src/main/java/org/apache/http/impl/execchain/MainClientExec.java
+++ b/httpclient/src/main/java/org/apache/http/impl/execchain/MainClientExec.java
@@ -404,7 +404,7 @@ public class MainClientExec implements ClientExecChain {
                         timeout > 0 ? timeout : 0,
                         context);
                 final HttpHost proxy  = route.getProxyHost();
-                tracker.connectProxy(proxy, false);
+                tracker.connectProxy(proxy, route.isSecure() && !route.isTunnelled());
                 break;
             case HttpRouteDirector.TUNNEL_TARGET: {
                 final boolean secure = createTunnelToTarget(


### PR DESCRIPTION
Changed route tracking of proxy to not default to false and instead to
use the route's secure value. this allow routes to proxies to be https and
not tunnel/CONNECT.  All test pass with this change.