### PR TITLE
Consistent use AuthSchemes#id

### DIFF
--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestCachingExecChain.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestCachingExecChain.java
@@ -50,6 +50,7 @@ import java.util.List;
 
 import org.apache.hc.client5.http.HttpRoute;
 import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
+import org.apache.hc.client5.http.auth.AuthSchemes;
 import org.apache.hc.client5.http.cache.CacheResponseStatus;
 import org.apache.hc.client5.http.cache.HttpCacheContext;
 import org.apache.hc.client5.http.cache.HttpCacheEntry;
@@ -737,9 +738,9 @@ public abstract class TestCachingExecChain {
             .setSharedCache(true).build());
         final Date now = new Date();
         final ClassicHttpRequest req1 = new HttpOptions("http://foo.example.com/");
-        req1.setHeader("Authorization", "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
+        req1.setHeader("Authorization", AuthSchemes.BASIC.id + " QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
         final ClassicHttpRequest req2 = new HttpGet("http://foo.example.com/");
-        req2.setHeader("Authorization", "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
+        req2.setHeader("Authorization", AuthSchemes.BASIC.id + " QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
         final ClassicHttpResponse resp1 = new BasicClassicHttpResponse(HttpStatus.SC_NO_CONTENT, "No Content");
         resp1.setHeader("Content-Length", "0");
         resp1.setHeader("ETag", "\"options-etag\"");

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestProtocolRecommendations.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestProtocolRecommendations.java
@@ -38,6 +38,7 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 
+import org.apache.hc.client5.http.auth.AuthSchemes;
 import org.apache.hc.client5.http.classic.ExecChain;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
@@ -611,7 +612,7 @@ public class TestProtocolRecommendations extends AbstractProtocolTest {
 
     @Test
     public void testDoesNotModifyAuthorizationOnRequests() throws Exception {
-        request.setHeader("Authorization", "Basic dXNlcjpwYXNzd2Q=");
+        request.setHeader("Authorization", AuthSchemes.BASIC.id + " dXNlcjpwYXNzd2Q=");
         testDoesNotModifyHeaderOnRequests("Authorization");
     }
 

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestProtocolRequirements.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestProtocolRequirements.java
@@ -37,6 +37,7 @@ import java.util.regex.Pattern;
 
 import org.apache.hc.client5.http.ClientProtocolException;
 import org.apache.hc.client5.http.HttpRoute;
+import org.apache.hc.client5.http.auth.AuthSchemes;
 import org.apache.hc.client5.http.cache.HttpCacheEntry;
 import org.apache.hc.client5.http.classic.ExecChain;
 import org.apache.hc.client5.http.utils.DateUtils;
@@ -4520,7 +4521,7 @@ public class TestProtocolRequirements extends AbstractProtocolTest {
     protected void testSharedCacheRevalidatesAuthorizedResponse(
             final ClassicHttpResponse authorizedResponse, final int minTimes, final int maxTimes) throws Exception {
         if (config.isSharedCache()) {
-            final String authorization = "Basic dXNlcjpwYXNzd2Q=";
+            final String authorization = AuthSchemes.BASIC.id + " dXNlcjpwYXNzd2Q=";
             final ClassicHttpRequest req1 = new BasicClassicHttpRequest("GET", "/");
             req1.setHeader("Authorization",authorization);
 
@@ -4584,8 +4585,8 @@ public class TestProtocolRequirements extends AbstractProtocolTest {
     protected void testSharedCacheMustUseNewRequestHeadersWhenRevalidatingAuthorizedResponse(
             final ClassicHttpResponse authorizedResponse) throws Exception {
         if (config.isSharedCache()) {
-            final String authorization1 = "Basic dXNlcjpwYXNzd2Q=";
-            final String authorization2 = "Basic dXNlcjpwYXNzd2Qy";
+            final String authorization1 = AuthSchemes.BASIC.id + " dXNlcjpwYXNzd2Q=";
+            final String authorization2 = AuthSchemes.BASIC.id + " dXNlcjpwYXNzd2Qy";
 
             final ClassicHttpRequest req1 = new BasicClassicHttpRequest("GET", "/");
             req1.setHeader("Authorization",authorization1);

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestResponseCachingPolicy.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestResponseCachingPolicy.java
@@ -29,6 +29,7 @@ package org.apache.hc.client5.http.impl.cache;
 import java.util.Date;
 import java.util.Random;
 
+import org.apache.hc.client5.http.auth.AuthSchemes;
 import org.apache.hc.client5.http.classic.methods.HttpOptions;
 import org.apache.hc.client5.http.utils.DateUtils;
 import org.apache.hc.core5.http.HttpRequest;
@@ -82,7 +83,7 @@ public class TestResponseCachingPolicy {
     @Test
     public void testResponsesToRequestsWithAuthorizationHeadersAreNotCacheableBySharedCache() {
         request = new BasicHttpRequest("GET","/");
-        request.setHeader("Authorization","Basic dXNlcjpwYXNzd2Q=");
+        request.setHeader("Authorization", AuthSchemes.BASIC.id + " dXNlcjpwYXNzd2Q=");
         Assert.assertFalse(policy.isResponseCacheable(request,response));
     }
 
@@ -90,14 +91,14 @@ public class TestResponseCachingPolicy {
     public void testResponsesToRequestsWithAuthorizationHeadersAreCacheableByNonSharedCache() {
         policy = new ResponseCachingPolicy(0, false, false, false);
         request = new BasicHttpRequest("GET","/");
-        request.setHeader("Authorization","Basic dXNlcjpwYXNzd2Q=");
+        request.setHeader("Authorization", AuthSchemes.BASIC.id + " dXNlcjpwYXNzd2Q=");
         Assert.assertTrue(policy.isResponseCacheable(request,response));
     }
 
     @Test
     public void testAuthorizedResponsesWithSMaxAgeAreCacheable() {
         request = new BasicHttpRequest("GET","/");
-        request.setHeader("Authorization","Basic dXNlcjpwYXNzd2Q=");
+        request.setHeader("Authorization", AuthSchemes.BASIC.id + " dXNlcjpwYXNzd2Q=");
         response.setHeader("Cache-Control","s-maxage=3600");
         Assert.assertTrue(policy.isResponseCacheable(request,response));
     }
@@ -105,7 +106,7 @@ public class TestResponseCachingPolicy {
     @Test
     public void testAuthorizedResponsesWithMustRevalidateAreCacheable() {
         request = new BasicHttpRequest("GET","/");
-        request.setHeader("Authorization","Basic dXNlcjpwYXNzd2Q=");
+        request.setHeader("Authorization", AuthSchemes.BASIC.id + " dXNlcjpwYXNzd2Q=");
         response.setHeader("Cache-Control","must-revalidate");
         Assert.assertTrue(policy.isResponseCacheable(request,response));
     }
@@ -113,7 +114,7 @@ public class TestResponseCachingPolicy {
     @Test
     public void testAuthorizedResponsesWithCacheControlPublicAreCacheable() {
         request = new BasicHttpRequest("GET","/");
-        request.setHeader("Authorization","Basic dXNlcjpwYXNzd2Q=");
+        request.setHeader("Authorization", AuthSchemes.BASIC.id + " dXNlcjpwYXNzd2Q=");
         response.setHeader("Cache-Control","public");
         Assert.assertTrue(policy.isResponseCacheable(request,response));
     }
@@ -121,7 +122,7 @@ public class TestResponseCachingPolicy {
     @Test
     public void testAuthorizedResponsesWithCacheControlMaxAgeAreNotCacheable() {
         request = new BasicHttpRequest("GET","/");
-        request.setHeader("Authorization","Basic dXNlcjpwYXNzd2Q=");
+        request.setHeader("Authorization", AuthSchemes.BASIC.id + " dXNlcjpwYXNzd2Q=");
         response.setHeader("Cache-Control","max-age=3600");
         Assert.assertFalse(policy.isResponseCacheable(request,response));
     }
@@ -142,7 +143,7 @@ public class TestResponseCachingPolicy {
     public void test206ResponseCodeIsNotCacheableUsingSharedPublicCache() {
         policy = new ResponseCachingPolicy(0, true, false, false);
 
-        request.setHeader("Authorization", "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
+        request.setHeader("Authorization", AuthSchemes.BASIC.id + " QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
         response.setCode(HttpStatus.SC_PARTIAL_CONTENT);
         response.setHeader("Cache-Control", "public");
         Assert.assertFalse(policy.isResponseCacheable(request, response));
@@ -413,7 +414,7 @@ public class TestResponseCachingPolicy {
     public void testVaryStarIsNotCacheableUsingSharedPublicCache() {
         policy = new ResponseCachingPolicy(0, true, false, false);
 
-        request.setHeader("Authorization", "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
+        request.setHeader("Authorization", AuthSchemes.BASIC.id + " QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
         response.setHeader("Cache-Control", "public");
         response.setHeader("Vary", "*");
         Assert.assertFalse(policy.isResponseCacheable(request, response));
@@ -445,7 +446,7 @@ public class TestResponseCachingPolicy {
         policy = new ResponseCachingPolicy(0, true, false, false);
 
         request = new HttpOptions("http://foo.example.com/");
-        request.setHeader("Authorization", "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
+        request.setHeader("Authorization", AuthSchemes.BASIC.id + " QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
         response.setCode(HttpStatus.SC_NO_CONTENT);
         response.setHeader("Cache-Control", "public");
 
@@ -470,7 +471,7 @@ public class TestResponseCachingPolicy {
     public void testResponsesWithMultipleAgeHeadersAreNotCacheableUsingSharedPublicCache() {
         policy = new ResponseCachingPolicy(0, true, false, false);
 
-        request.setHeader("Authorization", "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
+        request.setHeader("Authorization", AuthSchemes.BASIC.id + " QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
         response.setHeader("Cache-Control", "public");
         response.addHeader("Age", "3");
         response.addHeader("Age", "5");
@@ -488,7 +489,7 @@ public class TestResponseCachingPolicy {
     public void testResponsesWithMultipleDateHeadersAreNotCacheableUsingSharedPublicCache() {
         policy = new ResponseCachingPolicy(0, true, false, false);
 
-        request.setHeader("Authorization", "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
+        request.setHeader("Authorization", AuthSchemes.BASIC.id + " QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
         response.setHeader("Cache-Control", "public");
         response.addHeader("Date", DateUtils.formatDate(now));
         response.addHeader("Date", DateUtils.formatDate(sixSecondsAgo));
@@ -505,7 +506,7 @@ public class TestResponseCachingPolicy {
     public void testResponsesWithMalformedDateHeadersAreNotCacheableUsingSharedPublicCache() {
         policy = new ResponseCachingPolicy(0, true, false, false);
 
-        request.setHeader("Authorization", "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
+        request.setHeader("Authorization", AuthSchemes.BASIC.id + " QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
         response.setHeader("Cache-Control", "public");
         response.addHeader("Date", "garbage");
         Assert.assertFalse(policy.isResponseCacheable(request, response));
@@ -522,7 +523,7 @@ public class TestResponseCachingPolicy {
     public void testResponsesWithMultipleExpiresHeadersAreNotCacheableUsingSharedPublicCache() {
         policy = new ResponseCachingPolicy(0, true, false, false);
 
-        request.setHeader("Authorization", "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
+        request.setHeader("Authorization", AuthSchemes.BASIC.id + " QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
         response.setHeader("Cache-Control", "public");
         response.addHeader("Expires", DateUtils.formatDate(now));
         response.addHeader("Expires", DateUtils.formatDate(sixSecondsAgo));
@@ -545,7 +546,7 @@ public class TestResponseCachingPolicy {
     public void testResponseThatHasTooMuchContentIsNotCacheableUsingSharedPublicCache() {
         policy = new ResponseCachingPolicy(0, true, false, false);
 
-        request.setHeader("Authorization", "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
+        request.setHeader("Authorization", AuthSchemes.BASIC.id + " QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
         response.setHeader("Cache-Control", "public");
         response.setHeader("Content-Length", "9000");
         Assert.assertFalse(policy.isResponseCacheable(request, response));

--- a/httpclient5-testing/src/main/java/org/apache/hc/client5/testing/async/AuthenticatingAsyncDecorator.java
+++ b/httpclient5-testing/src/main/java/org/apache/hc/client5/testing/async/AuthenticatingAsyncDecorator.java
@@ -31,6 +31,7 @@ import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.apache.hc.client5.http.auth.AuthSchemes;
 import org.apache.hc.client5.testing.auth.Authenticator;
 import org.apache.hc.client5.testing.auth.BasicAuthTokenExtractor;
 import org.apache.hc.core5.http.ContentType;
@@ -95,7 +96,7 @@ public class AuthenticatingAsyncDecorator implements AsyncServerExchangeHandler 
         } else {
             final HttpResponse unauthorized = new BasicHttpResponse(HttpStatus.SC_UNAUTHORIZED);
             final String realm = authenticator.getRealm(authority, requestUri);
-            unauthorized.addHeader(HttpHeaders.WWW_AUTHENTICATE, "Basic realm=\"" + realm + "\"");
+            unauthorized.addHeader(HttpHeaders.WWW_AUTHENTICATE, AuthSchemes.BASIC.id + " realm=\"" + realm + "\"");
 
             customizeUnauthorizedResponse(unauthorized);
 

--- a/httpclient5-testing/src/main/java/org/apache/hc/client5/testing/auth/BasicAuthTokenExtractor.java
+++ b/httpclient5-testing/src/main/java/org/apache/hc/client5/testing/auth/BasicAuthTokenExtractor.java
@@ -52,7 +52,7 @@ public class BasicAuthTokenExtractor {
                     final BinaryDecoder codec = new Base64();
                     return new String(codec.decode(credsRaw), StandardCharsets.US_ASCII);
                 } catch (final DecoderException ex) {
-                    throw new ProtocolException("Malformed BASIC credentials");
+                    throw new ProtocolException("Malformed Basic credentials");
                 }
             }
         }

--- a/httpclient5-testing/src/main/java/org/apache/hc/client5/testing/auth/BasicAuthTokenExtractor.java
+++ b/httpclient5-testing/src/main/java/org/apache/hc/client5/testing/auth/BasicAuthTokenExtractor.java
@@ -32,6 +32,7 @@ import java.nio.charset.StandardCharsets;
 import org.apache.commons.codec.BinaryDecoder;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Base64;
+import org.apache.hc.client5.http.auth.AuthSchemes;
 import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.ProtocolException;
 
@@ -44,7 +45,7 @@ public class BasicAuthTokenExtractor {
                 throw new ProtocolException("Invalid challenge response: " + challengeResponse);
             }
             final String authscheme = challengeResponse.substring(0, i);
-            if (authscheme.equalsIgnoreCase("basic")) {
+            if (authscheme.equalsIgnoreCase(AuthSchemes.BASIC.id)) {
                 final String s = challengeResponse.substring(i + 1).trim();
                 try {
                     final byte[] credsRaw = s.getBytes(StandardCharsets.US_ASCII);

--- a/httpclient5-testing/src/main/java/org/apache/hc/client5/testing/classic/AuthenticatingDecorator.java
+++ b/httpclient5-testing/src/main/java/org/apache/hc/client5/testing/classic/AuthenticatingDecorator.java
@@ -29,6 +29,7 @@ package org.apache.hc.client5.testing.classic;
 
 import java.io.IOException;
 
+import org.apache.hc.client5.http.auth.AuthSchemes;
 import org.apache.hc.client5.testing.auth.Authenticator;
 import org.apache.hc.client5.testing.auth.BasicAuthTokenExtractor;
 import org.apache.hc.core5.http.ClassicHttpRequest;
@@ -83,7 +84,7 @@ public class AuthenticatingDecorator implements HttpServerRequestHandler {
         } else {
             final ClassicHttpResponse unauthorized = new BasicClassicHttpResponse(HttpStatus.SC_UNAUTHORIZED);
             final String realm = authenticator.getRealm(authority, requestUri);
-            unauthorized.addHeader(HttpHeaders.WWW_AUTHENTICATE, "Basic realm=\"" + realm + "\"");
+            unauthorized.addHeader(HttpHeaders.WWW_AUTHENTICATE, AuthSchemes.BASIC.id + " realm=\"" + realm + "\"");
             customizeUnauthorizedResponse(unauthorized);
             if (unauthorized.getEntity() == null) {
                 unauthorized.setEntity(new StringEntity("Unauthorized"));

--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/AbstractHttpAsyncClientAuthentication.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/AbstractHttpAsyncClientAuthentication.java
@@ -39,6 +39,7 @@ import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
 import org.apache.hc.client5.http.auth.AuthChallenge;
 import org.apache.hc.client5.http.auth.AuthScheme;
 import org.apache.hc.client5.http.auth.AuthSchemeProvider;
+import org.apache.hc.client5.http.auth.AuthSchemes;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.ChallengeType;
 import org.apache.hc.client5.http.auth.Credentials;
@@ -538,7 +539,7 @@ public abstract class AbstractHttpAsyncClientAuthentication<T extends CloseableH
 
                             @Override
                             protected void customizeUnauthorizedResponse(final HttpResponse unauthorized) {
-                                unauthorized.addHeader(HttpHeaders.WWW_AUTHENTICATE, "Digest realm=\"test realm\" invalid");
+                                unauthorized.addHeader(HttpHeaders.WWW_AUTHENTICATE, AuthSchemes.DIGEST.id + " realm=\"test realm\" invalid");
                             }
 
                         };

--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestClientAuthentication.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestClientAuthentication.java
@@ -39,6 +39,7 @@ import org.apache.hc.client5.http.auth.AuthCache;
 import org.apache.hc.client5.http.auth.AuthChallenge;
 import org.apache.hc.client5.http.auth.AuthScheme;
 import org.apache.hc.client5.http.auth.AuthSchemeProvider;
+import org.apache.hc.client5.http.auth.AuthSchemes;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.ChallengeType;
 import org.apache.hc.client5.http.auth.Credentials;
@@ -719,7 +720,7 @@ public class TestClientAuthentication extends LocalServerTestBase {
 
                             @Override
                             protected void customizeUnauthorizedResponse(final ClassicHttpResponse unauthorized) {
-                                unauthorized.addHeader(HttpHeaders.WWW_AUTHENTICATE, "Digest realm=\"test realm\" invalid");
+                                unauthorized.addHeader(HttpHeaders.WWW_AUTHENTICATE, AuthSchemes.DIGEST.id + " realm=\"test realm\" invalid");
                             }
 
                         };

--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestClientAuthenticationFakeNTLM.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestClientAuthenticationFakeNTLM.java
@@ -28,6 +28,7 @@ package org.apache.hc.client5.testing.sync;
 
 import java.io.IOException;
 
+import org.apache.hc.client5.http.auth.AuthSchemes;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.NTCredentials;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
@@ -60,7 +61,7 @@ public class TestClientAuthenticationFakeNTLM extends LocalServerTestBase {
                 final HttpContext context) throws HttpException, IOException {
             response.setCode(HttpStatus.SC_UNAUTHORIZED);
             response.setHeader("Connection", "Keep-Alive");
-            response.setHeader(HttpHeaders.WWW_AUTHENTICATE, "NTLM");
+            response.setHeader(HttpHeaders.WWW_AUTHENTICATE, AuthSchemes.NTLM.id);
         }
     }
 
@@ -92,7 +93,7 @@ public class TestClientAuthenticationFakeNTLM extends LocalServerTestBase {
         private final String authenticateHeaderValue;
 
         public NtlmType2MessageResponseHandler(final String type2Message) {
-            this.authenticateHeaderValue = "NTLM " + type2Message;
+            this.authenticateHeaderValue = AuthSchemes.NTLM.id + " " + type2Message;
         }
 
         @Override
@@ -103,7 +104,7 @@ public class TestClientAuthenticationFakeNTLM extends LocalServerTestBase {
             response.setCode(HttpStatus.SC_UNAUTHORIZED);
             response.setHeader("Connection", "Keep-Alive");
             if (!request.containsHeader(HttpHeaders.AUTHORIZATION)) {
-                response.setHeader(HttpHeaders.WWW_AUTHENTICATE, "NTLM");
+                response.setHeader(HttpHeaders.WWW_AUTHENTICATE, AuthSchemes.NTLM.id);
             } else {
                 response.setHeader(HttpHeaders.WWW_AUTHENTICATE, authenticateHeaderValue);
             }
@@ -163,7 +164,7 @@ public class TestClientAuthenticationFakeNTLM extends LocalServerTestBase {
         private final String authenticateHeaderValue;
 
         public NtlmType2MessageOnlyResponseHandler(final String type2Message) {
-            this.authenticateHeaderValue = "NTLM " + type2Message;
+            this.authenticateHeaderValue = AuthSchemes.NTLM.id + " " + type2Message;
         }
 
         @Override

--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestSPNegoScheme.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestSPNegoScheme.java
@@ -78,7 +78,7 @@ public class TestSPNegoScheme extends LocalServerTestBase {
                 final ClassicHttpResponse response,
                 final HttpContext context) throws HttpException, IOException {
             response.setCode(HttpStatus.SC_UNAUTHORIZED);
-            response.addHeader(new BasicHeader("WWW-Authenticate", "Negotiate blablabla"));
+            response.addHeader(new BasicHeader("WWW-Authenticate", AuthSchemes.SPNEGO.id + " blablabla"));
             response.addHeader(new BasicHeader("Connection", "Keep-Alive"));
             response.setEntity(new StringEntity("auth required "));
         }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/BasicScheme.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/BasicScheme.java
@@ -42,6 +42,7 @@ import java.util.Map;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.hc.client5.http.auth.AuthChallenge;
 import org.apache.hc.client5.http.auth.AuthScheme;
+import org.apache.hc.client5.http.auth.AuthSchemes;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.AuthStateCacheable;
 import org.apache.hc.client5.http.auth.AuthenticationException;
@@ -99,7 +100,7 @@ public class BasicScheme implements AuthScheme, Serializable {
 
     @Override
     public String getName() {
-        return "basic";
+        return AuthSchemes.BASIC.id;
     }
 
     @Override
@@ -173,7 +174,7 @@ public class BasicScheme implements AuthScheme, Serializable {
         }
         final byte[] encodedCreds = this.base64codec.encode(this.buffer.toByteArray());
         this.buffer.reset();
-        return "Basic " + new String(encodedCreds, 0, encodedCreds.length, StandardCharsets.US_ASCII);
+        return AuthSchemes.BASIC.id + " " + new String(encodedCreds, 0, encodedCreds.length, StandardCharsets.US_ASCII);
     }
 
     private void writeObject(final ObjectOutputStream out) throws IOException {

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/DigestScheme.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/DigestScheme.java
@@ -46,6 +46,7 @@ import java.util.StringTokenizer;
 
 import org.apache.hc.client5.http.auth.AuthChallenge;
 import org.apache.hc.client5.http.auth.AuthScheme;
+import org.apache.hc.client5.http.auth.AuthSchemes;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.AuthenticationException;
 import org.apache.hc.client5.http.utils.ByteArrayBuilder;
@@ -126,7 +127,7 @@ public class DigestScheme implements AuthScheme, Serializable {
 
     @Override
     public String getName() {
-        return "digest";
+        return AuthSchemes.DIGEST.id;
     }
 
     @Override
@@ -374,7 +375,7 @@ public class DigestScheme implements AuthScheme, Serializable {
         final String digest = formatHex(digester.digest(digestInput));
 
         final CharArrayBuffer buffer = new CharArrayBuffer(128);
-        buffer.append("Digest ");
+        buffer.append(AuthSchemes.DIGEST.id + " ");
 
         final List<BasicNameValuePair> params = new ArrayList<>(20);
         params.add(new BasicNameValuePair("username", username));

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/GGSSchemeBase.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/GGSSchemeBase.java
@@ -35,6 +35,7 @@ import org.apache.hc.client5.http.DnsResolver;
 import org.apache.hc.client5.http.SystemDefaultDnsResolver;
 import org.apache.hc.client5.http.auth.AuthChallenge;
 import org.apache.hc.client5.http.auth.AuthScheme;
+import org.apache.hc.client5.http.auth.AuthSchemes;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.AuthenticationException;
 import org.apache.hc.client5.http.auth.Credentials;
@@ -246,7 +247,7 @@ public abstract class GGSSchemeBase implements AuthScheme {
             if (log.isDebugEnabled()) {
                 log.debug("Sending response '" + tokenstr + "' back to the auth server");
             }
-            return "Negotiate " + tokenstr;
+            return AuthSchemes.SPNEGO.id + " " + tokenstr;
         default:
             throw new IllegalStateException("Illegal state: " + state);
         }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/KerberosScheme.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/KerberosScheme.java
@@ -34,7 +34,7 @@ import org.ietf.jgss.GSSException;
 import org.ietf.jgss.Oid;
 
 /**
- * KERBEROS authentication scheme.
+ * Kerberos authentication scheme.
  * <p>
  * Please note this class is considered experimental and may be discontinued or removed
  * in the future.

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/KerberosScheme.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/KerberosScheme.java
@@ -27,6 +27,7 @@
 package org.apache.hc.client5.http.impl.auth;
 
 import org.apache.hc.client5.http.DnsResolver;
+import org.apache.hc.client5.http.auth.AuthSchemes;
 import org.apache.hc.client5.http.auth.KerberosConfig;
 import org.apache.hc.core5.annotation.Experimental;
 import org.ietf.jgss.GSSException;
@@ -59,7 +60,7 @@ public class KerberosScheme extends GGSSchemeBase {
 
     @Override
     public String getName() {
-        return "Kerberos";
+        return AuthSchemes.KERBEROS.id;
     }
 
     @Override

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/NTLMScheme.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/NTLMScheme.java
@@ -30,6 +30,7 @@ import java.security.Principal;
 
 import org.apache.hc.client5.http.auth.AuthChallenge;
 import org.apache.hc.client5.http.auth.AuthScheme;
+import org.apache.hc.client5.http.auth.AuthSchemes;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.AuthenticationException;
 import org.apache.hc.client5.http.auth.Credentials;
@@ -80,7 +81,7 @@ public final class NTLMScheme implements AuthScheme {
 
     @Override
     public String getName() {
-        return "ntlm";
+        return AuthSchemes.NTLM.id;
     }
 
     @Override
@@ -168,7 +169,7 @@ public final class NTLMScheme implements AuthScheme {
         } else {
             throw new AuthenticationException("Unexpected state: " + this.state);
         }
-        return "NTLM " + response;
+        return AuthSchemes.NTLM.id + " " + response;
     }
 
     @Override

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/SPNegoScheme.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/SPNegoScheme.java
@@ -27,6 +27,7 @@
 package org.apache.hc.client5.http.impl.auth;
 
 import org.apache.hc.client5.http.DnsResolver;
+import org.apache.hc.client5.http.auth.AuthSchemes;
 import org.apache.hc.client5.http.auth.KerberosConfig;
 import org.apache.hc.core5.annotation.Experimental;
 import org.ietf.jgss.GSSException;
@@ -60,7 +61,7 @@ public class SPNegoScheme extends GGSSchemeBase {
 
     @Override
     public String getName() {
-        return "Negotiate";
+        return AuthSchemes.SPNEGO.id;
     }
 
     @Override

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/auth/TestAuthChallenge.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/auth/TestAuthChallenge.java
@@ -37,21 +37,21 @@ public class TestAuthChallenge {
 
     @Test
     public void testAuthChallengeWithValue() {
-        final AuthChallenge authChallenge = new AuthChallenge(ChallengeType.TARGET, "Basic", "blah", null);
-        Assert.assertEquals("Basic", authChallenge.getScheme());
+        final AuthChallenge authChallenge = new AuthChallenge(ChallengeType.TARGET, AuthSchemes.BASIC.id, "blah", null);
+        Assert.assertEquals(AuthSchemes.BASIC.id, authChallenge.getScheme());
         Assert.assertEquals("blah", authChallenge.getValue());
         Assert.assertEquals(null, authChallenge.getParams());
-        Assert.assertEquals("Basic blah", authChallenge.toString());
+        Assert.assertEquals(AuthSchemes.BASIC.id + " blah", authChallenge.toString());
     }
 
     @Test
     public void testAuthChallengeWithParams() {
-        final AuthChallenge authChallenge = new AuthChallenge(ChallengeType.TARGET, "Basic", null,
+        final AuthChallenge authChallenge = new AuthChallenge(ChallengeType.TARGET, AuthSchemes.BASIC.id, null,
                 Arrays.asList(new BasicNameValuePair("blah", "this"), new BasicNameValuePair("blah", "that")));
-        Assert.assertEquals("Basic", authChallenge.getScheme());
+        Assert.assertEquals(AuthSchemes.BASIC.id, authChallenge.getScheme());
         Assert.assertEquals(null, authChallenge.getValue());
         Assert.assertNotNull(authChallenge.getParams());
-        Assert.assertEquals("Basic [blah=this, blah=that]", authChallenge.toString());
+        Assert.assertEquals(AuthSchemes.BASIC.id + " [blah=this, blah=that]", authChallenge.toString());
     }
 
 }

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClientPreemptiveBasicAuthentication.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClientPreemptiveBasicAuthentication.java
@@ -38,7 +38,7 @@ import org.apache.hc.core5.http.io.entity.EntityUtils;
 
 /**
  * An example of how HttpClient can be customized to authenticate
- * preemptively using BASIC scheme.
+ * preemptively using Basic scheme.
  * <b/>
  * Generally, preemptive authentication can be considered less
  * secure than a response to an authentication challenge
@@ -49,7 +49,7 @@ public class ClientPreemptiveBasicAuthentication {
     public static void main(final String[] args) throws Exception {
         try (final CloseableHttpClient httpclient = HttpClients.createDefault()) {
 
-            // Generate BASIC scheme object and add it to the local auth cache
+            // Generate Basic scheme object and add it to the local auth cache
             final BasicScheme basicAuth = new BasicScheme();
             basicAuth.initPreemptive(new UsernamePasswordCredentials("user", "passwd".toCharArray()));
 

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClientPreemptiveDigestAuthentication.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClientPreemptiveDigestAuthentication.java
@@ -42,9 +42,9 @@ import org.apache.hc.core5.http.io.entity.EntityUtils;
 
 /**
  * An example of how HttpClient can authenticate multiple requests
- * using the same DIGEST scheme. After the initial request / response exchange
+ * using the same Digest scheme. After the initial request / response exchange
  * all subsequent requests sharing the same execution context can re-use
- * the last DIGEST nonce value to authenticate with the server.
+ * the last Digest nonce value to authenticate with the server.
  */
 public class ClientPreemptiveDigestAuthentication {
 

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/TestAuthenticationStrategy.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/TestAuthenticationStrategy.java
@@ -29,6 +29,7 @@ package org.apache.hc.client5.http.impl;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.apache.hc.client5.http.auth.AuthChallenge;
@@ -84,9 +85,9 @@ public class TestAuthenticationStrategy {
         final HttpClientContext context = HttpClientContext.create();
 
         final Map<String, AuthChallenge> challenges = new HashMap<>();
-        challenges.put("basic", new AuthChallenge(ChallengeType.TARGET, "Basic",
+        challenges.put(AuthSchemes.BASIC.id, new AuthChallenge(ChallengeType.TARGET, AuthSchemes.BASIC.id,
                 new BasicNameValuePair("realm", "test")));
-        challenges.put("digest", new AuthChallenge(ChallengeType.TARGET, "Digest",
+        challenges.put(AuthSchemes.DIGEST.id, new AuthChallenge(ChallengeType.TARGET, AuthSchemes.DIGEST.id,
                 new BasicNameValuePair("realm", "test"), new BasicNameValuePair("nonce", "1234")));
 
         final List<AuthScheme> authSchemes = authStrategy.select(ChallengeType.TARGET, challenges, context);
@@ -100,16 +101,16 @@ public class TestAuthenticationStrategy {
         final HttpClientContext context = HttpClientContext.create();
 
         final Map<String, AuthChallenge> challenges = new HashMap<>();
-        challenges.put("basic", new AuthChallenge(ChallengeType.TARGET, "Basic",
+        challenges.put(AuthSchemes.BASIC.id.toLowerCase(Locale.ROOT), new AuthChallenge(ChallengeType.TARGET, AuthSchemes.BASIC.id,
                 new BasicNameValuePair("realm", "realm1")));
-        challenges.put("digest", new AuthChallenge(ChallengeType.TARGET, "Digest",
+        challenges.put(AuthSchemes.DIGEST.id.toLowerCase(Locale.ROOT), new AuthChallenge(ChallengeType.TARGET, AuthSchemes.DIGEST.id,
                 new BasicNameValuePair("realm", "realm2"), new BasicNameValuePair("nonce", "1234")));
         challenges.put("whatever", new AuthChallenge(ChallengeType.TARGET, "Whatever",
                 new BasicNameValuePair("realm", "realm3")));
 
         final Registry<AuthSchemeProvider> authSchemeRegistry = RegistryBuilder.<AuthSchemeProvider>create()
-            .register("basic", new BasicSchemeFactory())
-            .register("digest", new DigestSchemeFactory()).build();
+            .register(AuthSchemes.BASIC.id, new BasicSchemeFactory())
+            .register(AuthSchemes.DIGEST.id, new DigestSchemeFactory()).build();
         context.setAuthSchemeRegistry(authSchemeRegistry);
 
         final BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
@@ -136,14 +137,14 @@ public class TestAuthenticationStrategy {
         final HttpClientContext context = HttpClientContext.create();
 
         final Map<String, AuthChallenge> challenges = new HashMap<>();
-        challenges.put("basic", new AuthChallenge(ChallengeType.TARGET, "Basic",
+        challenges.put(AuthSchemes.BASIC.id.toLowerCase(Locale.ROOT), new AuthChallenge(ChallengeType.TARGET, AuthSchemes.BASIC.id,
                 new BasicNameValuePair("realm", "realm1")));
-        challenges.put("digest", new AuthChallenge(ChallengeType.TARGET, "Digest",
+        challenges.put(AuthSchemes.DIGEST.id.toLowerCase(Locale.ROOT), new AuthChallenge(ChallengeType.TARGET, AuthSchemes.DIGEST.id,
                 new BasicNameValuePair("realm", "realm2"), new BasicNameValuePair("nonce", "1234")));
 
         final Registry<AuthSchemeProvider> authSchemeRegistry = RegistryBuilder.<AuthSchemeProvider>create()
-            .register("basic", new BasicSchemeFactory())
-            .register("digest", new DigestSchemeFactory()).build();
+            .register(AuthSchemes.BASIC.id, new BasicSchemeFactory())
+            .register(AuthSchemes.DIGEST.id, new DigestSchemeFactory()).build();
         context.setAuthSchemeRegistry(authSchemeRegistry);
         context.setRequestConfig(config);
 

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestAuthChallengeParser.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestAuthChallengeParser.java
@@ -29,6 +29,7 @@ package org.apache.hc.client5.http.impl.auth;
 import java.util.List;
 
 import org.apache.hc.client5.http.auth.AuthChallenge;
+import org.apache.hc.client5.http.auth.AuthSchemes;
 import org.apache.hc.client5.http.auth.ChallengeType;
 import org.apache.hc.core5.http.NameValuePair;
 import org.apache.hc.core5.http.ParseException;
@@ -150,13 +151,13 @@ public class TestAuthChallengeParser {
     @Test
     public void testParseBasicAuthChallenge() throws Exception {
         final CharArrayBuffer buffer = new CharArrayBuffer(64);
-        buffer.append("Basic realm=blah");
+        buffer.append(AuthSchemes.BASIC.id + " realm=blah");
         final ParserCursor cursor = new ParserCursor(0, buffer.length());
         final List<AuthChallenge> challenges = parser.parse(ChallengeType.TARGET, buffer, cursor);
         Assert.assertNotNull(challenges);
         Assert.assertEquals(1, challenges.size());
         final AuthChallenge challenge1 = challenges.get(0);
-        Assert.assertEquals("Basic", challenge1.getScheme());
+        Assert.assertEquals(AuthSchemes.BASIC.id, challenge1.getScheme());
         Assert.assertEquals(null, challenge1.getValue());
         final List<NameValuePair> params = challenge1.getParams();
         Assert.assertNotNull(params);
@@ -167,13 +168,13 @@ public class TestAuthChallengeParser {
     @Test
     public void testParseAuthChallengeWithBlanks() throws Exception {
         final CharArrayBuffer buffer = new CharArrayBuffer(64);
-        buffer.append("   Basic  realm = blah   ");
+        buffer.append("   " + AuthSchemes.BASIC.id + "  realm = blah   ");
         final ParserCursor cursor = new ParserCursor(0, buffer.length());
         final List<AuthChallenge> challenges = parser.parse(ChallengeType.TARGET, buffer, cursor);
         Assert.assertNotNull(challenges);
         Assert.assertEquals(1, challenges.size());
         final AuthChallenge challenge1 = challenges.get(0);
-        Assert.assertEquals("Basic", challenge1.getScheme());
+        Assert.assertEquals(AuthSchemes.BASIC.id, challenge1.getScheme());
         Assert.assertEquals(null, challenge1.getValue());
         final List<NameValuePair> params = challenge1.getParams();
         Assert.assertNotNull(params);
@@ -205,15 +206,15 @@ public class TestAuthChallengeParser {
     @Test
     public void testParseMultipleAuthChallengeWithParams() throws Exception {
         final CharArrayBuffer buffer = new CharArrayBuffer(64);
-        buffer.append("Basic realm=blah, param1 = this, param2=that, " +
-                "Basic realm=\"\\\"yada\\\"\", this, that=,this-and-that  ");
+        buffer.append(AuthSchemes.BASIC.id + " realm=blah, param1 = this, param2=that, " +
+                AuthSchemes.BASIC.id + " realm=\"\\\"yada\\\"\", this, that=,this-and-that  ");
         final ParserCursor cursor = new ParserCursor(0, buffer.length());
         final List<AuthChallenge> challenges = parser.parse(ChallengeType.TARGET, buffer, cursor);
         Assert.assertNotNull(challenges);
         Assert.assertEquals(2, challenges.size());
 
         final AuthChallenge challenge1 = challenges.get(0);
-        Assert.assertEquals("Basic", challenge1.getScheme());
+        Assert.assertEquals(AuthSchemes.BASIC.id, challenge1.getScheme());
         Assert.assertEquals(null, challenge1.getValue());
         final List<NameValuePair> params1 = challenge1.getParams();
         Assert.assertNotNull(params1);
@@ -223,7 +224,7 @@ public class TestAuthChallengeParser {
         assertNameValuePair(new BasicNameValuePair("param2", "that"), params1.get(2));
 
         final AuthChallenge challenge2 = challenges.get(1);
-        Assert.assertEquals("Basic", challenge2.getScheme());
+        Assert.assertEquals(AuthSchemes.BASIC.id, challenge2.getScheme());
         Assert.assertEquals(null, challenge2.getValue());
         final List<NameValuePair> params2 = challenge2.getParams();
         Assert.assertNotNull(params2);

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestBasicCredentialsProvider.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestBasicCredentialsProvider.java
@@ -26,6 +26,7 @@
  */
 package org.apache.hc.client5.http.impl.auth;
 
+import org.apache.hc.client5.http.auth.AuthSchemes;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.Credentials;
 import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
@@ -141,15 +142,15 @@ public class TestBasicCredentialsProvider {
         state.setCredentials(scope2, creds2);
         state.setCredentials(scope3, creds3);
 
-        Credentials got = state.getCredentials(new AuthScope("http", "someotherhost", 80, "someotherrealm", "basic"), null);
+        Credentials got = state.getCredentials(new AuthScope("http", "someotherhost", 80, "someotherrealm", AuthSchemes.BASIC.id), null);
         Credentials expected = creds1;
         Assert.assertEquals(expected, got);
 
-        got = state.getCredentials(new AuthScope("http", "someotherhost", 80, "somerealm", "basic"), null);
+        got = state.getCredentials(new AuthScope("http", "someotherhost", 80, "somerealm", AuthSchemes.BASIC.id), null);
         expected = creds2;
         Assert.assertEquals(expected, got);
 
-        got = state.getCredentials(new AuthScope("http", "somehost", 80, "someotherrealm", "basic"), null);
+        got = state.getCredentials(new AuthScope("http", "somehost", 80, "someotherrealm", AuthSchemes.BASIC.id), null);
         expected = creds3;
         Assert.assertEquals(expected, got);
     }

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestBasicScheme.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestBasicScheme.java
@@ -36,6 +36,7 @@ import java.util.List;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.hc.client5.http.auth.AuthChallenge;
 import org.apache.hc.client5.http.auth.AuthScheme;
+import org.apache.hc.client5.http.auth.AuthSchemes;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.ChallengeType;
 import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
@@ -64,7 +65,7 @@ public class TestBasicScheme {
 
     @Test
     public void testBasicAuthenticationEmptyChallenge() throws Exception {
-        final String challenge = "Basic";
+        final String challenge = AuthSchemes.BASIC.id;
         final AuthChallenge authChallenge = parse(challenge);
         final AuthScheme authscheme = new BasicScheme();
         authscheme.processChallenge(authChallenge, null);
@@ -89,12 +90,12 @@ public class TestBasicScheme {
         Assert.assertTrue(authscheme.isResponseReady(host, credentialsProvider, null));
         final HttpRequest request = new BasicHttpRequest("GET", "/");
         final String authResponse = authscheme.generateAuthResponse(host, request, null);
-        Assert.assertEquals("Basic ZGg65C32Lfw=", authResponse);
+        Assert.assertEquals(AuthSchemes.BASIC.id + " ZGg65C32Lfw=", authResponse);
     }
 
     @Test
     public void testBasicAuthentication() throws Exception {
-        final AuthChallenge authChallenge = parse("Basic realm=\"test\"");
+        final AuthChallenge authChallenge = parse(AuthSchemes.BASIC.id + " realm=\"test\"");
 
         final BasicScheme authscheme = new BasicScheme();
         authscheme.processChallenge(authChallenge, null);
@@ -109,7 +110,7 @@ public class TestBasicScheme {
         Assert.assertTrue(authscheme.isResponseReady(host, credentialsProvider, null));
         final String authResponse = authscheme.generateAuthResponse(host, request, null);
 
-        final String expected = "Basic " + new String(
+        final String expected = AuthSchemes.BASIC.id + " " + new String(
                 Base64.encodeBase64("testuser:testpass".getBytes(StandardCharsets.US_ASCII)),
                 StandardCharsets.US_ASCII);
         Assert.assertEquals(expected, authResponse);
@@ -120,7 +121,7 @@ public class TestBasicScheme {
 
     @Test
     public void testBasicProxyAuthentication() throws Exception {
-        final AuthChallenge authChallenge = parse("Basic realm=\"test\"");
+        final AuthChallenge authChallenge = parse(AuthSchemes.BASIC.id + " realm=\"test\"");
 
         final BasicScheme authscheme = new BasicScheme();
         authscheme.processChallenge(authChallenge, null);
@@ -135,7 +136,7 @@ public class TestBasicScheme {
         Assert.assertTrue(authscheme.isResponseReady(host, credentialsProvider, null));
         final String authResponse = authscheme.generateAuthResponse(host, request, null);
 
-        final String expected = "Basic " + new String(
+        final String expected = AuthSchemes.BASIC.id + " " + new String(
                 Base64.encodeBase64("testuser:testpass".getBytes(StandardCharsets.US_ASCII)),
                 StandardCharsets.US_ASCII);
         Assert.assertEquals(expected, authResponse);
@@ -146,7 +147,7 @@ public class TestBasicScheme {
 
     @Test
     public void testSerialization() throws Exception {
-        final AuthChallenge authChallenge = parse("Basic realm=\"test\"");
+        final AuthChallenge authChallenge = parse(AuthSchemes.BASIC.id + " realm=\"test\"");
 
         final BasicScheme basicScheme = new BasicScheme();
         basicScheme.processChallenge(authChallenge, null);

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestDigestScheme.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestDigestScheme.java
@@ -39,6 +39,7 @@ import java.util.Map;
 
 import org.apache.hc.client5.http.auth.AuthChallenge;
 import org.apache.hc.client5.http.auth.AuthScheme;
+import org.apache.hc.client5.http.auth.AuthSchemes;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.AuthenticationException;
 import org.apache.hc.client5.http.auth.ChallengeType;
@@ -77,14 +78,14 @@ public class TestDigestScheme {
 
     @Test(expected=MalformedChallengeException.class)
     public void testDigestAuthenticationEmptyChallenge1() throws Exception {
-        final AuthChallenge authChallenge = parse("Digest");
+        final AuthChallenge authChallenge = parse(AuthSchemes.DIGEST.id);
         final AuthScheme authscheme = new DigestScheme();
         authscheme.processChallenge(authChallenge, null);
     }
 
     @Test(expected=MalformedChallengeException.class)
     public void testDigestAuthenticationEmptyChallenge2() throws Exception {
-        final AuthChallenge authChallenge = parse("Digest ");
+        final AuthChallenge authChallenge = parse(AuthSchemes.DIGEST.id + " ");
         final AuthScheme authscheme = new DigestScheme();
         authscheme.processChallenge(authChallenge, null);
     }
@@ -98,7 +99,7 @@ public class TestDigestScheme {
         final Credentials creds = new UsernamePasswordCredentials("username","password".toCharArray());
         credentialsProvider.setCredentials(authScope, creds);
 
-        final String challenge = "Digest realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\"";
+        final String challenge = AuthSchemes.DIGEST.id + " realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\"";
         final AuthChallenge authChallenge = parse(challenge);
         final DigestScheme authscheme = new DigestScheme();
         authscheme.processChallenge(authChallenge, null);
@@ -125,7 +126,7 @@ public class TestDigestScheme {
         final Credentials creds = new UsernamePasswordCredentials("username","password".toCharArray());
         credentialsProvider.setCredentials(authScope, creds);
 
-        final String challenge = "Digest realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\"";
+        final String challenge = AuthSchemes.DIGEST.id + " realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\"";
         final AuthChallenge authChallenge = parse(challenge);
         final DigestScheme authscheme = new DigestScheme();
         authscheme.processChallenge(authChallenge, null);
@@ -149,7 +150,7 @@ public class TestDigestScheme {
         final Credentials creds = new UsernamePasswordCredentials("username","password".toCharArray());
         credentialsProvider.setCredentials(authScope, creds);
 
-        final String challenge = "Digest realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\"";
+        final String challenge = AuthSchemes.DIGEST.id + " realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\"";
         final AuthChallenge authChallenge = parse(challenge);
         final DigestScheme authscheme = new DigestScheme();
         authscheme.processChallenge(authChallenge, null);
@@ -180,7 +181,7 @@ public class TestDigestScheme {
         final Credentials creds = new UsernamePasswordCredentials("username","password".toCharArray());
         credentialsProvider.setCredentials(authScope, creds);
 
-        final String challenge = "Digest realm=\"realm1\", " +
+        final String challenge = AuthSchemes.DIGEST.id + " realm=\"realm1\", " +
                 "nonce=\"f2a3f18799759d4f1a1c068b92b573cb\", " +
                 "algorithm=SHA";
         final AuthChallenge authChallenge = parse(challenge);
@@ -207,7 +208,7 @@ public class TestDigestScheme {
         final Credentials creds = new UsernamePasswordCredentials("username","password".toCharArray());
         credentialsProvider.setCredentials(authScope, creds);
 
-        final String challenge = "Digest realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\"";
+        final String challenge = AuthSchemes.DIGEST.id + " realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\"";
         final AuthChallenge authChallenge = parse(challenge);
         final DigestScheme authscheme = new DigestScheme();
         authscheme.processChallenge(authChallenge, null);
@@ -232,7 +233,7 @@ public class TestDigestScheme {
         final Credentials creds = new UsernamePasswordCredentials("username","password".toCharArray());
         credentialsProvider.setCredentials(authScope, creds);
 
-        final String challenge = "Digest no-realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\"";
+        final String challenge = AuthSchemes.DIGEST.id + " no-realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\"";
         final AuthChallenge authChallenge = parse(challenge);
         final DigestScheme authscheme = new DigestScheme();
         authscheme.processChallenge(authChallenge, null);
@@ -250,7 +251,7 @@ public class TestDigestScheme {
         final Credentials creds = new UsernamePasswordCredentials("username","password".toCharArray());
         credentialsProvider.setCredentials(authScope, creds);
 
-        final String challenge = "Digest realm=\"realm1\", no-nonce=\"f2a3f18799759d4f1a1c068b92b573cb\"";
+        final String challenge = AuthSchemes.DIGEST.id + " realm=\"realm1\", no-nonce=\"f2a3f18799759d4f1a1c068b92b573cb\"";
         final AuthChallenge authChallenge = parse(challenge);
         final DigestScheme authscheme = new DigestScheme();
         authscheme.processChallenge(authChallenge, null);
@@ -278,7 +279,7 @@ public class TestDigestScheme {
         final Credentials creds = new UsernamePasswordCredentials(username, password.toCharArray());
         credentialsProvider.setCredentials(authScope, creds);
 
-        final String challenge="Digest realm=\"" + realm + "\", "
+        final String challenge=AuthSchemes.DIGEST.id + " realm=\"" + realm + "\", "
             + "nonce=\"" + nonce + "\", "
             + "opaque=\"SomeString\", "
             + "stale=false, "
@@ -329,7 +330,7 @@ public class TestDigestScheme {
         final Credentials creds = new UsernamePasswordCredentials(username, password.toCharArray());
         credentialsProvider.setCredentials(authScope, creds);
 
-        final String challenge="Digest realm=\"" + realm + "\", "
+        final String challenge=AuthSchemes.DIGEST.id + " realm=\"" + realm + "\", "
             + "nonce=\"" + nonce + "\", "
             + "opaque=\"SomeString\", "
             + "stale=false, "
@@ -374,7 +375,7 @@ public class TestDigestScheme {
         final Credentials creds = new UsernamePasswordCredentials(username, password.toCharArray());
         credentialsProvider.setCredentials(authScope, creds);
 
-        final String challenge="Digest realm=\"" + realm + "\", "
+        final String challenge=AuthSchemes.DIGEST.id + " realm=\"" + realm + "\", "
             + "nonce=\"" + nonce + "\", "
             + "opaque=\"SomeString\", "
             + "stale=false, "
@@ -409,7 +410,7 @@ public class TestDigestScheme {
         final Credentials creds = new UsernamePasswordCredentials(username, password.toCharArray());
         credentialsProvider.setCredentials(authScope, creds);
 
-        final String challenge="Digest realm=\"" + realm + "\", "
+        final String challenge=AuthSchemes.DIGEST.id + " realm=\"" + realm + "\", "
             + "nonce=\"" + nonce + "\", "
             + "opaque=\"SomeString\", "
             + "stale=false, "
@@ -427,7 +428,7 @@ public class TestDigestScheme {
 
     @Test
     public void testDigestAuthenticationWithStaleNonce() throws Exception {
-        final String challenge = "Digest realm=\"realm1\", " +
+        final String challenge = AuthSchemes.DIGEST.id + " realm=\"realm1\", " +
                 "nonce=\"f2a3f18799759d4f1a1c068b92b573cb\", stale=\"true\"";
         final AuthChallenge authChallenge = parse(challenge);
         final AuthScheme authscheme = new DigestScheme();
@@ -437,7 +438,7 @@ public class TestDigestScheme {
     }
 
     private static Map<String, String> parseAuthResponse(final String authResponse) {
-        if (!authResponse.startsWith("Digest ")) {
+        if (!authResponse.startsWith(AuthSchemes.DIGEST.id + " ")) {
             return null;
         }
         final String s = authResponse.substring(7);
@@ -459,7 +460,7 @@ public class TestDigestScheme {
         final Credentials creds = new UsernamePasswordCredentials("username","password".toCharArray());
         credentialsProvider.setCredentials(authScope, creds);
 
-        final String challenge1 = "Digest realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\", qop=auth";
+        final String challenge1 = AuthSchemes.DIGEST.id + " realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\", qop=auth";
         final AuthChallenge authChallenge1 = parse(challenge1);
 
         final DigestScheme authscheme = new DigestScheme();
@@ -475,7 +476,7 @@ public class TestDigestScheme {
 
         final Map<String, String> table2 = parseAuthResponse(authResponse2);
         Assert.assertEquals("00000002", table2.get("nc"));
-        final String challenge2 = "Digest realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\", qop=auth";
+        final String challenge2 = AuthSchemes.DIGEST.id + " realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\", qop=auth";
         final AuthChallenge authChallenge2 = parse(challenge2);
         authscheme.processChallenge(authChallenge2, null);
 
@@ -484,7 +485,7 @@ public class TestDigestScheme {
 
         final Map<String, String> table3 = parseAuthResponse(authResponse3);
         Assert.assertEquals("00000003", table3.get("nc"));
-        final String challenge3 = "Digest realm=\"realm1\", nonce=\"e273f1776275974f1a120d8b92c5b3cb\", qop=auth";
+        final String challenge3 = AuthSchemes.DIGEST.id + " realm=\"realm1\", nonce=\"e273f1776275974f1a120d8b92c5b3cb\", qop=auth";
         final AuthChallenge authChallenge3 = parse(challenge3);
         authscheme.processChallenge(authChallenge3, null);
 
@@ -504,7 +505,7 @@ public class TestDigestScheme {
         final Credentials creds = new UsernamePasswordCredentials("username","password".toCharArray());
         credentialsProvider.setCredentials(authScope, creds);
 
-        final String challenge1 = "Digest qop=\"auth\", algorithm=MD5-sess, nonce=\"1234567890abcdef\", " +
+        final String challenge1 = AuthSchemes.DIGEST.id + " qop=\"auth\", algorithm=MD5-sess, nonce=\"1234567890abcdef\", " +
                 "charset=utf-8, realm=\"subnet.domain.com\"";
         final AuthChallenge authChallenge1 = parse(challenge1);
         final DigestScheme authscheme = new DigestScheme();
@@ -527,7 +528,7 @@ public class TestDigestScheme {
         Assert.assertEquals(cnonce1, cnonce2);
         Assert.assertEquals(sessionKey1, sessionKey2);
 
-        final String challenge2 = "Digest qop=\"auth\", algorithm=MD5-sess, nonce=\"1234567890abcdef\", " +
+        final String challenge2 = AuthSchemes.DIGEST.id + " qop=\"auth\", algorithm=MD5-sess, nonce=\"1234567890abcdef\", " +
             "charset=utf-8, realm=\"subnet.domain.com\"";
         final AuthChallenge authChallenge2 = parse(challenge2);
         authscheme.processChallenge(authChallenge2, null);
@@ -542,7 +543,7 @@ public class TestDigestScheme {
         Assert.assertEquals(cnonce1, cnonce3);
         Assert.assertEquals(sessionKey1, sessionKey3);
 
-        final String challenge3 = "Digest qop=\"auth\", algorithm=MD5-sess, nonce=\"fedcba0987654321\", " +
+        final String challenge3 = AuthSchemes.DIGEST.id + " qop=\"auth\", algorithm=MD5-sess, nonce=\"fedcba0987654321\", " +
             "charset=utf-8, realm=\"subnet.domain.com\"";
         final AuthChallenge authChallenge3 = parse(challenge3);
         authscheme.processChallenge(authChallenge3, null);
@@ -594,7 +595,7 @@ public class TestDigestScheme {
         final Credentials creds = new UsernamePasswordCredentials("username","password".toCharArray());
         credentialsProvider.setCredentials(authScope, creds);
 
-        final String challenge = "Digest realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\", " +
+        final String challenge = AuthSchemes.DIGEST.id + " realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\", " +
                 "qop=\"auth,auth-int\"";
         final AuthChallenge authChallenge = parse(challenge);
         final DigestScheme authscheme = new DigestScheme();
@@ -621,7 +622,7 @@ public class TestDigestScheme {
         final Credentials creds = new UsernamePasswordCredentials("username","password".toCharArray());
         credentialsProvider.setCredentials(authScope, creds);
 
-        final String challenge = "Digest realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\", " +
+        final String challenge = AuthSchemes.DIGEST.id + " realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\", " +
                 "qop=\"auth-int\"";
         final AuthChallenge authChallenge = parse(challenge);
         final DigestScheme authscheme = new DigestScheme();
@@ -649,7 +650,7 @@ public class TestDigestScheme {
         final Credentials creds = new UsernamePasswordCredentials("username","password".toCharArray());
         credentialsProvider.setCredentials(authScope, creds);
 
-        final String challenge = "Digest realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\", " +
+        final String challenge = AuthSchemes.DIGEST.id + " realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\", " +
                 "qop=\"auth,auth-int\"";
         final AuthChallenge authChallenge = parse(challenge);
         final DigestScheme authscheme = new DigestScheme();
@@ -676,7 +677,7 @@ public class TestDigestScheme {
         final Credentials creds = new UsernamePasswordCredentials("username","password".toCharArray());
         credentialsProvider.setCredentials(authScope, creds);
 
-        final String challenge = "Digest Realm=\"-\", " +
+        final String challenge = AuthSchemes.DIGEST.id + " Realm=\"-\", " +
                 "nonce=\"YjYuNGYyYmJhMzUuY2I5ZDhlZDE5M2ZlZDM 1Mjk3NGJkNTIyYjgyNTcwMjQ=\", " +
                 "opaque=\"98700A3D9CE17065E2246B41035C6609\", qop=\"auth\"";
         final AuthChallenge authChallenge = parse(challenge);
@@ -698,7 +699,7 @@ public class TestDigestScheme {
         final Credentials creds = new UsernamePasswordCredentials("username","password".toCharArray());
         credentialsProvider.setCredentials(authScope, creds);
 
-        final String challenge = "Digest realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\", " +
+        final String challenge = AuthSchemes.DIGEST.id + " realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\", " +
                 "qop=\"auth-int\"";
         final AuthChallenge authChallenge = parse(challenge);
         final DigestScheme authscheme = new DigestScheme();
@@ -710,7 +711,7 @@ public class TestDigestScheme {
 
     @Test
     public void testSerialization() throws Exception {
-        final String challenge = "Digest realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\", " +
+        final String challenge = AuthSchemes.DIGEST.id + " realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\", " +
                 "qop=\"auth,auth-int\"";
         final AuthChallenge authChallenge = parse(challenge);
         final DigestScheme digestScheme = new DigestScheme();

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestSystemDefaultCredentialsProvider.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestSystemDefaultCredentialsProvider.java
@@ -32,6 +32,7 @@ import java.net.InetAddress;
 import java.net.PasswordAuthentication;
 import java.net.URL;
 
+import org.apache.hc.client5.http.auth.AuthSchemes;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.Credentials;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
@@ -91,7 +92,7 @@ public class TestSystemDefaultCredentialsProvider {
         final AuthenticatorDelegate authenticatorDelegate = installAuthenticator(AUTH1);
 
         final URL httpRequestUrl = new URL(TARGET_SCHEME1, TARGET_HOST1, TARGET_PORT1, "/");
-        final AuthScope authScope = new AuthScope(PROXY_PROTOCOL1, PROXY_HOST1, PROXY_PORT1, PROMPT1, "BASIC");
+        final AuthScope authScope = new AuthScope(PROXY_PROTOCOL1, PROXY_HOST1, PROXY_PORT1, PROMPT1, AuthSchemes.BASIC.id);
         final HttpCoreContext coreContext = new HttpCoreContext();
         coreContext.setAttribute(HttpCoreContext.HTTP_REQUEST, new HttpGet(httpRequestUrl.toURI()));
 
@@ -99,7 +100,7 @@ public class TestSystemDefaultCredentialsProvider {
             new SystemDefaultCredentialsProvider().getCredentials(authScope, coreContext);
 
         Mockito.verify(authenticatorDelegate).getPasswordAuthentication(PROXY_HOST1, null, PROXY_PORT1, PROXY_PROTOCOL1,
-                                                                        PROMPT1, "Basic", httpRequestUrl,
+                                                                        PROMPT1, AuthSchemes.BASIC.id, httpRequestUrl,
                                                                         RequestorType.SERVER);
         Assert.assertNotNull(receivedCredentials);
         Assert.assertEquals(AUTH1.getUserName(), receivedCredentials.getUserPrincipal().getName());
@@ -111,13 +112,13 @@ public class TestSystemDefaultCredentialsProvider {
 
         final AuthenticatorDelegate authenticatorDelegate = installAuthenticator(AUTH1);
 
-        final AuthScope authScope = new AuthScope(PROXY_PROTOCOL1, PROXY_HOST1, PROXY_PORT1, PROMPT1, "BASIC");
+        final AuthScope authScope = new AuthScope(PROXY_PROTOCOL1, PROXY_HOST1, PROXY_PORT1, PROMPT1, AuthSchemes.BASIC.id);
 
         final Credentials receivedCredentials =
             new SystemDefaultCredentialsProvider().getCredentials(authScope, null);
 
         Mockito.verify(authenticatorDelegate).getPasswordAuthentication(PROXY_HOST1, null, PROXY_PORT1, PROXY_PROTOCOL1,
-                                                                        PROMPT1, "Basic", null,
+                                                                        PROMPT1, AuthSchemes.BASIC.id, null,
                                                                         RequestorType.SERVER);
         Assert.assertNotNull(receivedCredentials);
         Assert.assertEquals(AUTH1.getUserName(), receivedCredentials.getUserPrincipal().getName());

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/classic/TestConnectExec.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/classic/TestConnectExec.java
@@ -36,6 +36,7 @@ import org.apache.hc.client5.http.HttpRoute;
 import org.apache.hc.client5.http.RouteInfo;
 import org.apache.hc.client5.http.auth.AuthChallenge;
 import org.apache.hc.client5.http.auth.AuthScheme;
+import org.apache.hc.client5.http.auth.AuthSchemes;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.ChallengeType;
 import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
@@ -244,7 +245,7 @@ public class TestConnectExec {
         final HttpClientContext context = new HttpClientContext();
         final ClassicHttpRequest request = new HttpGet("http://bar/test");
         final ClassicHttpResponse response1 = new BasicClassicHttpResponse(407, "Huh?");
-        response1.setHeader(HttpHeaders.PROXY_AUTHENTICATE, "Basic realm=test");
+        response1.setHeader(HttpHeaders.PROXY_AUTHENTICATE, AuthSchemes.BASIC.id + " realm=test");
         final InputStream inStream1 = Mockito.spy(new ByteArrayInputStream(new byte[] {1, 2, 3}));
         response1.setEntity(EntityBuilder.create()
                 .setStream(inStream1)
@@ -285,7 +286,7 @@ public class TestConnectExec {
         final HttpClientContext context = new HttpClientContext();
         final ClassicHttpRequest request = new HttpGet("http://bar/test");
         final ClassicHttpResponse response1 = new BasicClassicHttpResponse(407, "Huh?");
-        response1.setHeader(HttpHeaders.PROXY_AUTHENTICATE, "Basic realm=test");
+        response1.setHeader(HttpHeaders.PROXY_AUTHENTICATE, AuthSchemes.BASIC.id + " realm=test");
         final InputStream inStream1 = Mockito.spy(new ByteArrayInputStream(new byte[] {1, 2, 3}));
         response1.setEntity(EntityBuilder.create()
                 .setStream(inStream1)

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/classic/TestProtocolExec.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/classic/TestProtocolExec.java
@@ -39,6 +39,7 @@ import org.apache.hc.client5.http.HttpRoute;
 import org.apache.hc.client5.http.auth.AuthChallenge;
 import org.apache.hc.client5.http.auth.AuthExchange;
 import org.apache.hc.client5.http.auth.AuthScheme;
+import org.apache.hc.client5.http.auth.AuthSchemes;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.ChallengeType;
 import org.apache.hc.client5.http.auth.Credentials;
@@ -213,7 +214,7 @@ public class TestProtocolExec {
         final HttpClientContext context = new HttpClientContext();
         final ClassicHttpRequest request = new HttpGet("http://foo/test");
         final ClassicHttpResponse response1 = new BasicClassicHttpResponse(401, "Huh?");
-        response1.setHeader(HttpHeaders.WWW_AUTHENTICATE, "Basic realm=test");
+        response1.setHeader(HttpHeaders.WWW_AUTHENTICATE, AuthSchemes.BASIC.id + " realm=test");
         final InputStream inStream1 = Mockito.spy(new ByteArrayInputStream(new byte[] {1, 2, 3}));
         response1.setEntity(EntityBuilder.create()
                 .setStream(inStream1)
@@ -252,7 +253,7 @@ public class TestProtocolExec {
         final HttpRoute route = new HttpRoute(target, proxy);
         final ClassicHttpRequest request = new HttpGet("http://foo/test");
         final ClassicHttpResponse response1 = new BasicClassicHttpResponse(401, "Huh?");
-        response1.setHeader(HttpHeaders.WWW_AUTHENTICATE, "Basic realm=test");
+        response1.setHeader(HttpHeaders.WWW_AUTHENTICATE, AuthSchemes.BASIC.id + " realm=test");
         final InputStream inStream1 = Mockito.spy(new ByteArrayInputStream(new byte[] {1, 2, 3}));
         response1.setEntity(EntityBuilder.create()
                 .setStream(inStream1)
@@ -304,7 +305,7 @@ public class TestProtocolExec {
                 .setStream(inStream0)
                 .build());
         final ClassicHttpResponse response1 = new BasicClassicHttpResponse(401, "Huh?");
-        response1.setHeader(HttpHeaders.WWW_AUTHENTICATE, "Basic realm=test");
+        response1.setHeader(HttpHeaders.WWW_AUTHENTICATE, AuthSchemes.BASIC.id + " realm=test");
         final InputStream inStream1 = new ByteArrayInputStream(new byte[] {1, 2, 3});
         response1.setEntity(EntityBuilder.create()
                 .setStream(inStream1)


### PR DESCRIPTION
Replace all literals with wellknown IDs we have defined for the schemes we support. It makes the entire codebase consistent.