### PR TITLE
HTTPCLIENT-2028: Now allowing 0 for validateAfterInactivity

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java
@@ -287,7 +287,7 @@ public class PoolingHttpClientConnectionManager
                     log.debug(id + ": endpoint leased " + ConnPoolSupport.formatStats(route, state, pool));
                 }
                 try {
-                    if (TimeValue.isPositive(validateAfterInactivity)) {
+                    if (TimeValue.isNonNegative(validateAfterInactivity)) {
                         final ManagedHttpClientConnection conn = poolEntry.getConnection();
                         if (conn != null
                                 && poolEntry.getUpdated() + validateAfterInactivity.toMillis() <= System.currentTimeMillis()) {


### PR DESCRIPTION
The purpose of this change is to allow stale checking all the time, in previous versions of HttpClient this was accomplished by staleConnectionCheckEnabled=true which is now removed, this adds that idea back