### PR TITLE
HTTPCLIENT-2030: Fix PublicSuffixMatcher::getDomainRoot on invalid hostnames (4.5.x)

### DIFF
--- a/httpclient/src/main/java/org/apache/http/conn/ssl/DefaultHostnameVerifier.java
+++ b/httpclient/src/main/java/org/apache/http/conn/ssl/DefaultHostnameVerifier.java
@@ -198,9 +198,10 @@ public final class DefaultHostnameVerifier implements HostnameVerifier {
 
     private static boolean matchIdentity(final String host, final String identity,
                                          final PublicSuffixMatcher publicSuffixMatcher,
+                                         final DomainType domainType,
                                          final boolean strict) {
         if (publicSuffixMatcher != null && host.contains(".")) {
-            if (!matchDomainRoot(host, publicSuffixMatcher.getDomainRoot(identity, DomainType.ICANN))) {
+            if (!matchDomainRoot(host, publicSuffixMatcher.getDomainRoot(identity, domainType))) {
                 return false;
             }
         }
@@ -235,20 +236,32 @@ public final class DefaultHostnameVerifier implements HostnameVerifier {
 
     static boolean matchIdentity(final String host, final String identity,
                                  final PublicSuffixMatcher publicSuffixMatcher) {
-        return matchIdentity(host, identity, publicSuffixMatcher, false);
+        return matchIdentity(host, identity, publicSuffixMatcher, null, false);
     }
 
     static boolean matchIdentity(final String host, final String identity) {
-        return matchIdentity(host, identity, null, false);
+        return matchIdentity(host, identity, null, null, false);
     }
 
     static boolean matchIdentityStrict(final String host, final String identity,
                                        final PublicSuffixMatcher publicSuffixMatcher) {
-        return matchIdentity(host, identity, publicSuffixMatcher, true);
+        return matchIdentity(host, identity, publicSuffixMatcher, null, true);
     }
 
     static boolean matchIdentityStrict(final String host, final String identity) {
-        return matchIdentity(host, identity, null, true);
+        return matchIdentity(host, identity, null, null, true);
+    }
+
+    static boolean matchIdentity(final String host, final String identity,
+                                 final PublicSuffixMatcher publicSuffixMatcher,
+                                 final DomainType domainType) {
+        return matchIdentity(host, identity, publicSuffixMatcher, domainType, false);
+    }
+
+    static boolean matchIdentityStrict(final String host, final String identity,
+                                       final PublicSuffixMatcher publicSuffixMatcher,
+                                       final DomainType domainType) {
+        return matchIdentity(host, identity, publicSuffixMatcher, domainType, true);
     }
 
     static String extractCN(final String subjectPrincipal) throws SSLException {

--- a/httpclient/src/main/java/org/apache/http/conn/util/PublicSuffixMatcher.java
+++ b/httpclient/src/main/java/org/apache/http/conn/util/PublicSuffixMatcher.java
@@ -166,9 +166,15 @@ public final class PublicSuffixMatcher {
             result = segment;
             segment = nextSegment;
         }
-        return result;
-    }
 
+        // If no expectations then this result is good.
+        if (expectedType == null || expectedType == DomainType.UNKNOWN) {
+            return result;
+        }
+
+        // If we did have expectations apparently there was no match
+        return null;
+    }
     /**
      * Tests whether the given domain matches any of entry from the public suffix list.
      */

--- a/httpclient/src/test/resources/suffixlistmatcher.txt
+++ b/httpclient/src/test/resources/suffixlistmatcher.txt
@@ -1,0 +1,46 @@
+// ====================================================================
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+// ====================================================================
+//
+// This software consists of voluntary contributions made by many
+// individuals on behalf of the Apache Software Foundation.  For more
+// information on the Apache Software Foundation, please see
+// <http://www.apache.org/>.
+//
+
+// ===BEGIN PRIVATE DOMAINS===
+xx
+lan
+// ===END PRIVATE DOMAINS===
+
+// ===BEGIN ICANN DOMAINS===
+
+jp
+ac.jp
+*.tokyo.jp
+!metro.tokyo.jp
+
+com
+co.jp
+gov.uk
+
+// unicode
+no
+hå.no
+
+// ===END ICANN DOMAINS===


### PR DESCRIPTION
This is an as exact as possible backport of https://github.com/apache/httpcomponents-client/pull/174 to the 4.5.x branch.
Only real differences are file locations and the UTF_8 had to be defined manually.