### PR TITLE
Escape DEL character when tracing

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/Wire.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/Wire.java
@@ -93,7 +93,7 @@ public class Wire {
                     buffer.insert(0, header);
                     this.log.debug(this.id + " " + buffer.toString());
                     buffer.setLength(0);
-            } else if ((ch < 32) || (ch > 127)) {
+            } else if ((ch < 32) || (ch >= 127)) {
                 buffer.append("[0x");
                 buffer.append(Integer.toHexString(ch));
                 buffer.append("]");


### PR DESCRIPTION
DEL characters should be converted to [0x7f] in Wire traces otherwise they are difficult to see in logs.