### PR TITLE
HTTPCLIENT-1984: Add normalize URI to RequestConfig copy constructor

### DIFF
--- a/httpclient/src/main/java/org/apache/http/client/config/RequestConfig.java
+++ b/httpclient/src/main/java/org/apache/http/client/config/RequestConfig.java
@@ -399,7 +399,8 @@ public class RequestConfig implements Cloneable {
             .setConnectTimeout(config.getConnectTimeout())
             .setSocketTimeout(config.getSocketTimeout())
             .setDecompressionEnabled(config.isDecompressionEnabled())
-            .setContentCompressionEnabled(config.isContentCompressionEnabled());
+            .setContentCompressionEnabled(config.isContentCompressionEnabled())
+            .setNormalizeUri(config.isNormalizeUri());
     }
 
     public static class Builder {

--- a/httpclient/src/test/java/org/apache/http/client/config/TestRequestConfig.java
+++ b/httpclient/src/test/java/org/apache/http/client/config/TestRequestConfig.java
@@ -80,6 +80,7 @@ public class TestRequestConfig {
                 .setTargetPreferredAuthSchemes(Arrays.asList(AuthSchemes.NTLM))
                 .setProxyPreferredAuthSchemes(Arrays.asList(AuthSchemes.DIGEST))
                 .setContentCompressionEnabled(false)
+                .setNormalizeUri(false)
                 .build();
         final RequestConfig config = RequestConfig.copy(config0).build();
         Assert.assertEquals(22, config.getSocketTimeout());
@@ -97,6 +98,7 @@ public class TestRequestConfig {
         Assert.assertEquals(Arrays.asList(AuthSchemes.NTLM), config.getTargetPreferredAuthSchemes());
         Assert.assertEquals(Arrays.asList(AuthSchemes.DIGEST), config.getProxyPreferredAuthSchemes());
         Assert.assertEquals(false, config.isContentCompressionEnabled());
+        Assert.assertEquals(false, config.isNormalizeUri());
     }
 
 }


### PR DESCRIPTION
Add normalize URI to RequestConfig copy constructor

https://issues.apache.org/jira/browse/HTTPCLIENT-1984