### PR TITLE
Fix bug in URIBuilder#isPathEmpty method 

### DIFF
--- a/httpclient/src/main/java/org/apache/http/client/utils/URIBuilder.java
+++ b/httpclient/src/main/java/org/apache/http/client/utils/URIBuilder.java
@@ -34,7 +34,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-
 import org.apache.http.Consts;
 import org.apache.http.NameValuePair;
 import org.apache.http.conn.util.InetAddressUtils;
@@ -521,7 +520,8 @@ public class URIBuilder {
      * @since 4.5.8
      */
     public boolean isPathEmpty() {
-        return (this.pathSegments == null || this.pathSegments.isEmpty()) && this.encodedPath == null;
+        return (this.pathSegments == null || this.pathSegments.isEmpty()) &&
+               (this.encodedPath == null || this.encodedPath.isEmpty());
     }
 
     /**

--- a/httpclient/src/test/java/org/apache/http/client/utils/TestURIUtils.java
+++ b/httpclient/src/test/java/org/apache/http/client/utils/TestURIUtils.java
@@ -34,6 +34,7 @@ import org.apache.http.conn.routing.HttpRoute;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.apache.http.client.utils.URIUtils.DROP_FRAGMENT;
 import static org.apache.http.client.utils.URIUtils.DROP_FRAGMENT_AND_NORMALIZE;
 import static org.apache.http.client.utils.URIUtils.NORMALIZE;
 
@@ -82,6 +83,17 @@ public class TestURIUtils {
                 URIUtils.rewriteURI(
                         URI.create("http://thishost/Fragment_identifier%23Examples")).toString());
     }
+
+    @Test
+    public void testRewriteWithEmptyPath() throws Exception {
+        final HttpHost target = new HttpHost("thathost", -1);
+
+        Assert.assertEquals("http://thathost/", URIUtils.rewriteURI(
+            URI.create("http://thathost"), target, DROP_FRAGMENT_AND_NORMALIZE).toString());
+        Assert.assertEquals("http://thathost/", URIUtils.rewriteURI(
+            URI.create("http://thathost"), target, DROP_FRAGMENT).toString());
+    }
+
 
     @Test
     public void testRewritePort() throws Exception {


### PR DESCRIPTION
isPathEmpty should verify if encodedPath member is an empty string.
Otherwise, [this code](https://github.com/apache/httpcomponents-client/blob/4.5.x/httpclient/src/main/java/org/apache/http/client/utils/URIUtils.java#L229) in URIUtils.rewriteURI will evaluate to false when normalization is disabled.

Before 4.5.6, URIUtils.rewriteURI method used [TextUtils#isEmpty method](https://github.com/apache/httpcomponents-core/blob/master/httpcore5/src/main/java/org/apache/hc/core5/util/TextUtils.java#L42) which checked for both null and empty string case.

* Added a new unit test. The test failed before including the empty string check