### PR TITLE
Upgrading commons-codec to 1.13 after sonatype-2012-0050 vulnerability

### DIFF
--- a/httpclient-cache/src/test/java/org/apache/http/impl/client/cache/TestHttpCacheEntrySerializers.java
+++ b/httpclient-cache/src/test/java/org/apache/http/impl/client/cache/TestHttpCacheEntrySerializers.java
@@ -288,7 +288,7 @@ public class TestHttpCacheEntrySerializers {
         variantMap.put("test variant 1","true");
         variantMap.put("test variant 2","true");
         final HttpCacheEntry cacheEntry = new HttpCacheEntry(new Date(), new Date(),
-                slObj, headers, new HeapResource(Base64.decodeBase64(body
+                slObj, headers, new HeapResource(Base64.encodeBase64(body
                         .getBytes(UTF8))), variantMap, HeaderConstants.GET_METHOD);
 
         return cacheEntry;

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <maven.compiler.target>1.6</maven.compiler.target>
     <httpcore.version>4.4.12</httpcore.version>
     <commons-logging.version>1.2</commons-logging.version>
-    <commons-codec.version>1.11</commons-codec.version>
+    <commons-codec.version>1.13</commons-codec.version>
     <ehcache.version>2.6.11</ehcache.version>
     <memcached.version>2.12.3</memcached.version>
     <slf4j.version>1.7.25</slf4j.version>


### PR DESCRIPTION
Updating library needed to sort out vulnerability `sonatype-2012-0050`

Description:
```
The Apache commons-codec package contains an Improper Input Validation vulnerability. 
The decode() method in the Base32, Base64, and BCodec classes fails to reject malformed
Base32 and Base64 encoded strings and consequently decodes them into arbitrary values. 
A remote attacker can leverage this vulnerability to potentially tunnel additional
information via seemingly legitimate Base32 or Base64 encoded strings.
```