### PR TITLE
[HTTPCLIENT-2042] AuthScope uses uppercase for scheme name whereas th…

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/auth/AuthScope.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/auth/AuthScope.java
@@ -75,7 +75,7 @@ public class AuthScope {
         this.host = host != null ? host.toLowerCase(Locale.ROOT) : null;
         this.port = port >= 0 ? port: -1;
         this.realm = realm;
-        this.authScheme = authScheme != null ? authScheme.toUpperCase(Locale.ROOT): null;
+        this.authScheme = authScheme != null ? authScheme.toLowerCase(Locale.ROOT): null;
     }
 
     /**
@@ -98,7 +98,7 @@ public class AuthScope {
         this.host = origin.getHostName().toLowerCase(Locale.ROOT);
         this.port = origin.getPort() >= 0 ? origin.getPort() : -1;
         this.realm = realm;
-        this.authScheme = schemeName != null ? schemeName.toUpperCase(Locale.ROOT): null;
+        this.authScheme = schemeName != null ? schemeName.toLowerCase(Locale.ROOT): null;
     }
 
     /**

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/SystemDefaultCredentialsProvider.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/SystemDefaultCredentialsProvider.java
@@ -32,6 +32,7 @@ import java.net.PasswordAuthentication;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -62,11 +63,11 @@ public class SystemDefaultCredentialsProvider implements CredentialsStore {
 
     static {
         SCHEME_MAP = new ConcurrentHashMap<>();
-        SCHEME_MAP.put(AuthSchemes.BASIC.name(), "Basic");
-        SCHEME_MAP.put(AuthSchemes.DIGEST.name(), "Digest");
-        SCHEME_MAP.put(AuthSchemes.NTLM.name(), "NTLM");
-        SCHEME_MAP.put(AuthSchemes.SPNEGO.name(), "SPNEGO");
-        SCHEME_MAP.put(AuthSchemes.KERBEROS.name(), "Kerberos");
+        SCHEME_MAP.put(AuthSchemes.BASIC.id.toLowerCase(Locale.ROOT), "Basic");
+        SCHEME_MAP.put(AuthSchemes.DIGEST.id.toLowerCase(Locale.ROOT), "Digest");
+        SCHEME_MAP.put(AuthSchemes.NTLM.id.toLowerCase(Locale.ROOT), "NTLM");
+        SCHEME_MAP.put(AuthSchemes.SPNEGO.id.toLowerCase(Locale.ROOT), "SPNEGO");
+        SCHEME_MAP.put(AuthSchemes.KERBEROS.id.toLowerCase(Locale.ROOT), "Kerberos");
     }
 
     private static String translateAuthScheme(final String key) {

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/auth/TestAuthScope.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/auth/TestAuthScope.java
@@ -38,12 +38,12 @@ public class TestAuthScope {
     @Test
     public void testBasics() {
         final AuthScope authscope = new AuthScope("http", "somehost", 80, "somerealm", "somescheme");
-        Assert.assertEquals("SOMESCHEME", authscope.getAuthScheme());
+        Assert.assertEquals("somescheme", authscope.getAuthScheme());
         Assert.assertEquals("http", authscope.getProtocol());
         Assert.assertEquals("somehost", authscope.getHost());
         Assert.assertEquals(80, authscope.getPort());
         Assert.assertEquals("somerealm", authscope.getRealm());
-        Assert.assertEquals("SOMESCHEME 'somerealm' http://somehost:80", authscope.toString());
+        Assert.assertEquals("somescheme 'somerealm' http://somehost:80", authscope.toString());
     }
 
     @Test


### PR DESCRIPTION
…e rest of the code uses the lowercase version

The auth scheme name is now consistently processed either in lowercse or
with String#equalsIgnoreCase().

@garydgregory @ok2c Please share your opinion. Another approach would also be to leave as-is because `AuthScheme#getName()` is retained as-is and lowercased where ever appropriate. That would be even better for consistency. Shall I rework the issue and PR then?