### PR TITLE
MultipartEntity limit 25Kb Size

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/entity/mime/MultipartFormEntity.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/entity/mime/MultipartFormEntity.java
@@ -95,9 +95,13 @@ class MultipartFormEntity implements HttpEntity {
     public InputStream getContent() throws IOException {
         if (this.contentLength < 0) {
             throw new ContentTooLongException("Content length is unknown");
-        } else if (this.contentLength > 25 * 1024) {
-            throw new ContentTooLongException("Content length is too long: " + this.contentLength);
-        }
+        } 
+        //I don't understand why are you guys limit size of multipart entity?
+        //many of people use this entity for upload files
+        //so I can't upload with this entity over 25Kb size file
+//         else if (this.contentLength > 25 * 1024) {
+//             throw new ContentTooLongException("Content length is too long: " + this.contentLength);
+//         }
         final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
         writeTo(outStream);
         outStream.flush();


### PR DESCRIPTION
Hello.
I use this library for access other server which file uploading is important part of one

so I want upload file over 25Kb with this entity but this entity limited 25Kb-(hardCode)
and I don't understand why are you guys limit this things

please give me your intent