### PR TITLE
bugfix/HTTPCLIENT-2022-httpcacheentryserializationexception-message-unused

### DIFF
--- a/httpclient-cache/src/main/java/org/apache/http/client/cache/HttpCacheEntrySerializationException.java
+++ b/httpclient-cache/src/main/java/org/apache/http/client/cache/HttpCacheEntrySerializationException.java
@@ -37,7 +37,7 @@ public class HttpCacheEntrySerializationException extends IOException {
     private static final long serialVersionUID = 9219188365878433519L;
 
     public HttpCacheEntrySerializationException(final String message) {
-        super();
+        super(message);
     }
 
     public HttpCacheEntrySerializationException(final String message, final Throwable cause) {


### PR DESCRIPTION
**HttpCacheEntrySerializationException Message Unused**
https://issues.apache.org/jira/browse/HTTPCLIENT-2022