### PR TITLE
Apply consistent id field names

### DIFF
--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestSPNegoScheme.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestSPNegoScheme.java
@@ -160,7 +160,7 @@ public class TestSPNegoScheme extends LocalServerTestBase {
         credentialsProvider.setCredentials(new AuthScope(null, null, -1, null, null), use_jaas_creds);
 
         final Registry<AuthSchemeProvider> authSchemeRegistry = RegistryBuilder.<AuthSchemeProvider>create()
-            .register(AuthSchemes.SPNEGO.ident, nsf)
+            .register(AuthSchemes.SPNEGO.id, nsf)
             .build();
         this.httpclient = HttpClients.custom()
             .setDefaultAuthSchemeRegistry(authSchemeRegistry)
@@ -191,7 +191,7 @@ public class TestSPNegoScheme extends LocalServerTestBase {
         credentialsProvider.setCredentials(new AuthScope(null, null, -1, null, null), use_jaas_creds);
 
         final Registry<AuthSchemeProvider> authSchemeRegistry = RegistryBuilder.<AuthSchemeProvider>create()
-            .register(AuthSchemes.SPNEGO.ident, nsf)
+            .register(AuthSchemes.SPNEGO.id, nsf)
             .build();
         this.httpclient = HttpClients.custom()
             .setDefaultAuthSchemeRegistry(authSchemeRegistry)

--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestWindowsNegotiateScheme.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestWindowsNegotiateScheme.java
@@ -81,10 +81,10 @@ public class TestWindowsNegotiateScheme extends LocalServerTestBase {
         // you can contact the server that authenticated you." is associated with SEC_E_DOWNGRADE_DETECTED.
 
         final Registry<AuthSchemeProvider> authSchemeRegistry = RegistryBuilder.<AuthSchemeProvider>create()
-            .register(AuthSchemes.SPNEGO.ident, new AuthSchemeProvider() {
+            .register(AuthSchemes.SPNEGO.id, new AuthSchemeProvider() {
                 @Override
                 public AuthScheme create(final HttpContext context) {
-                    return new WindowsNegotiateSchemeGetTokenFail(AuthSchemes.SPNEGO.ident, "HTTP/example.com");
+                    return new WindowsNegotiateSchemeGetTokenFail(AuthSchemes.SPNEGO.id, "HTTP/example.com");
                 }
             }).build();
         final CloseableHttpClient customClient = HttpClientBuilder.create()

--- a/httpclient5-win/src/main/java/org/apache/hc/client5/http/impl/win/WinHttpClients.java
+++ b/httpclient5-win/src/main/java/org/apache/hc/client5/http/impl/win/WinHttpClients.java
@@ -67,10 +67,10 @@ public class WinHttpClients {
     private static HttpClientBuilder createBuilder() {
         if (isWinAuthAvailable()) {
             final Registry<AuthSchemeProvider> authSchemeRegistry = RegistryBuilder.<AuthSchemeProvider>create()
-                    .register(AuthSchemes.BASIC.ident, new BasicSchemeFactory())
-                    .register(AuthSchemes.DIGEST.ident, new DigestSchemeFactory())
-                    .register(AuthSchemes.NTLM.ident, new WindowsNTLMSchemeFactory(null))
-                    .register(AuthSchemes.SPNEGO.ident, new WindowsNegotiateSchemeFactory(null))
+                    .register(AuthSchemes.BASIC.id, new BasicSchemeFactory())
+                    .register(AuthSchemes.DIGEST.id, new DigestSchemeFactory())
+                    .register(AuthSchemes.NTLM.id, new WindowsNTLMSchemeFactory(null))
+                    .register(AuthSchemes.SPNEGO.id, new WindowsNegotiateSchemeFactory(null))
                     .build();
             return HttpClientBuilder.create()
                     .setDefaultAuthSchemeRegistry(authSchemeRegistry);

--- a/httpclient5-win/src/main/java/org/apache/hc/client5/http/impl/win/WindowsNTLMSchemeFactory.java
+++ b/httpclient5-win/src/main/java/org/apache/hc/client5/http/impl/win/WindowsNTLMSchemeFactory.java
@@ -54,7 +54,7 @@ public class WindowsNTLMSchemeFactory implements AuthSchemeProvider {
 
     @Override
     public AuthScheme create(final HttpContext context) {
-        return new WindowsNegotiateScheme(AuthSchemes.NTLM.ident, servicePrincipalName);
+        return new WindowsNegotiateScheme(AuthSchemes.NTLM.id, servicePrincipalName);
     }
 
 }

--- a/httpclient5-win/src/main/java/org/apache/hc/client5/http/impl/win/WindowsNegotiateScheme.java
+++ b/httpclient5-win/src/main/java/org/apache/hc/client5/http/impl/win/WindowsNegotiateScheme.java
@@ -86,7 +86,7 @@ public class WindowsNegotiateScheme implements AuthScheme {
     WindowsNegotiateScheme(final String scheme, final String servicePrincipalName) {
         super();
 
-        this.scheme = (scheme == null) ? AuthSchemes.SPNEGO.ident : scheme;
+        this.scheme = (scheme == null) ? AuthSchemes.SPNEGO.id : scheme;
         this.continueNeeded = true;
         this.servicePrincipalName = servicePrincipalName;
 

--- a/httpclient5-win/src/main/java/org/apache/hc/client5/http/impl/win/WindowsNegotiateSchemeFactory.java
+++ b/httpclient5-win/src/main/java/org/apache/hc/client5/http/impl/win/WindowsNegotiateSchemeFactory.java
@@ -54,7 +54,7 @@ public class WindowsNegotiateSchemeFactory implements AuthSchemeProvider {
 
     @Override
     public AuthScheme create(final HttpContext context) {
-        return new WindowsNegotiateScheme(AuthSchemes.SPNEGO.ident, servicePrincipalName);
+        return new WindowsNegotiateScheme(AuthSchemes.SPNEGO.id, servicePrincipalName);
     }
 
 }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/auth/AuthSchemes.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/auth/AuthSchemes.java
@@ -65,10 +65,10 @@ public enum AuthSchemes {
      */
     KERBEROS("Kerberos");
 
-    public final String ident;
+    public final String id;
 
-    AuthSchemes(final String ident) {
-        this.ident = ident;
+    AuthSchemes(final String id) {
+        this.id = id;
     }
 
 }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/cookie/CookieSpecs.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/cookie/CookieSpecs.java
@@ -51,10 +51,10 @@ public enum CookieSpecs {
      */
     IGNORE_COOKIES("ignoreCookies");
 
-    public final String ident;
+    public final String id;
 
-    CookieSpecs(final String ident) {
-        this.ident = ident;
+    CookieSpecs(final String id) {
+        this.id = id;
     }
 
 }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/AuthSupport.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/AuthSupport.java
@@ -63,7 +63,7 @@ public class AuthSupport {
         final char[] password = atColon >= 0 ? userInfo.substring(atColon + 1).toCharArray() : null;
 
         credentialsStore.setCredentials(
-                new AuthScope(scheme, authority.getHostName(), authority.getPort(), null, AuthSchemes.BASIC.ident),
+                new AuthScope(scheme, authority.getHostName(), authority.getPort(), null, AuthSchemes.BASIC.id),
                 new UsernamePasswordCredentials(userName, password));
     }
 

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/CookieSpecSupport.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/CookieSpecSupport.java
@@ -50,11 +50,11 @@ public final class CookieSpecSupport {
      */
     public static RegistryBuilder<CookieSpecProvider> createDefaultBuilder(final PublicSuffixMatcher publicSuffixMatcher) {
         return RegistryBuilder.<CookieSpecProvider>create()
-                .register(CookieSpecs.STANDARD.ident, new RFC6265CookieSpecProvider(
+                .register(CookieSpecs.STANDARD.id, new RFC6265CookieSpecProvider(
                         RFC6265CookieSpecProvider.CompatibilityLevel.RELAXED, publicSuffixMatcher))
-                .register(CookieSpecs.STANDARD_STRICT.ident, new RFC6265CookieSpecProvider(
+                .register(CookieSpecs.STANDARD_STRICT.id, new RFC6265CookieSpecProvider(
                         RFC6265CookieSpecProvider.CompatibilityLevel.STRICT, publicSuffixMatcher))
-                .register(CookieSpecs.IGNORE_COOKIES.ident, new IgnoreSpecProvider());
+                .register(CookieSpecs.IGNORE_COOKIES.id, new IgnoreSpecProvider());
     }
 
     /**

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/DefaultAuthenticationStrategy.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/DefaultAuthenticationStrategy.java
@@ -65,11 +65,11 @@ public class DefaultAuthenticationStrategy implements AuthenticationStrategy {
 
     private static final List<String> DEFAULT_SCHEME_PRIORITY =
         Collections.unmodifiableList(Arrays.asList(
-                AuthSchemes.SPNEGO.ident,
-                AuthSchemes.KERBEROS.ident,
-                AuthSchemes.NTLM.ident,
-                AuthSchemes.DIGEST.ident,
-                AuthSchemes.BASIC.ident));
+                AuthSchemes.SPNEGO.id,
+                AuthSchemes.KERBEROS.id,
+                AuthSchemes.NTLM.id,
+                AuthSchemes.DIGEST.id,
+                AuthSchemes.BASIC.id));
 
     @Override
     public List<AuthScheme> select(

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/H2AsyncClientBuilder.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/H2AsyncClientBuilder.java
@@ -763,12 +763,12 @@ public class H2AsyncClientBuilder {
         Lookup<AuthSchemeProvider> authSchemeRegistryCopy = this.authSchemeRegistry;
         if (authSchemeRegistryCopy == null) {
             authSchemeRegistryCopy = RegistryBuilder.<AuthSchemeProvider>create()
-                    .register(AuthSchemes.BASIC.ident, new BasicSchemeFactory())
-                    .register(AuthSchemes.DIGEST.ident, new DigestSchemeFactory())
-                    .register(AuthSchemes.NTLM.ident, new NTLMSchemeFactory())
-                    .register(AuthSchemes.SPNEGO.ident,
+                    .register(AuthSchemes.BASIC.id, new BasicSchemeFactory())
+                    .register(AuthSchemes.DIGEST.id, new DigestSchemeFactory())
+                    .register(AuthSchemes.NTLM.id, new NTLMSchemeFactory())
+                    .register(AuthSchemes.SPNEGO.id,
                             new SPNegoSchemeFactory(KerberosConfig.DEFAULT, SystemDefaultDnsResolver.INSTANCE))
-                    .register(AuthSchemes.KERBEROS.ident,
+                    .register(AuthSchemes.KERBEROS.id,
                             new KerberosSchemeFactory(KerberosConfig.DEFAULT, SystemDefaultDnsResolver.INSTANCE))
                     .build();
         }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncClientBuilder.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncClientBuilder.java
@@ -970,12 +970,12 @@ public class HttpAsyncClientBuilder {
         Lookup<AuthSchemeProvider> authSchemeRegistryCopy = this.authSchemeRegistry;
         if (authSchemeRegistryCopy == null) {
             authSchemeRegistryCopy = RegistryBuilder.<AuthSchemeProvider>create()
-                    .register(AuthSchemes.BASIC.ident, new BasicSchemeFactory())
-                    .register(AuthSchemes.DIGEST.ident, new DigestSchemeFactory())
-                    .register(AuthSchemes.NTLM.ident, new NTLMSchemeFactory())
-                    .register(AuthSchemes.SPNEGO.ident,
+                    .register(AuthSchemes.BASIC.id, new BasicSchemeFactory())
+                    .register(AuthSchemes.DIGEST.id, new DigestSchemeFactory())
+                    .register(AuthSchemes.NTLM.id, new NTLMSchemeFactory())
+                    .register(AuthSchemes.SPNEGO.id,
                             new SPNegoSchemeFactory(KerberosConfig.DEFAULT, SystemDefaultDnsResolver.INSTANCE))
-                    .register(AuthSchemes.KERBEROS.ident,
+                    .register(AuthSchemes.KERBEROS.id,
                             new KerberosSchemeFactory(KerberosConfig.DEFAULT, SystemDefaultDnsResolver.INSTANCE))
                     .build();
         }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/SystemDefaultCredentialsProvider.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/SystemDefaultCredentialsProvider.java
@@ -149,7 +149,7 @@ public class SystemDefaultCredentialsProvider implements CredentialsStore {
                 if (domain != null) {
                     return new NTCredentials(systemcreds.getUserName(), systemcreds.getPassword(), null, domain);
                 }
-                if (AuthSchemes.NTLM.ident.equalsIgnoreCase(authScope.getAuthScheme())) {
+                if (AuthSchemes.NTLM.id.equalsIgnoreCase(authScope.getAuthScheme())) {
                     // Domain may be specified in a fully qualified user name
                     return new NTCredentials(
                             systemcreds.getUserName(), systemcreds.getPassword(), null, null);

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/HttpClientBuilder.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/HttpClientBuilder.java
@@ -942,11 +942,11 @@ public class HttpClientBuilder {
         Lookup<AuthSchemeProvider> authSchemeRegistryCopy = this.authSchemeRegistry;
         if (authSchemeRegistryCopy == null) {
             authSchemeRegistryCopy = RegistryBuilder.<AuthSchemeProvider>create()
-                .register(AuthSchemes.BASIC.ident, new BasicSchemeFactory())
-                .register(AuthSchemes.DIGEST.ident, new DigestSchemeFactory())
-                .register(AuthSchemes.NTLM.ident, new NTLMSchemeFactory())
-                .register(AuthSchemes.SPNEGO.ident, new SPNegoSchemeFactory(KerberosConfig.DEFAULT, SystemDefaultDnsResolver.INSTANCE))
-                .register(AuthSchemes.KERBEROS.ident, new KerberosSchemeFactory(KerberosConfig.DEFAULT, SystemDefaultDnsResolver.INSTANCE))
+                .register(AuthSchemes.BASIC.id, new BasicSchemeFactory())
+                .register(AuthSchemes.DIGEST.id, new DigestSchemeFactory())
+                .register(AuthSchemes.NTLM.id, new NTLMSchemeFactory())
+                .register(AuthSchemes.SPNEGO.id, new SPNegoSchemeFactory(KerberosConfig.DEFAULT, SystemDefaultDnsResolver.INSTANCE))
+                .register(AuthSchemes.KERBEROS.id, new KerberosSchemeFactory(KerberosConfig.DEFAULT, SystemDefaultDnsResolver.INSTANCE))
                 .build();
         }
         Lookup<CookieSpecProvider> cookieSpecRegistryCopy = this.cookieSpecRegistry;

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/ProxyClient.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/ProxyClient.java
@@ -115,12 +115,12 @@ public class ProxyClient {
         this.authenticator = new HttpAuthenticator();
         this.proxyAuthExchange = new AuthExchange();
         this.authSchemeRegistry = RegistryBuilder.<AuthSchemeProvider>create()
-                .register(AuthSchemes.BASIC.ident, new BasicSchemeFactory())
-                .register(AuthSchemes.DIGEST.ident, new DigestSchemeFactory())
-                .register(AuthSchemes.NTLM.ident, new NTLMSchemeFactory())
-                .register(AuthSchemes.SPNEGO.ident,
+                .register(AuthSchemes.BASIC.id, new BasicSchemeFactory())
+                .register(AuthSchemes.DIGEST.id, new DigestSchemeFactory())
+                .register(AuthSchemes.NTLM.id, new NTLMSchemeFactory())
+                .register(AuthSchemes.SPNEGO.id,
                         new SPNegoSchemeFactory(KerberosConfig.DEFAULT, SystemDefaultDnsResolver.INSTANCE))
-                .register(AuthSchemes.KERBEROS.ident,
+                .register(AuthSchemes.KERBEROS.id,
                         new KerberosSchemeFactory(KerberosConfig.DEFAULT, SystemDefaultDnsResolver.INSTANCE))
                 .build();
         this.reuseStrategy = new DefaultConnectionReuseStrategy();

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/protocol/RequestAddCookies.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/protocol/RequestAddCookies.java
@@ -108,7 +108,7 @@ public class RequestAddCookies implements HttpRequestInterceptor {
         final RequestConfig config = clientContext.getRequestConfig();
         String policy = config.getCookieSpec();
         if (policy == null) {
-            policy = CookieSpecs.STANDARD.ident;
+            policy = CookieSpecs.STANDARD.id;
         }
         if (this.log.isDebugEnabled()) {
             this.log.debug("CookieSpec selected: " + policy);

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/config/TestRequestConfig.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/config/TestRequestConfig.java
@@ -73,10 +73,10 @@ public class TestRequestConfig {
                 .setRedirectsEnabled(false)
                 .setCircularRedirectsAllowed(true)
                 .setMaxRedirects(100)
-                .setCookieSpec(CookieSpecs.STANDARD.ident)
+                .setCookieSpec(CookieSpecs.STANDARD.id)
                 .setProxy(new HttpHost("someproxy"))
-                .setTargetPreferredAuthSchemes(Collections.singletonList(AuthSchemes.NTLM.ident))
-                .setProxyPreferredAuthSchemes(Collections.singletonList(AuthSchemes.DIGEST.ident))
+                .setTargetPreferredAuthSchemes(Collections.singletonList(AuthSchemes.NTLM.id))
+                .setProxyPreferredAuthSchemes(Collections.singletonList(AuthSchemes.DIGEST.id))
                 .setContentCompressionEnabled(false)
                 .build();
         final RequestConfig config = RequestConfig.copy(config0).build();
@@ -87,10 +87,10 @@ public class TestRequestConfig {
         Assert.assertEquals(false, config.isRedirectsEnabled());
         Assert.assertEquals(true, config.isCircularRedirectsAllowed());
         Assert.assertEquals(100, config.getMaxRedirects());
-        Assert.assertEquals(CookieSpecs.STANDARD.ident, config.getCookieSpec());
+        Assert.assertEquals(CookieSpecs.STANDARD.id, config.getCookieSpec());
         Assert.assertEquals(new HttpHost("someproxy"), config.getProxy());
-        Assert.assertEquals(Collections.singletonList(AuthSchemes.NTLM.ident), config.getTargetPreferredAuthSchemes());
-        Assert.assertEquals(Collections.singletonList(AuthSchemes.DIGEST.ident), config.getProxyPreferredAuthSchemes());
+        Assert.assertEquals(Collections.singletonList(AuthSchemes.NTLM.id), config.getTargetPreferredAuthSchemes());
+        Assert.assertEquals(Collections.singletonList(AuthSchemes.DIGEST.id), config.getProxyPreferredAuthSchemes());
         Assert.assertEquals(false, config.isContentCompressionEnabled());
     }
 

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClientConfiguration.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClientConfiguration.java
@@ -193,10 +193,10 @@ public class ClientConfiguration {
         final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
         // Create global request configuration
         final RequestConfig defaultRequestConfig = RequestConfig.custom()
-            .setCookieSpec(CookieSpecs.STANDARD.ident)
+            .setCookieSpec(CookieSpecs.STANDARD.id)
             .setExpectContinueEnabled(true)
-            .setTargetPreferredAuthSchemes(Arrays.asList(AuthSchemes.NTLM.ident, AuthSchemes.DIGEST.ident))
-            .setProxyPreferredAuthSchemes(Arrays.asList(AuthSchemes.BASIC.ident))
+            .setTargetPreferredAuthSchemes(Arrays.asList(AuthSchemes.NTLM.id, AuthSchemes.DIGEST.id))
+            .setProxyPreferredAuthSchemes(Arrays.asList(AuthSchemes.BASIC.id))
             .build();
 
         // Create an HttpClient with the given custom dependencies and configuration.

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClientCustomPublicSuffixList.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClientCustomPublicSuffixList.java
@@ -63,8 +63,8 @@ public class ClientCustomPublicSuffixList {
 
         final RFC6265CookieSpecProvider cookieSpecProvider = new RFC6265CookieSpecProvider(publicSuffixMatcher);
         final Lookup<CookieSpecProvider> cookieSpecRegistry = RegistryBuilder.<CookieSpecProvider>create()
-                .register(CookieSpecs.STANDARD.ident, cookieSpecProvider)
-                .register(CookieSpecs.STANDARD_STRICT.ident, cookieSpecProvider)
+                .register(CookieSpecs.STANDARD.id, cookieSpecProvider)
+                .register(CookieSpecs.STANDARD_STRICT.id, cookieSpecProvider)
                 .build();
         final SSLConnectionSocketFactory sslsf = new SSLConnectionSocketFactory(
                 SSLContexts.createDefault(),

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/TestAuthenticationStrategy.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/TestAuthenticationStrategy.java
@@ -130,7 +130,7 @@ public class TestAuthenticationStrategy {
     public void testCustomAuthPreference() throws Exception {
         final DefaultAuthenticationStrategy authStrategy = new DefaultAuthenticationStrategy();
         final RequestConfig config = RequestConfig.custom()
-            .setTargetPreferredAuthSchemes(Collections.singletonList(AuthSchemes.BASIC.ident))
+            .setTargetPreferredAuthSchemes(Collections.singletonList(AuthSchemes.BASIC.id))
             .build();
 
         final HttpClientContext context = HttpClientContext.create();

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestHttpAuthenticator.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestHttpAuthenticator.java
@@ -69,7 +69,7 @@ public class TestHttpAuthenticator {
 
         @Override
         public String getName() {
-            return AuthSchemes.BASIC.ident;
+            return AuthSchemes.BASIC.id;
         }
 
     }

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/protocol/TestRequestAddCookies.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/protocol/TestRequestAddCookies.java
@@ -76,11 +76,11 @@ public class TestRequestAddCookies {
         this.cookieStore.addCookie(cookie2);
 
         this.cookieSpecRegistry = RegistryBuilder.<CookieSpecProvider>create()
-            .register(CookieSpecs.STANDARD.ident, new RFC6265CookieSpecProvider(
+            .register(CookieSpecs.STANDARD.id, new RFC6265CookieSpecProvider(
                     RFC6265CookieSpecProvider.CompatibilityLevel.RELAXED, null))
-            .register(CookieSpecs.STANDARD_STRICT.ident,  new RFC6265CookieSpecProvider(
+            .register(CookieSpecs.STANDARD_STRICT.id,  new RFC6265CookieSpecProvider(
                     RFC6265CookieSpecProvider.CompatibilityLevel.STRICT, null))
-            .register(CookieSpecs.IGNORE_COOKIES.ident, new IgnoreSpecProvider())
+            .register(CookieSpecs.IGNORE_COOKIES.id, new IgnoreSpecProvider())
             .build();
     }
 
@@ -203,7 +203,7 @@ public class TestRequestAddCookies {
     public void testAddCookiesUsingExplicitCookieSpec() throws Exception {
         final HttpRequest request = new BasicHttpRequest("GET", "/");
         final RequestConfig config = RequestConfig.custom()
-                .setCookieSpec(CookieSpecs.STANDARD_STRICT.ident)
+                .setCookieSpec(CookieSpecs.STANDARD_STRICT.id)
                 .build();
         final HttpRoute route = new HttpRoute(this.target, null, false);
 


### PR DESCRIPTION
As with HttpCore an entity should have a consistent id field, named 'id'
throughout the entire codebase.

@garydgregory This is what we have been talking about this month. Consistent id names as in HttpCore.