### PR TITLE
[HTTPCLIENT-2046] Rename enum AuthSchemes to StandardAuthScheme.

### DIFF
--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestCachingExecChain.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestCachingExecChain.java
@@ -50,7 +50,7 @@ import java.util.List;
 
 import org.apache.hc.client5.http.HttpRoute;
 import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
-import org.apache.hc.client5.http.auth.AuthSchemes;
+import org.apache.hc.client5.http.auth.StandardAuthScheme;
 import org.apache.hc.client5.http.cache.CacheResponseStatus;
 import org.apache.hc.client5.http.cache.HttpCacheContext;
 import org.apache.hc.client5.http.cache.HttpCacheEntry;
@@ -738,9 +738,9 @@ public abstract class TestCachingExecChain {
             .setSharedCache(true).build());
         final Date now = new Date();
         final ClassicHttpRequest req1 = new HttpOptions("http://foo.example.com/");
-        req1.setHeader("Authorization", AuthSchemes.BASIC.id + " QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
+        req1.setHeader("Authorization", StandardAuthScheme.BASIC.id + " QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
         final ClassicHttpRequest req2 = new HttpGet("http://foo.example.com/");
-        req2.setHeader("Authorization", AuthSchemes.BASIC.id + " QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
+        req2.setHeader("Authorization", StandardAuthScheme.BASIC.id + " QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
         final ClassicHttpResponse resp1 = new BasicClassicHttpResponse(HttpStatus.SC_NO_CONTENT, "No Content");
         resp1.setHeader("Content-Length", "0");
         resp1.setHeader("ETag", "\"options-etag\"");

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestProtocolRecommendations.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestProtocolRecommendations.java
@@ -38,7 +38,7 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 
-import org.apache.hc.client5.http.auth.AuthSchemes;
+import org.apache.hc.client5.http.auth.StandardAuthScheme;
 import org.apache.hc.client5.http.classic.ExecChain;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
@@ -612,7 +612,7 @@ public class TestProtocolRecommendations extends AbstractProtocolTest {
 
     @Test
     public void testDoesNotModifyAuthorizationOnRequests() throws Exception {
-        request.setHeader("Authorization", AuthSchemes.BASIC.id + " dXNlcjpwYXNzd2Q=");
+        request.setHeader("Authorization", StandardAuthScheme.BASIC.id + " dXNlcjpwYXNzd2Q=");
         testDoesNotModifyHeaderOnRequests("Authorization");
     }
 

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestProtocolRequirements.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestProtocolRequirements.java
@@ -37,7 +37,7 @@ import java.util.regex.Pattern;
 
 import org.apache.hc.client5.http.ClientProtocolException;
 import org.apache.hc.client5.http.HttpRoute;
-import org.apache.hc.client5.http.auth.AuthSchemes;
+import org.apache.hc.client5.http.auth.StandardAuthScheme;
 import org.apache.hc.client5.http.cache.HttpCacheEntry;
 import org.apache.hc.client5.http.classic.ExecChain;
 import org.apache.hc.client5.http.utils.DateUtils;
@@ -4521,7 +4521,7 @@ public class TestProtocolRequirements extends AbstractProtocolTest {
     protected void testSharedCacheRevalidatesAuthorizedResponse(
             final ClassicHttpResponse authorizedResponse, final int minTimes, final int maxTimes) throws Exception {
         if (config.isSharedCache()) {
-            final String authorization = AuthSchemes.BASIC.id + " dXNlcjpwYXNzd2Q=";
+            final String authorization = StandardAuthScheme.BASIC.id + " dXNlcjpwYXNzd2Q=";
             final ClassicHttpRequest req1 = new BasicClassicHttpRequest("GET", "/");
             req1.setHeader("Authorization",authorization);
 
@@ -4585,8 +4585,8 @@ public class TestProtocolRequirements extends AbstractProtocolTest {
     protected void testSharedCacheMustUseNewRequestHeadersWhenRevalidatingAuthorizedResponse(
             final ClassicHttpResponse authorizedResponse) throws Exception {
         if (config.isSharedCache()) {
-            final String authorization1 = AuthSchemes.BASIC.id + " dXNlcjpwYXNzd2Q=";
-            final String authorization2 = AuthSchemes.BASIC.id + " dXNlcjpwYXNzd2Qy";
+            final String authorization1 = StandardAuthScheme.BASIC.id + " dXNlcjpwYXNzd2Q=";
+            final String authorization2 = StandardAuthScheme.BASIC.id + " dXNlcjpwYXNzd2Qy";
 
             final ClassicHttpRequest req1 = new BasicClassicHttpRequest("GET", "/");
             req1.setHeader("Authorization",authorization1);

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestResponseCachingPolicy.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestResponseCachingPolicy.java
@@ -29,7 +29,7 @@ package org.apache.hc.client5.http.impl.cache;
 import java.util.Date;
 import java.util.Random;
 
-import org.apache.hc.client5.http.auth.AuthSchemes;
+import org.apache.hc.client5.http.auth.StandardAuthScheme;
 import org.apache.hc.client5.http.classic.methods.HttpOptions;
 import org.apache.hc.client5.http.utils.DateUtils;
 import org.apache.hc.core5.http.HttpRequest;
@@ -83,7 +83,7 @@ public class TestResponseCachingPolicy {
     @Test
     public void testResponsesToRequestsWithAuthorizationHeadersAreNotCacheableBySharedCache() {
         request = new BasicHttpRequest("GET","/");
-        request.setHeader("Authorization", AuthSchemes.BASIC.id + " dXNlcjpwYXNzd2Q=");
+        request.setHeader("Authorization", StandardAuthScheme.BASIC.id + " dXNlcjpwYXNzd2Q=");
         Assert.assertFalse(policy.isResponseCacheable(request,response));
     }
 
@@ -91,14 +91,14 @@ public class TestResponseCachingPolicy {
     public void testResponsesToRequestsWithAuthorizationHeadersAreCacheableByNonSharedCache() {
         policy = new ResponseCachingPolicy(0, false, false, false);
         request = new BasicHttpRequest("GET","/");
-        request.setHeader("Authorization", AuthSchemes.BASIC.id + " dXNlcjpwYXNzd2Q=");
+        request.setHeader("Authorization", StandardAuthScheme.BASIC.id + " dXNlcjpwYXNzd2Q=");
         Assert.assertTrue(policy.isResponseCacheable(request,response));
     }
 
     @Test
     public void testAuthorizedResponsesWithSMaxAgeAreCacheable() {
         request = new BasicHttpRequest("GET","/");
-        request.setHeader("Authorization", AuthSchemes.BASIC.id + " dXNlcjpwYXNzd2Q=");
+        request.setHeader("Authorization", StandardAuthScheme.BASIC.id + " dXNlcjpwYXNzd2Q=");
         response.setHeader("Cache-Control","s-maxage=3600");
         Assert.assertTrue(policy.isResponseCacheable(request,response));
     }
@@ -106,7 +106,7 @@ public class TestResponseCachingPolicy {
     @Test
     public void testAuthorizedResponsesWithMustRevalidateAreCacheable() {
         request = new BasicHttpRequest("GET","/");
-        request.setHeader("Authorization", AuthSchemes.BASIC.id + " dXNlcjpwYXNzd2Q=");
+        request.setHeader("Authorization", StandardAuthScheme.BASIC.id + " dXNlcjpwYXNzd2Q=");
         response.setHeader("Cache-Control","must-revalidate");
         Assert.assertTrue(policy.isResponseCacheable(request,response));
     }
@@ -114,7 +114,7 @@ public class TestResponseCachingPolicy {
     @Test
     public void testAuthorizedResponsesWithCacheControlPublicAreCacheable() {
         request = new BasicHttpRequest("GET","/");
-        request.setHeader("Authorization", AuthSchemes.BASIC.id + " dXNlcjpwYXNzd2Q=");
+        request.setHeader("Authorization", StandardAuthScheme.BASIC.id + " dXNlcjpwYXNzd2Q=");
         response.setHeader("Cache-Control","public");
         Assert.assertTrue(policy.isResponseCacheable(request,response));
     }
@@ -122,7 +122,7 @@ public class TestResponseCachingPolicy {
     @Test
     public void testAuthorizedResponsesWithCacheControlMaxAgeAreNotCacheable() {
         request = new BasicHttpRequest("GET","/");
-        request.setHeader("Authorization", AuthSchemes.BASIC.id + " dXNlcjpwYXNzd2Q=");
+        request.setHeader("Authorization", StandardAuthScheme.BASIC.id + " dXNlcjpwYXNzd2Q=");
         response.setHeader("Cache-Control","max-age=3600");
         Assert.assertFalse(policy.isResponseCacheable(request,response));
     }
@@ -143,7 +143,7 @@ public class TestResponseCachingPolicy {
     public void test206ResponseCodeIsNotCacheableUsingSharedPublicCache() {
         policy = new ResponseCachingPolicy(0, true, false, false);
 
-        request.setHeader("Authorization", AuthSchemes.BASIC.id + " QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
+        request.setHeader("Authorization", StandardAuthScheme.BASIC.id + " QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
         response.setCode(HttpStatus.SC_PARTIAL_CONTENT);
         response.setHeader("Cache-Control", "public");
         Assert.assertFalse(policy.isResponseCacheable(request, response));
@@ -414,7 +414,7 @@ public class TestResponseCachingPolicy {
     public void testVaryStarIsNotCacheableUsingSharedPublicCache() {
         policy = new ResponseCachingPolicy(0, true, false, false);
 
-        request.setHeader("Authorization", AuthSchemes.BASIC.id + " QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
+        request.setHeader("Authorization", StandardAuthScheme.BASIC.id + " QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
         response.setHeader("Cache-Control", "public");
         response.setHeader("Vary", "*");
         Assert.assertFalse(policy.isResponseCacheable(request, response));
@@ -446,7 +446,7 @@ public class TestResponseCachingPolicy {
         policy = new ResponseCachingPolicy(0, true, false, false);
 
         request = new HttpOptions("http://foo.example.com/");
-        request.setHeader("Authorization", AuthSchemes.BASIC.id + " QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
+        request.setHeader("Authorization", StandardAuthScheme.BASIC.id + " QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
         response.setCode(HttpStatus.SC_NO_CONTENT);
         response.setHeader("Cache-Control", "public");
 
@@ -471,7 +471,7 @@ public class TestResponseCachingPolicy {
     public void testResponsesWithMultipleAgeHeadersAreNotCacheableUsingSharedPublicCache() {
         policy = new ResponseCachingPolicy(0, true, false, false);
 
-        request.setHeader("Authorization", AuthSchemes.BASIC.id + " QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
+        request.setHeader("Authorization", StandardAuthScheme.BASIC.id + " QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
         response.setHeader("Cache-Control", "public");
         response.addHeader("Age", "3");
         response.addHeader("Age", "5");
@@ -489,7 +489,7 @@ public class TestResponseCachingPolicy {
     public void testResponsesWithMultipleDateHeadersAreNotCacheableUsingSharedPublicCache() {
         policy = new ResponseCachingPolicy(0, true, false, false);
 
-        request.setHeader("Authorization", AuthSchemes.BASIC.id + " QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
+        request.setHeader("Authorization", StandardAuthScheme.BASIC.id + " QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
         response.setHeader("Cache-Control", "public");
         response.addHeader("Date", DateUtils.formatDate(now));
         response.addHeader("Date", DateUtils.formatDate(sixSecondsAgo));
@@ -506,7 +506,7 @@ public class TestResponseCachingPolicy {
     public void testResponsesWithMalformedDateHeadersAreNotCacheableUsingSharedPublicCache() {
         policy = new ResponseCachingPolicy(0, true, false, false);
 
-        request.setHeader("Authorization", AuthSchemes.BASIC.id + " QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
+        request.setHeader("Authorization", StandardAuthScheme.BASIC.id + " QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
         response.setHeader("Cache-Control", "public");
         response.addHeader("Date", "garbage");
         Assert.assertFalse(policy.isResponseCacheable(request, response));
@@ -523,7 +523,7 @@ public class TestResponseCachingPolicy {
     public void testResponsesWithMultipleExpiresHeadersAreNotCacheableUsingSharedPublicCache() {
         policy = new ResponseCachingPolicy(0, true, false, false);
 
-        request.setHeader("Authorization", AuthSchemes.BASIC.id + " QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
+        request.setHeader("Authorization", StandardAuthScheme.BASIC.id + " QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
         response.setHeader("Cache-Control", "public");
         response.addHeader("Expires", DateUtils.formatDate(now));
         response.addHeader("Expires", DateUtils.formatDate(sixSecondsAgo));
@@ -546,7 +546,7 @@ public class TestResponseCachingPolicy {
     public void testResponseThatHasTooMuchContentIsNotCacheableUsingSharedPublicCache() {
         policy = new ResponseCachingPolicy(0, true, false, false);
 
-        request.setHeader("Authorization", AuthSchemes.BASIC.id + " QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
+        request.setHeader("Authorization", StandardAuthScheme.BASIC.id + " QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
         response.setHeader("Cache-Control", "public");
         response.setHeader("Content-Length", "9000");
         Assert.assertFalse(policy.isResponseCacheable(request, response));

--- a/httpclient5-testing/src/main/java/org/apache/hc/client5/testing/async/AuthenticatingAsyncDecorator.java
+++ b/httpclient5-testing/src/main/java/org/apache/hc/client5/testing/async/AuthenticatingAsyncDecorator.java
@@ -31,7 +31,7 @@ import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.apache.hc.client5.http.auth.AuthSchemes;
+import org.apache.hc.client5.http.auth.StandardAuthScheme;
 import org.apache.hc.client5.testing.auth.Authenticator;
 import org.apache.hc.client5.testing.auth.BasicAuthTokenExtractor;
 import org.apache.hc.core5.http.ContentType;
@@ -96,7 +96,7 @@ public class AuthenticatingAsyncDecorator implements AsyncServerExchangeHandler 
         } else {
             final HttpResponse unauthorized = new BasicHttpResponse(HttpStatus.SC_UNAUTHORIZED);
             final String realm = authenticator.getRealm(authority, requestUri);
-            unauthorized.addHeader(HttpHeaders.WWW_AUTHENTICATE, AuthSchemes.BASIC.id + " realm=\"" + realm + "\"");
+            unauthorized.addHeader(HttpHeaders.WWW_AUTHENTICATE, StandardAuthScheme.BASIC.id + " realm=\"" + realm + "\"");
 
             customizeUnauthorizedResponse(unauthorized);
 

--- a/httpclient5-testing/src/main/java/org/apache/hc/client5/testing/auth/BasicAuthTokenExtractor.java
+++ b/httpclient5-testing/src/main/java/org/apache/hc/client5/testing/auth/BasicAuthTokenExtractor.java
@@ -32,7 +32,7 @@ import java.nio.charset.StandardCharsets;
 import org.apache.commons.codec.BinaryDecoder;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Base64;
-import org.apache.hc.client5.http.auth.AuthSchemes;
+import org.apache.hc.client5.http.auth.StandardAuthScheme;
 import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.ProtocolException;
 
@@ -45,7 +45,7 @@ public class BasicAuthTokenExtractor {
                 throw new ProtocolException("Invalid challenge response: " + challengeResponse);
             }
             final String authscheme = challengeResponse.substring(0, i);
-            if (authscheme.equalsIgnoreCase(AuthSchemes.BASIC.id)) {
+            if (authscheme.equalsIgnoreCase(StandardAuthScheme.BASIC.id)) {
                 final String s = challengeResponse.substring(i + 1).trim();
                 try {
                     final byte[] credsRaw = s.getBytes(StandardCharsets.US_ASCII);

--- a/httpclient5-testing/src/main/java/org/apache/hc/client5/testing/classic/AuthenticatingDecorator.java
+++ b/httpclient5-testing/src/main/java/org/apache/hc/client5/testing/classic/AuthenticatingDecorator.java
@@ -29,7 +29,7 @@ package org.apache.hc.client5.testing.classic;
 
 import java.io.IOException;
 
-import org.apache.hc.client5.http.auth.AuthSchemes;
+import org.apache.hc.client5.http.auth.StandardAuthScheme;
 import org.apache.hc.client5.testing.auth.Authenticator;
 import org.apache.hc.client5.testing.auth.BasicAuthTokenExtractor;
 import org.apache.hc.core5.http.ClassicHttpRequest;
@@ -84,7 +84,7 @@ public class AuthenticatingDecorator implements HttpServerRequestHandler {
         } else {
             final ClassicHttpResponse unauthorized = new BasicClassicHttpResponse(HttpStatus.SC_UNAUTHORIZED);
             final String realm = authenticator.getRealm(authority, requestUri);
-            unauthorized.addHeader(HttpHeaders.WWW_AUTHENTICATE, AuthSchemes.BASIC.id + " realm=\"" + realm + "\"");
+            unauthorized.addHeader(HttpHeaders.WWW_AUTHENTICATE, StandardAuthScheme.BASIC.id + " realm=\"" + realm + "\"");
             customizeUnauthorizedResponse(unauthorized);
             if (unauthorized.getEntity() == null) {
                 unauthorized.setEntity(new StringEntity("Unauthorized"));

--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/AbstractHttpAsyncClientAuthentication.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/AbstractHttpAsyncClientAuthentication.java
@@ -39,7 +39,7 @@ import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
 import org.apache.hc.client5.http.auth.AuthChallenge;
 import org.apache.hc.client5.http.auth.AuthScheme;
 import org.apache.hc.client5.http.auth.AuthSchemeFactory;
-import org.apache.hc.client5.http.auth.AuthSchemes;
+import org.apache.hc.client5.http.auth.StandardAuthScheme;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.ChallengeType;
 import org.apache.hc.client5.http.auth.Credentials;
@@ -539,7 +539,7 @@ public abstract class AbstractHttpAsyncClientAuthentication<T extends CloseableH
 
                             @Override
                             protected void customizeUnauthorizedResponse(final HttpResponse unauthorized) {
-                                unauthorized.addHeader(HttpHeaders.WWW_AUTHENTICATE, AuthSchemes.DIGEST.id + " realm=\"test realm\" invalid");
+                                unauthorized.addHeader(HttpHeaders.WWW_AUTHENTICATE, StandardAuthScheme.DIGEST.id + " realm=\"test realm\" invalid");
                             }
 
                         };

--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestClientAuthentication.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestClientAuthentication.java
@@ -39,7 +39,7 @@ import org.apache.hc.client5.http.auth.AuthCache;
 import org.apache.hc.client5.http.auth.AuthChallenge;
 import org.apache.hc.client5.http.auth.AuthScheme;
 import org.apache.hc.client5.http.auth.AuthSchemeFactory;
-import org.apache.hc.client5.http.auth.AuthSchemes;
+import org.apache.hc.client5.http.auth.StandardAuthScheme;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.ChallengeType;
 import org.apache.hc.client5.http.auth.Credentials;
@@ -720,7 +720,7 @@ public class TestClientAuthentication extends LocalServerTestBase {
 
                             @Override
                             protected void customizeUnauthorizedResponse(final ClassicHttpResponse unauthorized) {
-                                unauthorized.addHeader(HttpHeaders.WWW_AUTHENTICATE, AuthSchemes.DIGEST.id + " realm=\"test realm\" invalid");
+                                unauthorized.addHeader(HttpHeaders.WWW_AUTHENTICATE, StandardAuthScheme.DIGEST.id + " realm=\"test realm\" invalid");
                             }
 
                         };

--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestClientAuthenticationFakeNTLM.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestClientAuthenticationFakeNTLM.java
@@ -28,7 +28,7 @@ package org.apache.hc.client5.testing.sync;
 
 import java.io.IOException;
 
-import org.apache.hc.client5.http.auth.AuthSchemes;
+import org.apache.hc.client5.http.auth.StandardAuthScheme;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.NTCredentials;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
@@ -61,7 +61,7 @@ public class TestClientAuthenticationFakeNTLM extends LocalServerTestBase {
                 final HttpContext context) throws HttpException, IOException {
             response.setCode(HttpStatus.SC_UNAUTHORIZED);
             response.setHeader("Connection", "Keep-Alive");
-            response.setHeader(HttpHeaders.WWW_AUTHENTICATE, AuthSchemes.NTLM.id);
+            response.setHeader(HttpHeaders.WWW_AUTHENTICATE, StandardAuthScheme.NTLM.id);
         }
     }
 
@@ -93,7 +93,7 @@ public class TestClientAuthenticationFakeNTLM extends LocalServerTestBase {
         private final String authenticateHeaderValue;
 
         public NtlmType2MessageResponseHandler(final String type2Message) {
-            this.authenticateHeaderValue = AuthSchemes.NTLM.id + " " + type2Message;
+            this.authenticateHeaderValue = StandardAuthScheme.NTLM.id + " " + type2Message;
         }
 
         @Override
@@ -104,7 +104,7 @@ public class TestClientAuthenticationFakeNTLM extends LocalServerTestBase {
             response.setCode(HttpStatus.SC_UNAUTHORIZED);
             response.setHeader("Connection", "Keep-Alive");
             if (!request.containsHeader(HttpHeaders.AUTHORIZATION)) {
-                response.setHeader(HttpHeaders.WWW_AUTHENTICATE, AuthSchemes.NTLM.id);
+                response.setHeader(HttpHeaders.WWW_AUTHENTICATE, StandardAuthScheme.NTLM.id);
             } else {
                 response.setHeader(HttpHeaders.WWW_AUTHENTICATE, authenticateHeaderValue);
             }
@@ -164,7 +164,7 @@ public class TestClientAuthenticationFakeNTLM extends LocalServerTestBase {
         private final String authenticateHeaderValue;
 
         public NtlmType2MessageOnlyResponseHandler(final String type2Message) {
-            this.authenticateHeaderValue = AuthSchemes.NTLM.id + " " + type2Message;
+            this.authenticateHeaderValue = StandardAuthScheme.NTLM.id + " " + type2Message;
         }
 
         @Override

--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestSPNegoScheme.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestSPNegoScheme.java
@@ -36,7 +36,7 @@ import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.Credentials;
 import org.apache.hc.client5.http.auth.KerberosConfig;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
-import org.apache.hc.client5.http.auth.AuthSchemes;
+import org.apache.hc.client5.http.auth.StandardAuthScheme;
 import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
 import org.apache.hc.client5.http.impl.auth.SPNegoScheme;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
@@ -78,7 +78,7 @@ public class TestSPNegoScheme extends LocalServerTestBase {
                 final ClassicHttpResponse response,
                 final HttpContext context) throws HttpException, IOException {
             response.setCode(HttpStatus.SC_UNAUTHORIZED);
-            response.addHeader(new BasicHeader("WWW-Authenticate", AuthSchemes.SPNEGO.id + " blablabla"));
+            response.addHeader(new BasicHeader("WWW-Authenticate", StandardAuthScheme.SPNEGO.id + " blablabla"));
             response.addHeader(new BasicHeader("Connection", "Keep-Alive"));
             response.setEntity(new StringEntity("auth required "));
         }
@@ -160,7 +160,7 @@ public class TestSPNegoScheme extends LocalServerTestBase {
         credentialsProvider.setCredentials(new AuthScope(null, null, -1, null, null), use_jaas_creds);
 
         final Registry<AuthSchemeFactory> authSchemeRegistry = RegistryBuilder.<AuthSchemeFactory>create()
-            .register(AuthSchemes.SPNEGO.id, nsf)
+            .register(StandardAuthScheme.SPNEGO.id, nsf)
             .build();
         this.httpclient = HttpClients.custom()
             .setDefaultAuthSchemeRegistry(authSchemeRegistry)
@@ -191,7 +191,7 @@ public class TestSPNegoScheme extends LocalServerTestBase {
         credentialsProvider.setCredentials(new AuthScope(null, null, -1, null, null), use_jaas_creds);
 
         final Registry<AuthSchemeFactory> authSchemeRegistry = RegistryBuilder.<AuthSchemeFactory>create()
-            .register(AuthSchemes.SPNEGO.id, nsf)
+            .register(StandardAuthScheme.SPNEGO.id, nsf)
             .build();
         this.httpclient = HttpClients.custom()
             .setDefaultAuthSchemeRegistry(authSchemeRegistry)

--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestWindowsNegotiateScheme.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestWindowsNegotiateScheme.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 import org.apache.hc.client5.http.auth.AuthScheme;
 import org.apache.hc.client5.http.auth.AuthSchemeFactory;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
-import org.apache.hc.client5.http.auth.AuthSchemes;
+import org.apache.hc.client5.http.auth.StandardAuthScheme;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
@@ -65,7 +65,7 @@ public class TestWindowsNegotiateScheme extends LocalServerTestBase {
                     final ClassicHttpRequest request,
                     final ClassicHttpResponse response,
                     final HttpContext context) throws HttpException, IOException {
-                response.addHeader(HttpHeaders.WWW_AUTHENTICATE, AuthSchemes.SPNEGO);
+                response.addHeader(HttpHeaders.WWW_AUTHENTICATE, StandardAuthScheme.SPNEGO);
                 response.setCode(HttpStatus.SC_UNAUTHORIZED);
             }
 
@@ -81,10 +81,10 @@ public class TestWindowsNegotiateScheme extends LocalServerTestBase {
         // you can contact the server that authenticated you." is associated with SEC_E_DOWNGRADE_DETECTED.
 
         final Registry<AuthSchemeFactory> authSchemeRegistry = RegistryBuilder.<AuthSchemeFactory>create()
-            .register(AuthSchemes.SPNEGO.id, new AuthSchemeFactory() {
+            .register(StandardAuthScheme.SPNEGO.id, new AuthSchemeFactory() {
                 @Override
                 public AuthScheme create(final HttpContext context) {
-                    return new WindowsNegotiateSchemeGetTokenFail(AuthSchemes.SPNEGO.id, "HTTP/example.com");
+                    return new WindowsNegotiateSchemeGetTokenFail(StandardAuthScheme.SPNEGO.id, "HTTP/example.com");
                 }
             }).build();
         final CloseableHttpClient customClient = HttpClientBuilder.create()

--- a/httpclient5-win/src/main/java/org/apache/hc/client5/http/impl/win/WinHttpClients.java
+++ b/httpclient5-win/src/main/java/org/apache/hc/client5/http/impl/win/WinHttpClients.java
@@ -29,7 +29,7 @@ package org.apache.hc.client5.http.impl.win;
 import java.util.Locale;
 
 import org.apache.hc.client5.http.auth.AuthSchemeFactory;
-import org.apache.hc.client5.http.auth.AuthSchemes;
+import org.apache.hc.client5.http.auth.StandardAuthScheme;
 import org.apache.hc.client5.http.impl.auth.BasicSchemeFactory;
 import org.apache.hc.client5.http.impl.auth.DigestSchemeFactory;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
@@ -67,10 +67,10 @@ public class WinHttpClients {
     private static HttpClientBuilder createBuilder() {
         if (isWinAuthAvailable()) {
             final Registry<AuthSchemeFactory> authSchemeRegistry = RegistryBuilder.<AuthSchemeFactory>create()
-                    .register(AuthSchemes.BASIC.id, BasicSchemeFactory.INSTANCE)
-                    .register(AuthSchemes.DIGEST.id, DigestSchemeFactory.INSTANCE)
-                    .register(AuthSchemes.NTLM.id, WindowsNTLMSchemeFactory.DEFAULT)
-                    .register(AuthSchemes.SPNEGO.id, WindowsNegotiateSchemeFactory.DEFAULT)
+                    .register(StandardAuthScheme.BASIC.id, BasicSchemeFactory.INSTANCE)
+                    .register(StandardAuthScheme.DIGEST.id, DigestSchemeFactory.INSTANCE)
+                    .register(StandardAuthScheme.NTLM.id, WindowsNTLMSchemeFactory.DEFAULT)
+                    .register(StandardAuthScheme.SPNEGO.id, WindowsNegotiateSchemeFactory.DEFAULT)
                     .build();
             return HttpClientBuilder.create()
                     .setDefaultAuthSchemeRegistry(authSchemeRegistry);

--- a/httpclient5-win/src/main/java/org/apache/hc/client5/http/impl/win/WindowsNTLMSchemeFactory.java
+++ b/httpclient5-win/src/main/java/org/apache/hc/client5/http/impl/win/WindowsNTLMSchemeFactory.java
@@ -29,7 +29,7 @@ package org.apache.hc.client5.http.impl.win;
 
 import org.apache.hc.client5.http.auth.AuthScheme;
 import org.apache.hc.client5.http.auth.AuthSchemeFactory;
-import org.apache.hc.client5.http.auth.AuthSchemes;
+import org.apache.hc.client5.http.auth.StandardAuthScheme;
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.Experimental;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
@@ -59,7 +59,7 @@ public class WindowsNTLMSchemeFactory implements AuthSchemeFactory {
 
     @Override
     public AuthScheme create(final HttpContext context) {
-        return new WindowsNegotiateScheme(AuthSchemes.NTLM.id, servicePrincipalName);
+        return new WindowsNegotiateScheme(StandardAuthScheme.NTLM.id, servicePrincipalName);
     }
 
 }

--- a/httpclient5-win/src/main/java/org/apache/hc/client5/http/impl/win/WindowsNegotiateScheme.java
+++ b/httpclient5-win/src/main/java/org/apache/hc/client5/http/impl/win/WindowsNegotiateScheme.java
@@ -32,7 +32,7 @@ import org.apache.commons.codec.binary.Base64;
 import org.apache.hc.client5.http.RouteInfo;
 import org.apache.hc.client5.http.auth.AuthChallenge;
 import org.apache.hc.client5.http.auth.AuthScheme;
-import org.apache.hc.client5.http.auth.AuthSchemes;
+import org.apache.hc.client5.http.auth.StandardAuthScheme;
 import org.apache.hc.client5.http.auth.AuthenticationException;
 import org.apache.hc.client5.http.auth.BasicUserPrincipal;
 import org.apache.hc.client5.http.auth.ChallengeType;
@@ -86,7 +86,7 @@ public class WindowsNegotiateScheme implements AuthScheme {
     WindowsNegotiateScheme(final String scheme, final String servicePrincipalName) {
         super();
 
-        this.scheme = (scheme == null) ? AuthSchemes.SPNEGO.id : scheme;
+        this.scheme = (scheme == null) ? StandardAuthScheme.SPNEGO.id : scheme;
         this.continueNeeded = true;
         this.servicePrincipalName = servicePrincipalName;
 

--- a/httpclient5-win/src/main/java/org/apache/hc/client5/http/impl/win/WindowsNegotiateSchemeFactory.java
+++ b/httpclient5-win/src/main/java/org/apache/hc/client5/http/impl/win/WindowsNegotiateSchemeFactory.java
@@ -29,7 +29,7 @@ package org.apache.hc.client5.http.impl.win;
 
 import org.apache.hc.client5.http.auth.AuthScheme;
 import org.apache.hc.client5.http.auth.AuthSchemeFactory;
-import org.apache.hc.client5.http.auth.AuthSchemes;
+import org.apache.hc.client5.http.auth.StandardAuthScheme;
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.Experimental;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
@@ -59,7 +59,7 @@ public class WindowsNegotiateSchemeFactory implements AuthSchemeFactory {
 
     @Override
     public AuthScheme create(final HttpContext context) {
-        return new WindowsNegotiateScheme(AuthSchemes.SPNEGO.id, servicePrincipalName);
+        return new WindowsNegotiateScheme(StandardAuthScheme.SPNEGO.id, servicePrincipalName);
     }
 
 }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/auth/StandardAuthScheme.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/auth/StandardAuthScheme.java
@@ -32,7 +32,7 @@ package org.apache.hc.client5.http.auth;
  *
  * @since 4.3
  */
-public enum AuthSchemes {
+public enum StandardAuthScheme {
 
     /**
      * Basic authentication scheme as defined in RFC 2617 (considered inherently
@@ -67,7 +67,7 @@ public enum AuthSchemes {
 
     public final String id;
 
-    AuthSchemes(final String id) {
+    StandardAuthScheme(final String id) {
         this.id = id;
     }
 

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/AuthSupport.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/AuthSupport.java
@@ -28,7 +28,7 @@
 package org.apache.hc.client5.http.impl;
 
 import org.apache.hc.client5.http.HttpRoute;
-import org.apache.hc.client5.http.auth.AuthSchemes;
+import org.apache.hc.client5.http.auth.StandardAuthScheme;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.CredentialsStore;
 import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
@@ -63,7 +63,7 @@ public class AuthSupport {
         final char[] password = atColon >= 0 ? userInfo.substring(atColon + 1).toCharArray() : null;
 
         credentialsStore.setCredentials(
-                new AuthScope(scheme, authority.getHostName(), authority.getPort(), null, AuthSchemes.BASIC.id),
+                new AuthScope(scheme, authority.getHostName(), authority.getPort(), null, StandardAuthScheme.BASIC.id),
                 new UsernamePasswordCredentials(userName, password));
     }
 

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/DefaultAuthenticationStrategy.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/DefaultAuthenticationStrategy.java
@@ -39,7 +39,7 @@ import org.apache.hc.client5.http.AuthenticationStrategy;
 import org.apache.hc.client5.http.auth.AuthChallenge;
 import org.apache.hc.client5.http.auth.AuthScheme;
 import org.apache.hc.client5.http.auth.AuthSchemeFactory;
-import org.apache.hc.client5.http.auth.AuthSchemes;
+import org.apache.hc.client5.http.auth.StandardAuthScheme;
 import org.apache.hc.client5.http.auth.ChallengeType;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.protocol.HttpClientContext;
@@ -65,11 +65,11 @@ public class DefaultAuthenticationStrategy implements AuthenticationStrategy {
 
     private static final List<String> DEFAULT_SCHEME_PRIORITY =
         Collections.unmodifiableList(Arrays.asList(
-                AuthSchemes.SPNEGO.id,
-                AuthSchemes.KERBEROS.id,
-                AuthSchemes.NTLM.id,
-                AuthSchemes.DIGEST.id,
-                AuthSchemes.BASIC.id));
+                StandardAuthScheme.SPNEGO.id,
+                StandardAuthScheme.KERBEROS.id,
+                StandardAuthScheme.NTLM.id,
+                StandardAuthScheme.DIGEST.id,
+                StandardAuthScheme.BASIC.id));
 
     @Override
     public List<AuthScheme> select(

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/H2AsyncClientBuilder.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/H2AsyncClientBuilder.java
@@ -44,7 +44,7 @@ import org.apache.hc.client5.http.HttpRequestRetryStrategy;
 import org.apache.hc.client5.http.SchemePortResolver;
 import org.apache.hc.client5.http.async.AsyncExecChainHandler;
 import org.apache.hc.client5.http.auth.AuthSchemeFactory;
-import org.apache.hc.client5.http.auth.AuthSchemes;
+import org.apache.hc.client5.http.auth.StandardAuthScheme;
 import org.apache.hc.client5.http.auth.CredentialsProvider;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.cookie.BasicCookieStore;
@@ -761,11 +761,11 @@ public class H2AsyncClientBuilder {
         Lookup<AuthSchemeFactory> authSchemeRegistryCopy = this.authSchemeRegistry;
         if (authSchemeRegistryCopy == null) {
             authSchemeRegistryCopy = RegistryBuilder.<AuthSchemeFactory>create()
-                    .register(AuthSchemes.BASIC.id, BasicSchemeFactory.INSTANCE)
-                    .register(AuthSchemes.DIGEST.id, DigestSchemeFactory.INSTANCE)
-                    .register(AuthSchemes.NTLM.id, NTLMSchemeFactory.INSTANCE)
-                    .register(AuthSchemes.SPNEGO.id, SPNegoSchemeFactory.DEFAULT)
-                    .register(AuthSchemes.KERBEROS.id, KerberosSchemeFactory.DEFAULT)
+                    .register(StandardAuthScheme.BASIC.id, BasicSchemeFactory.INSTANCE)
+                    .register(StandardAuthScheme.DIGEST.id, DigestSchemeFactory.INSTANCE)
+                    .register(StandardAuthScheme.NTLM.id, NTLMSchemeFactory.INSTANCE)
+                    .register(StandardAuthScheme.SPNEGO.id, SPNegoSchemeFactory.DEFAULT)
+                    .register(StandardAuthScheme.KERBEROS.id, KerberosSchemeFactory.DEFAULT)
                     .build();
         }
         Lookup<CookieSpecFactory> cookieSpecRegistryCopy = this.cookieSpecRegistry;

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncClientBuilder.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncClientBuilder.java
@@ -45,7 +45,7 @@ import org.apache.hc.client5.http.SchemePortResolver;
 import org.apache.hc.client5.http.UserTokenHandler;
 import org.apache.hc.client5.http.async.AsyncExecChainHandler;
 import org.apache.hc.client5.http.auth.AuthSchemeFactory;
-import org.apache.hc.client5.http.auth.AuthSchemes;
+import org.apache.hc.client5.http.auth.StandardAuthScheme;
 import org.apache.hc.client5.http.auth.CredentialsProvider;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.cookie.BasicCookieStore;
@@ -968,11 +968,11 @@ public class HttpAsyncClientBuilder {
         Lookup<AuthSchemeFactory> authSchemeRegistryCopy = this.authSchemeRegistry;
         if (authSchemeRegistryCopy == null) {
             authSchemeRegistryCopy = RegistryBuilder.<AuthSchemeFactory>create()
-                    .register(AuthSchemes.BASIC.id, BasicSchemeFactory.INSTANCE)
-                    .register(AuthSchemes.DIGEST.id, DigestSchemeFactory.INSTANCE)
-                    .register(AuthSchemes.NTLM.id, NTLMSchemeFactory.INSTANCE)
-                    .register(AuthSchemes.SPNEGO.id, SPNegoSchemeFactory.DEFAULT)
-                    .register(AuthSchemes.KERBEROS.id, KerberosSchemeFactory.DEFAULT)
+                    .register(StandardAuthScheme.BASIC.id, BasicSchemeFactory.INSTANCE)
+                    .register(StandardAuthScheme.DIGEST.id, DigestSchemeFactory.INSTANCE)
+                    .register(StandardAuthScheme.NTLM.id, NTLMSchemeFactory.INSTANCE)
+                    .register(StandardAuthScheme.SPNEGO.id, SPNegoSchemeFactory.DEFAULT)
+                    .register(StandardAuthScheme.KERBEROS.id, KerberosSchemeFactory.DEFAULT)
                     .build();
         }
         Lookup<CookieSpecFactory> cookieSpecRegistryCopy = this.cookieSpecRegistry;

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/BasicScheme.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/BasicScheme.java
@@ -42,7 +42,7 @@ import java.util.Map;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.hc.client5.http.auth.AuthChallenge;
 import org.apache.hc.client5.http.auth.AuthScheme;
-import org.apache.hc.client5.http.auth.AuthSchemes;
+import org.apache.hc.client5.http.auth.StandardAuthScheme;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.AuthStateCacheable;
 import org.apache.hc.client5.http.auth.AuthenticationException;
@@ -100,7 +100,7 @@ public class BasicScheme implements AuthScheme, Serializable {
 
     @Override
     public String getName() {
-        return AuthSchemes.BASIC.id;
+        return StandardAuthScheme.BASIC.id;
     }
 
     @Override
@@ -174,7 +174,7 @@ public class BasicScheme implements AuthScheme, Serializable {
         }
         final byte[] encodedCreds = this.base64codec.encode(this.buffer.toByteArray());
         this.buffer.reset();
-        return AuthSchemes.BASIC.id + " " + new String(encodedCreds, 0, encodedCreds.length, StandardCharsets.US_ASCII);
+        return StandardAuthScheme.BASIC.id + " " + new String(encodedCreds, 0, encodedCreds.length, StandardCharsets.US_ASCII);
     }
 
     private void writeObject(final ObjectOutputStream out) throws IOException {

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/DigestScheme.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/DigestScheme.java
@@ -46,7 +46,7 @@ import java.util.StringTokenizer;
 
 import org.apache.hc.client5.http.auth.AuthChallenge;
 import org.apache.hc.client5.http.auth.AuthScheme;
-import org.apache.hc.client5.http.auth.AuthSchemes;
+import org.apache.hc.client5.http.auth.StandardAuthScheme;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.AuthenticationException;
 import org.apache.hc.client5.http.utils.ByteArrayBuilder;
@@ -127,7 +127,7 @@ public class DigestScheme implements AuthScheme, Serializable {
 
     @Override
     public String getName() {
-        return AuthSchemes.DIGEST.id;
+        return StandardAuthScheme.DIGEST.id;
     }
 
     @Override
@@ -375,7 +375,7 @@ public class DigestScheme implements AuthScheme, Serializable {
         final String digest = formatHex(digester.digest(digestInput));
 
         final CharArrayBuffer buffer = new CharArrayBuffer(128);
-        buffer.append(AuthSchemes.DIGEST.id + " ");
+        buffer.append(StandardAuthScheme.DIGEST.id + " ");
 
         final List<BasicNameValuePair> params = new ArrayList<>(20);
         params.add(new BasicNameValuePair("username", username));

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/GGSSchemeBase.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/GGSSchemeBase.java
@@ -35,7 +35,7 @@ import org.apache.hc.client5.http.DnsResolver;
 import org.apache.hc.client5.http.SystemDefaultDnsResolver;
 import org.apache.hc.client5.http.auth.AuthChallenge;
 import org.apache.hc.client5.http.auth.AuthScheme;
-import org.apache.hc.client5.http.auth.AuthSchemes;
+import org.apache.hc.client5.http.auth.StandardAuthScheme;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.AuthenticationException;
 import org.apache.hc.client5.http.auth.Credentials;
@@ -247,7 +247,7 @@ public abstract class GGSSchemeBase implements AuthScheme {
             if (log.isDebugEnabled()) {
                 log.debug("Sending response '" + tokenstr + "' back to the auth server");
             }
-            return AuthSchemes.SPNEGO.id + " " + tokenstr;
+            return StandardAuthScheme.SPNEGO.id + " " + tokenstr;
         default:
             throw new IllegalStateException("Illegal state: " + state);
         }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/KerberosScheme.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/KerberosScheme.java
@@ -27,7 +27,7 @@
 package org.apache.hc.client5.http.impl.auth;
 
 import org.apache.hc.client5.http.DnsResolver;
-import org.apache.hc.client5.http.auth.AuthSchemes;
+import org.apache.hc.client5.http.auth.StandardAuthScheme;
 import org.apache.hc.client5.http.auth.KerberosConfig;
 import org.apache.hc.core5.annotation.Experimental;
 import org.ietf.jgss.GSSException;
@@ -60,7 +60,7 @@ public class KerberosScheme extends GGSSchemeBase {
 
     @Override
     public String getName() {
-        return AuthSchemes.KERBEROS.id;
+        return StandardAuthScheme.KERBEROS.id;
     }
 
     @Override

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/NTLMScheme.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/NTLMScheme.java
@@ -30,7 +30,7 @@ import java.security.Principal;
 
 import org.apache.hc.client5.http.auth.AuthChallenge;
 import org.apache.hc.client5.http.auth.AuthScheme;
-import org.apache.hc.client5.http.auth.AuthSchemes;
+import org.apache.hc.client5.http.auth.StandardAuthScheme;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.AuthenticationException;
 import org.apache.hc.client5.http.auth.Credentials;
@@ -81,7 +81,7 @@ public final class NTLMScheme implements AuthScheme {
 
     @Override
     public String getName() {
-        return AuthSchemes.NTLM.id;
+        return StandardAuthScheme.NTLM.id;
     }
 
     @Override
@@ -169,7 +169,7 @@ public final class NTLMScheme implements AuthScheme {
         } else {
             throw new AuthenticationException("Unexpected state: " + this.state);
         }
-        return AuthSchemes.NTLM.id + " " + response;
+        return StandardAuthScheme.NTLM.id + " " + response;
     }
 
     @Override

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/SPNegoScheme.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/SPNegoScheme.java
@@ -27,7 +27,7 @@
 package org.apache.hc.client5.http.impl.auth;
 
 import org.apache.hc.client5.http.DnsResolver;
-import org.apache.hc.client5.http.auth.AuthSchemes;
+import org.apache.hc.client5.http.auth.StandardAuthScheme;
 import org.apache.hc.client5.http.auth.KerberosConfig;
 import org.apache.hc.core5.annotation.Experimental;
 import org.ietf.jgss.GSSException;
@@ -61,7 +61,7 @@ public class SPNegoScheme extends GGSSchemeBase {
 
     @Override
     public String getName() {
-        return AuthSchemes.SPNEGO.id;
+        return StandardAuthScheme.SPNEGO.id;
     }
 
     @Override

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/SystemDefaultCredentialsProvider.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/SystemDefaultCredentialsProvider.java
@@ -40,7 +40,7 @@ import org.apache.hc.client5.http.auth.Credentials;
 import org.apache.hc.client5.http.auth.CredentialsStore;
 import org.apache.hc.client5.http.auth.NTCredentials;
 import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
-import org.apache.hc.client5.http.auth.AuthSchemes;
+import org.apache.hc.client5.http.auth.StandardAuthScheme;
 import org.apache.hc.client5.http.protocol.HttpClientContext;
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
@@ -62,11 +62,11 @@ public class SystemDefaultCredentialsProvider implements CredentialsStore {
 
     static {
         SCHEME_MAP = new ConcurrentHashMap<>();
-        SCHEME_MAP.put(AuthSchemes.BASIC.name(), "Basic");
-        SCHEME_MAP.put(AuthSchemes.DIGEST.name(), "Digest");
-        SCHEME_MAP.put(AuthSchemes.NTLM.name(), "NTLM");
-        SCHEME_MAP.put(AuthSchemes.SPNEGO.name(), "SPNEGO");
-        SCHEME_MAP.put(AuthSchemes.KERBEROS.name(), "Kerberos");
+        SCHEME_MAP.put(StandardAuthScheme.BASIC.name(), "Basic");
+        SCHEME_MAP.put(StandardAuthScheme.DIGEST.name(), "Digest");
+        SCHEME_MAP.put(StandardAuthScheme.NTLM.name(), "NTLM");
+        SCHEME_MAP.put(StandardAuthScheme.SPNEGO.name(), "SPNEGO");
+        SCHEME_MAP.put(StandardAuthScheme.KERBEROS.name(), "Kerberos");
     }
 
     private static String translateAuthScheme(final String key) {
@@ -149,7 +149,7 @@ public class SystemDefaultCredentialsProvider implements CredentialsStore {
                 if (domain != null) {
                     return new NTCredentials(systemcreds.getUserName(), systemcreds.getPassword(), null, domain);
                 }
-                if (AuthSchemes.NTLM.id.equalsIgnoreCase(authScope.getAuthScheme())) {
+                if (StandardAuthScheme.NTLM.id.equalsIgnoreCase(authScope.getAuthScheme())) {
                     // Domain may be specified in a fully qualified user name
                     return new NTCredentials(
                             systemcreds.getUserName(), systemcreds.getPassword(), null, null);

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/HttpClientBuilder.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/HttpClientBuilder.java
@@ -43,7 +43,7 @@ import org.apache.hc.client5.http.HttpRequestRetryStrategy;
 import org.apache.hc.client5.http.SchemePortResolver;
 import org.apache.hc.client5.http.UserTokenHandler;
 import org.apache.hc.client5.http.auth.AuthSchemeFactory;
-import org.apache.hc.client5.http.auth.AuthSchemes;
+import org.apache.hc.client5.http.auth.StandardAuthScheme;
 import org.apache.hc.client5.http.auth.CredentialsProvider;
 import org.apache.hc.client5.http.classic.BackoffManager;
 import org.apache.hc.client5.http.classic.ConnectionBackoffStrategy;
@@ -940,11 +940,11 @@ public class HttpClientBuilder {
         Lookup<AuthSchemeFactory> authSchemeRegistryCopy = this.authSchemeRegistry;
         if (authSchemeRegistryCopy == null) {
             authSchemeRegistryCopy = RegistryBuilder.<AuthSchemeFactory>create()
-                .register(AuthSchemes.BASIC.id, BasicSchemeFactory.INSTANCE)
-                .register(AuthSchemes.DIGEST.id, DigestSchemeFactory.INSTANCE)
-                .register(AuthSchemes.NTLM.id, NTLMSchemeFactory.INSTANCE)
-                .register(AuthSchemes.SPNEGO.id, SPNegoSchemeFactory.DEFAULT)
-                .register(AuthSchemes.KERBEROS.id, KerberosSchemeFactory.DEFAULT)
+                .register(StandardAuthScheme.BASIC.id, BasicSchemeFactory.INSTANCE)
+                .register(StandardAuthScheme.DIGEST.id, DigestSchemeFactory.INSTANCE)
+                .register(StandardAuthScheme.NTLM.id, NTLMSchemeFactory.INSTANCE)
+                .register(StandardAuthScheme.SPNEGO.id, SPNegoSchemeFactory.DEFAULT)
+                .register(StandardAuthScheme.KERBEROS.id, KerberosSchemeFactory.DEFAULT)
                 .build();
         }
         Lookup<CookieSpecFactory> cookieSpecRegistryCopy = this.cookieSpecRegistry;

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/ProxyClient.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/ProxyClient.java
@@ -36,7 +36,7 @@ import org.apache.hc.client5.http.RouteInfo.LayerType;
 import org.apache.hc.client5.http.RouteInfo.TunnelType;
 import org.apache.hc.client5.http.auth.AuthExchange;
 import org.apache.hc.client5.http.auth.AuthSchemeFactory;
-import org.apache.hc.client5.http.auth.AuthSchemes;
+import org.apache.hc.client5.http.auth.StandardAuthScheme;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.ChallengeType;
 import org.apache.hc.client5.http.auth.Credentials;
@@ -113,11 +113,11 @@ public class ProxyClient {
         this.authenticator = new HttpAuthenticator();
         this.proxyAuthExchange = new AuthExchange();
         this.authSchemeRegistry = RegistryBuilder.<AuthSchemeFactory>create()
-                .register(AuthSchemes.BASIC.id, BasicSchemeFactory.INSTANCE)
-                .register(AuthSchemes.DIGEST.id, DigestSchemeFactory.INSTANCE)
-                .register(AuthSchemes.NTLM.id, NTLMSchemeFactory.INSTANCE)
-                .register(AuthSchemes.SPNEGO.id, SPNegoSchemeFactory.DEFAULT)
-                .register(AuthSchemes.KERBEROS.id, KerberosSchemeFactory.DEFAULT)
+                .register(StandardAuthScheme.BASIC.id, BasicSchemeFactory.INSTANCE)
+                .register(StandardAuthScheme.DIGEST.id, DigestSchemeFactory.INSTANCE)
+                .register(StandardAuthScheme.NTLM.id, NTLMSchemeFactory.INSTANCE)
+                .register(StandardAuthScheme.SPNEGO.id, SPNegoSchemeFactory.DEFAULT)
+                .register(StandardAuthScheme.KERBEROS.id, KerberosSchemeFactory.DEFAULT)
                 .build();
         this.reuseStrategy = new DefaultConnectionReuseStrategy();
     }

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/auth/TestAuthChallenge.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/auth/TestAuthChallenge.java
@@ -37,21 +37,21 @@ public class TestAuthChallenge {
 
     @Test
     public void testAuthChallengeWithValue() {
-        final AuthChallenge authChallenge = new AuthChallenge(ChallengeType.TARGET, AuthSchemes.BASIC.id, "blah", null);
-        Assert.assertEquals(AuthSchemes.BASIC.id, authChallenge.getScheme());
+        final AuthChallenge authChallenge = new AuthChallenge(ChallengeType.TARGET, StandardAuthScheme.BASIC.id, "blah", null);
+        Assert.assertEquals(StandardAuthScheme.BASIC.id, authChallenge.getScheme());
         Assert.assertEquals("blah", authChallenge.getValue());
         Assert.assertEquals(null, authChallenge.getParams());
-        Assert.assertEquals(AuthSchemes.BASIC.id + " blah", authChallenge.toString());
+        Assert.assertEquals(StandardAuthScheme.BASIC.id + " blah", authChallenge.toString());
     }
 
     @Test
     public void testAuthChallengeWithParams() {
-        final AuthChallenge authChallenge = new AuthChallenge(ChallengeType.TARGET, AuthSchemes.BASIC.id, null,
+        final AuthChallenge authChallenge = new AuthChallenge(ChallengeType.TARGET, StandardAuthScheme.BASIC.id, null,
                 Arrays.asList(new BasicNameValuePair("blah", "this"), new BasicNameValuePair("blah", "that")));
-        Assert.assertEquals(AuthSchemes.BASIC.id, authChallenge.getScheme());
+        Assert.assertEquals(StandardAuthScheme.BASIC.id, authChallenge.getScheme());
         Assert.assertEquals(null, authChallenge.getValue());
         Assert.assertNotNull(authChallenge.getParams());
-        Assert.assertEquals(AuthSchemes.BASIC.id + " [blah=this, blah=that]", authChallenge.toString());
+        Assert.assertEquals(StandardAuthScheme.BASIC.id + " [blah=this, blah=that]", authChallenge.toString());
     }
 
 }

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/config/TestRequestConfig.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/config/TestRequestConfig.java
@@ -30,7 +30,7 @@ package org.apache.hc.client5.http.config;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.hc.client5.http.auth.AuthSchemes;
+import org.apache.hc.client5.http.auth.StandardAuthScheme;
 import org.apache.hc.client5.http.cookie.CookieSpecs;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.util.TimeValue;
@@ -75,8 +75,8 @@ public class TestRequestConfig {
                 .setMaxRedirects(100)
                 .setCookieSpec(CookieSpecs.STANDARD.id)
                 .setProxy(new HttpHost("someproxy"))
-                .setTargetPreferredAuthSchemes(Collections.singletonList(AuthSchemes.NTLM.id))
-                .setProxyPreferredAuthSchemes(Collections.singletonList(AuthSchemes.DIGEST.id))
+                .setTargetPreferredAuthSchemes(Collections.singletonList(StandardAuthScheme.NTLM.id))
+                .setProxyPreferredAuthSchemes(Collections.singletonList(StandardAuthScheme.DIGEST.id))
                 .setContentCompressionEnabled(false)
                 .build();
         final RequestConfig config = RequestConfig.copy(config0).build();
@@ -89,8 +89,8 @@ public class TestRequestConfig {
         Assert.assertEquals(100, config.getMaxRedirects());
         Assert.assertEquals(CookieSpecs.STANDARD.id, config.getCookieSpec());
         Assert.assertEquals(new HttpHost("someproxy"), config.getProxy());
-        Assert.assertEquals(Collections.singletonList(AuthSchemes.NTLM.id), config.getTargetPreferredAuthSchemes());
-        Assert.assertEquals(Collections.singletonList(AuthSchemes.DIGEST.id), config.getProxyPreferredAuthSchemes());
+        Assert.assertEquals(Collections.singletonList(StandardAuthScheme.NTLM.id), config.getTargetPreferredAuthSchemes());
+        Assert.assertEquals(Collections.singletonList(StandardAuthScheme.DIGEST.id), config.getProxyPreferredAuthSchemes());
         Assert.assertEquals(false, config.isContentCompressionEnabled());
     }
 

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClientConfiguration.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClientConfiguration.java
@@ -38,7 +38,7 @@ import javax.net.ssl.SSLContext;
 import org.apache.hc.client5.http.DnsResolver;
 import org.apache.hc.client5.http.HttpRoute;
 import org.apache.hc.client5.http.SystemDefaultDnsResolver;
-import org.apache.hc.client5.http.auth.AuthSchemes;
+import org.apache.hc.client5.http.auth.StandardAuthScheme;
 import org.apache.hc.client5.http.auth.CredentialsProvider;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -195,8 +195,8 @@ public class ClientConfiguration {
         final RequestConfig defaultRequestConfig = RequestConfig.custom()
             .setCookieSpec(CookieSpecs.STANDARD.id)
             .setExpectContinueEnabled(true)
-            .setTargetPreferredAuthSchemes(Arrays.asList(AuthSchemes.NTLM.id, AuthSchemes.DIGEST.id))
-            .setProxyPreferredAuthSchemes(Arrays.asList(AuthSchemes.BASIC.id))
+            .setTargetPreferredAuthSchemes(Arrays.asList(StandardAuthScheme.NTLM.id, StandardAuthScheme.DIGEST.id))
+            .setProxyPreferredAuthSchemes(Arrays.asList(StandardAuthScheme.BASIC.id))
             .build();
 
         // Create an HttpClient with the given custom dependencies and configuration.

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/TestAuthenticationStrategy.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/TestAuthenticationStrategy.java
@@ -38,7 +38,7 @@ import org.apache.hc.client5.http.auth.AuthSchemeFactory;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.ChallengeType;
 import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
-import org.apache.hc.client5.http.auth.AuthSchemes;
+import org.apache.hc.client5.http.auth.StandardAuthScheme;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
 import org.apache.hc.client5.http.impl.auth.BasicScheme;
@@ -85,9 +85,9 @@ public class TestAuthenticationStrategy {
         final HttpClientContext context = HttpClientContext.create();
 
         final Map<String, AuthChallenge> challenges = new HashMap<>();
-        challenges.put(AuthSchemes.BASIC.id.toLowerCase(Locale.ROOT), new AuthChallenge(ChallengeType.TARGET, AuthSchemes.BASIC.id,
+        challenges.put(StandardAuthScheme.BASIC.id.toLowerCase(Locale.ROOT), new AuthChallenge(ChallengeType.TARGET, StandardAuthScheme.BASIC.id,
                 new BasicNameValuePair("realm", "test")));
-        challenges.put(AuthSchemes.DIGEST.id.toLowerCase(Locale.ROOT), new AuthChallenge(ChallengeType.TARGET, AuthSchemes.DIGEST.id,
+        challenges.put(StandardAuthScheme.DIGEST.id.toLowerCase(Locale.ROOT), new AuthChallenge(ChallengeType.TARGET, StandardAuthScheme.DIGEST.id,
                 new BasicNameValuePair("realm", "test"), new BasicNameValuePair("nonce", "1234")));
 
         final List<AuthScheme> authSchemes = authStrategy.select(ChallengeType.TARGET, challenges, context);
@@ -101,16 +101,16 @@ public class TestAuthenticationStrategy {
         final HttpClientContext context = HttpClientContext.create();
 
         final Map<String, AuthChallenge> challenges = new HashMap<>();
-        challenges.put(AuthSchemes.BASIC.id.toLowerCase(Locale.ROOT), new AuthChallenge(ChallengeType.TARGET, AuthSchemes.BASIC.id,
+        challenges.put(StandardAuthScheme.BASIC.id.toLowerCase(Locale.ROOT), new AuthChallenge(ChallengeType.TARGET, StandardAuthScheme.BASIC.id,
                 new BasicNameValuePair("realm", "realm1")));
-        challenges.put(AuthSchemes.DIGEST.id.toLowerCase(Locale.ROOT), new AuthChallenge(ChallengeType.TARGET, AuthSchemes.DIGEST.id,
+        challenges.put(StandardAuthScheme.DIGEST.id.toLowerCase(Locale.ROOT), new AuthChallenge(ChallengeType.TARGET, StandardAuthScheme.DIGEST.id,
                 new BasicNameValuePair("realm", "realm2"), new BasicNameValuePair("nonce", "1234")));
         challenges.put("whatever", new AuthChallenge(ChallengeType.TARGET, "Whatever",
                 new BasicNameValuePair("realm", "realm3")));
 
         final Registry<AuthSchemeFactory> authSchemeRegistry = RegistryBuilder.<AuthSchemeFactory>create()
-            .register(AuthSchemes.BASIC.id, BasicSchemeFactory.INSTANCE)
-            .register(AuthSchemes.DIGEST.id, DigestSchemeFactory.INSTANCE).build();
+            .register(StandardAuthScheme.BASIC.id, BasicSchemeFactory.INSTANCE)
+            .register(StandardAuthScheme.DIGEST.id, DigestSchemeFactory.INSTANCE).build();
         context.setAuthSchemeRegistry(authSchemeRegistry);
 
         final BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
@@ -131,20 +131,20 @@ public class TestAuthenticationStrategy {
     public void testCustomAuthPreference() throws Exception {
         final DefaultAuthenticationStrategy authStrategy = new DefaultAuthenticationStrategy();
         final RequestConfig config = RequestConfig.custom()
-            .setTargetPreferredAuthSchemes(Collections.singletonList(AuthSchemes.BASIC.id))
+            .setTargetPreferredAuthSchemes(Collections.singletonList(StandardAuthScheme.BASIC.id))
             .build();
 
         final HttpClientContext context = HttpClientContext.create();
 
         final Map<String, AuthChallenge> challenges = new HashMap<>();
-        challenges.put(AuthSchemes.BASIC.id.toLowerCase(Locale.ROOT), new AuthChallenge(ChallengeType.TARGET, AuthSchemes.BASIC.id,
+        challenges.put(StandardAuthScheme.BASIC.id.toLowerCase(Locale.ROOT), new AuthChallenge(ChallengeType.TARGET, StandardAuthScheme.BASIC.id,
                 new BasicNameValuePair("realm", "realm1")));
-        challenges.put(AuthSchemes.DIGEST.id.toLowerCase(Locale.ROOT), new AuthChallenge(ChallengeType.TARGET, AuthSchemes.DIGEST.id,
+        challenges.put(StandardAuthScheme.DIGEST.id.toLowerCase(Locale.ROOT), new AuthChallenge(ChallengeType.TARGET, StandardAuthScheme.DIGEST.id,
                 new BasicNameValuePair("realm", "realm2"), new BasicNameValuePair("nonce", "1234")));
 
         final Registry<AuthSchemeFactory> authSchemeRegistry = RegistryBuilder.<AuthSchemeFactory>create()
-            .register(AuthSchemes.BASIC.id, BasicSchemeFactory.INSTANCE)
-            .register(AuthSchemes.DIGEST.id, DigestSchemeFactory.INSTANCE).build();
+            .register(StandardAuthScheme.BASIC.id, BasicSchemeFactory.INSTANCE)
+            .register(StandardAuthScheme.DIGEST.id, DigestSchemeFactory.INSTANCE).build();
         context.setAuthSchemeRegistry(authSchemeRegistry);
         context.setRequestConfig(config);
 

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestAuthChallengeParser.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestAuthChallengeParser.java
@@ -29,7 +29,7 @@ package org.apache.hc.client5.http.impl.auth;
 import java.util.List;
 
 import org.apache.hc.client5.http.auth.AuthChallenge;
-import org.apache.hc.client5.http.auth.AuthSchemes;
+import org.apache.hc.client5.http.auth.StandardAuthScheme;
 import org.apache.hc.client5.http.auth.ChallengeType;
 import org.apache.hc.core5.http.NameValuePair;
 import org.apache.hc.core5.http.ParseException;
@@ -151,13 +151,13 @@ public class TestAuthChallengeParser {
     @Test
     public void testParseBasicAuthChallenge() throws Exception {
         final CharArrayBuffer buffer = new CharArrayBuffer(64);
-        buffer.append(AuthSchemes.BASIC.id + " realm=blah");
+        buffer.append(StandardAuthScheme.BASIC.id + " realm=blah");
         final ParserCursor cursor = new ParserCursor(0, buffer.length());
         final List<AuthChallenge> challenges = parser.parse(ChallengeType.TARGET, buffer, cursor);
         Assert.assertNotNull(challenges);
         Assert.assertEquals(1, challenges.size());
         final AuthChallenge challenge1 = challenges.get(0);
-        Assert.assertEquals(AuthSchemes.BASIC.id, challenge1.getScheme());
+        Assert.assertEquals(StandardAuthScheme.BASIC.id, challenge1.getScheme());
         Assert.assertEquals(null, challenge1.getValue());
         final List<NameValuePair> params = challenge1.getParams();
         Assert.assertNotNull(params);
@@ -168,13 +168,13 @@ public class TestAuthChallengeParser {
     @Test
     public void testParseAuthChallengeWithBlanks() throws Exception {
         final CharArrayBuffer buffer = new CharArrayBuffer(64);
-        buffer.append("   " + AuthSchemes.BASIC.id + "  realm = blah   ");
+        buffer.append("   " + StandardAuthScheme.BASIC.id + "  realm = blah   ");
         final ParserCursor cursor = new ParserCursor(0, buffer.length());
         final List<AuthChallenge> challenges = parser.parse(ChallengeType.TARGET, buffer, cursor);
         Assert.assertNotNull(challenges);
         Assert.assertEquals(1, challenges.size());
         final AuthChallenge challenge1 = challenges.get(0);
-        Assert.assertEquals(AuthSchemes.BASIC.id, challenge1.getScheme());
+        Assert.assertEquals(StandardAuthScheme.BASIC.id, challenge1.getScheme());
         Assert.assertEquals(null, challenge1.getValue());
         final List<NameValuePair> params = challenge1.getParams();
         Assert.assertNotNull(params);
@@ -206,15 +206,15 @@ public class TestAuthChallengeParser {
     @Test
     public void testParseMultipleAuthChallengeWithParams() throws Exception {
         final CharArrayBuffer buffer = new CharArrayBuffer(64);
-        buffer.append(AuthSchemes.BASIC.id + " realm=blah, param1 = this, param2=that, " +
-                AuthSchemes.BASIC.id + " realm=\"\\\"yada\\\"\", this, that=,this-and-that  ");
+        buffer.append(StandardAuthScheme.BASIC.id + " realm=blah, param1 = this, param2=that, " +
+                StandardAuthScheme.BASIC.id + " realm=\"\\\"yada\\\"\", this, that=,this-and-that  ");
         final ParserCursor cursor = new ParserCursor(0, buffer.length());
         final List<AuthChallenge> challenges = parser.parse(ChallengeType.TARGET, buffer, cursor);
         Assert.assertNotNull(challenges);
         Assert.assertEquals(2, challenges.size());
 
         final AuthChallenge challenge1 = challenges.get(0);
-        Assert.assertEquals(AuthSchemes.BASIC.id, challenge1.getScheme());
+        Assert.assertEquals(StandardAuthScheme.BASIC.id, challenge1.getScheme());
         Assert.assertEquals(null, challenge1.getValue());
         final List<NameValuePair> params1 = challenge1.getParams();
         Assert.assertNotNull(params1);
@@ -224,7 +224,7 @@ public class TestAuthChallengeParser {
         assertNameValuePair(new BasicNameValuePair("param2", "that"), params1.get(2));
 
         final AuthChallenge challenge2 = challenges.get(1);
-        Assert.assertEquals(AuthSchemes.BASIC.id, challenge2.getScheme());
+        Assert.assertEquals(StandardAuthScheme.BASIC.id, challenge2.getScheme());
         Assert.assertEquals(null, challenge2.getValue());
         final List<NameValuePair> params2 = challenge2.getParams();
         Assert.assertNotNull(params2);

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestBasicCredentialsProvider.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestBasicCredentialsProvider.java
@@ -26,7 +26,7 @@
  */
 package org.apache.hc.client5.http.impl.auth;
 
-import org.apache.hc.client5.http.auth.AuthSchemes;
+import org.apache.hc.client5.http.auth.StandardAuthScheme;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.Credentials;
 import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
@@ -142,15 +142,15 @@ public class TestBasicCredentialsProvider {
         state.setCredentials(scope2, creds2);
         state.setCredentials(scope3, creds3);
 
-        Credentials got = state.getCredentials(new AuthScope("http", "someotherhost", 80, "someotherrealm", AuthSchemes.BASIC.id), null);
+        Credentials got = state.getCredentials(new AuthScope("http", "someotherhost", 80, "someotherrealm", StandardAuthScheme.BASIC.id), null);
         Credentials expected = creds1;
         Assert.assertEquals(expected, got);
 
-        got = state.getCredentials(new AuthScope("http", "someotherhost", 80, "somerealm", AuthSchemes.BASIC.id), null);
+        got = state.getCredentials(new AuthScope("http", "someotherhost", 80, "somerealm", StandardAuthScheme.BASIC.id), null);
         expected = creds2;
         Assert.assertEquals(expected, got);
 
-        got = state.getCredentials(new AuthScope("http", "somehost", 80, "someotherrealm", AuthSchemes.BASIC.id), null);
+        got = state.getCredentials(new AuthScope("http", "somehost", 80, "someotherrealm", StandardAuthScheme.BASIC.id), null);
         expected = creds3;
         Assert.assertEquals(expected, got);
     }

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestBasicScheme.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestBasicScheme.java
@@ -36,7 +36,7 @@ import java.util.List;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.hc.client5.http.auth.AuthChallenge;
 import org.apache.hc.client5.http.auth.AuthScheme;
-import org.apache.hc.client5.http.auth.AuthSchemes;
+import org.apache.hc.client5.http.auth.StandardAuthScheme;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.ChallengeType;
 import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
@@ -65,7 +65,7 @@ public class TestBasicScheme {
 
     @Test
     public void testBasicAuthenticationEmptyChallenge() throws Exception {
-        final String challenge = AuthSchemes.BASIC.id;
+        final String challenge = StandardAuthScheme.BASIC.id;
         final AuthChallenge authChallenge = parse(challenge);
         final AuthScheme authscheme = new BasicScheme();
         authscheme.processChallenge(authChallenge, null);
@@ -90,12 +90,12 @@ public class TestBasicScheme {
         Assert.assertTrue(authscheme.isResponseReady(host, credentialsProvider, null));
         final HttpRequest request = new BasicHttpRequest("GET", "/");
         final String authResponse = authscheme.generateAuthResponse(host, request, null);
-        Assert.assertEquals(AuthSchemes.BASIC.id + " ZGg65C32Lfw=", authResponse);
+        Assert.assertEquals(StandardAuthScheme.BASIC.id + " ZGg65C32Lfw=", authResponse);
     }
 
     @Test
     public void testBasicAuthentication() throws Exception {
-        final AuthChallenge authChallenge = parse(AuthSchemes.BASIC.id + " realm=\"test\"");
+        final AuthChallenge authChallenge = parse(StandardAuthScheme.BASIC.id + " realm=\"test\"");
 
         final BasicScheme authscheme = new BasicScheme();
         authscheme.processChallenge(authChallenge, null);
@@ -110,7 +110,7 @@ public class TestBasicScheme {
         Assert.assertTrue(authscheme.isResponseReady(host, credentialsProvider, null));
         final String authResponse = authscheme.generateAuthResponse(host, request, null);
 
-        final String expected = AuthSchemes.BASIC.id + " " + new String(
+        final String expected = StandardAuthScheme.BASIC.id + " " + new String(
                 Base64.encodeBase64("testuser:testpass".getBytes(StandardCharsets.US_ASCII)),
                 StandardCharsets.US_ASCII);
         Assert.assertEquals(expected, authResponse);
@@ -121,7 +121,7 @@ public class TestBasicScheme {
 
     @Test
     public void testBasicProxyAuthentication() throws Exception {
-        final AuthChallenge authChallenge = parse(AuthSchemes.BASIC.id + " realm=\"test\"");
+        final AuthChallenge authChallenge = parse(StandardAuthScheme.BASIC.id + " realm=\"test\"");
 
         final BasicScheme authscheme = new BasicScheme();
         authscheme.processChallenge(authChallenge, null);
@@ -136,7 +136,7 @@ public class TestBasicScheme {
         Assert.assertTrue(authscheme.isResponseReady(host, credentialsProvider, null));
         final String authResponse = authscheme.generateAuthResponse(host, request, null);
 
-        final String expected = AuthSchemes.BASIC.id + " " + new String(
+        final String expected = StandardAuthScheme.BASIC.id + " " + new String(
                 Base64.encodeBase64("testuser:testpass".getBytes(StandardCharsets.US_ASCII)),
                 StandardCharsets.US_ASCII);
         Assert.assertEquals(expected, authResponse);
@@ -147,7 +147,7 @@ public class TestBasicScheme {
 
     @Test
     public void testSerialization() throws Exception {
-        final AuthChallenge authChallenge = parse(AuthSchemes.BASIC.id + " realm=\"test\"");
+        final AuthChallenge authChallenge = parse(StandardAuthScheme.BASIC.id + " realm=\"test\"");
 
         final BasicScheme basicScheme = new BasicScheme();
         basicScheme.processChallenge(authChallenge, null);

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestDigestScheme.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestDigestScheme.java
@@ -39,7 +39,7 @@ import java.util.Map;
 
 import org.apache.hc.client5.http.auth.AuthChallenge;
 import org.apache.hc.client5.http.auth.AuthScheme;
-import org.apache.hc.client5.http.auth.AuthSchemes;
+import org.apache.hc.client5.http.auth.StandardAuthScheme;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.AuthenticationException;
 import org.apache.hc.client5.http.auth.ChallengeType;
@@ -78,14 +78,14 @@ public class TestDigestScheme {
 
     @Test(expected=MalformedChallengeException.class)
     public void testDigestAuthenticationEmptyChallenge1() throws Exception {
-        final AuthChallenge authChallenge = parse(AuthSchemes.DIGEST.id);
+        final AuthChallenge authChallenge = parse(StandardAuthScheme.DIGEST.id);
         final AuthScheme authscheme = new DigestScheme();
         authscheme.processChallenge(authChallenge, null);
     }
 
     @Test(expected=MalformedChallengeException.class)
     public void testDigestAuthenticationEmptyChallenge2() throws Exception {
-        final AuthChallenge authChallenge = parse(AuthSchemes.DIGEST.id + " ");
+        final AuthChallenge authChallenge = parse(StandardAuthScheme.DIGEST.id + " ");
         final AuthScheme authscheme = new DigestScheme();
         authscheme.processChallenge(authChallenge, null);
     }
@@ -99,7 +99,7 @@ public class TestDigestScheme {
         final Credentials creds = new UsernamePasswordCredentials("username","password".toCharArray());
         credentialsProvider.setCredentials(authScope, creds);
 
-        final String challenge = AuthSchemes.DIGEST.id + " realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\"";
+        final String challenge = StandardAuthScheme.DIGEST.id + " realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\"";
         final AuthChallenge authChallenge = parse(challenge);
         final DigestScheme authscheme = new DigestScheme();
         authscheme.processChallenge(authChallenge, null);
@@ -126,7 +126,7 @@ public class TestDigestScheme {
         final Credentials creds = new UsernamePasswordCredentials("username","password".toCharArray());
         credentialsProvider.setCredentials(authScope, creds);
 
-        final String challenge = AuthSchemes.DIGEST.id + " realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\"";
+        final String challenge = StandardAuthScheme.DIGEST.id + " realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\"";
         final AuthChallenge authChallenge = parse(challenge);
         final DigestScheme authscheme = new DigestScheme();
         authscheme.processChallenge(authChallenge, null);
@@ -150,7 +150,7 @@ public class TestDigestScheme {
         final Credentials creds = new UsernamePasswordCredentials("username","password".toCharArray());
         credentialsProvider.setCredentials(authScope, creds);
 
-        final String challenge = AuthSchemes.DIGEST.id + " realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\"";
+        final String challenge = StandardAuthScheme.DIGEST.id + " realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\"";
         final AuthChallenge authChallenge = parse(challenge);
         final DigestScheme authscheme = new DigestScheme();
         authscheme.processChallenge(authChallenge, null);
@@ -181,7 +181,7 @@ public class TestDigestScheme {
         final Credentials creds = new UsernamePasswordCredentials("username","password".toCharArray());
         credentialsProvider.setCredentials(authScope, creds);
 
-        final String challenge = AuthSchemes.DIGEST.id + " realm=\"realm1\", " +
+        final String challenge = StandardAuthScheme.DIGEST.id + " realm=\"realm1\", " +
                 "nonce=\"f2a3f18799759d4f1a1c068b92b573cb\", " +
                 "algorithm=SHA";
         final AuthChallenge authChallenge = parse(challenge);
@@ -208,7 +208,7 @@ public class TestDigestScheme {
         final Credentials creds = new UsernamePasswordCredentials("username","password".toCharArray());
         credentialsProvider.setCredentials(authScope, creds);
 
-        final String challenge = AuthSchemes.DIGEST.id + " realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\"";
+        final String challenge = StandardAuthScheme.DIGEST.id + " realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\"";
         final AuthChallenge authChallenge = parse(challenge);
         final DigestScheme authscheme = new DigestScheme();
         authscheme.processChallenge(authChallenge, null);
@@ -233,7 +233,7 @@ public class TestDigestScheme {
         final Credentials creds = new UsernamePasswordCredentials("username","password".toCharArray());
         credentialsProvider.setCredentials(authScope, creds);
 
-        final String challenge = AuthSchemes.DIGEST.id + " no-realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\"";
+        final String challenge = StandardAuthScheme.DIGEST.id + " no-realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\"";
         final AuthChallenge authChallenge = parse(challenge);
         final DigestScheme authscheme = new DigestScheme();
         authscheme.processChallenge(authChallenge, null);
@@ -251,7 +251,7 @@ public class TestDigestScheme {
         final Credentials creds = new UsernamePasswordCredentials("username","password".toCharArray());
         credentialsProvider.setCredentials(authScope, creds);
 
-        final String challenge = AuthSchemes.DIGEST.id + " realm=\"realm1\", no-nonce=\"f2a3f18799759d4f1a1c068b92b573cb\"";
+        final String challenge = StandardAuthScheme.DIGEST.id + " realm=\"realm1\", no-nonce=\"f2a3f18799759d4f1a1c068b92b573cb\"";
         final AuthChallenge authChallenge = parse(challenge);
         final DigestScheme authscheme = new DigestScheme();
         authscheme.processChallenge(authChallenge, null);
@@ -279,7 +279,7 @@ public class TestDigestScheme {
         final Credentials creds = new UsernamePasswordCredentials(username, password.toCharArray());
         credentialsProvider.setCredentials(authScope, creds);
 
-        final String challenge=AuthSchemes.DIGEST.id + " realm=\"" + realm + "\", "
+        final String challenge=StandardAuthScheme.DIGEST.id + " realm=\"" + realm + "\", "
             + "nonce=\"" + nonce + "\", "
             + "opaque=\"SomeString\", "
             + "stale=false, "
@@ -330,7 +330,7 @@ public class TestDigestScheme {
         final Credentials creds = new UsernamePasswordCredentials(username, password.toCharArray());
         credentialsProvider.setCredentials(authScope, creds);
 
-        final String challenge=AuthSchemes.DIGEST.id + " realm=\"" + realm + "\", "
+        final String challenge=StandardAuthScheme.DIGEST.id + " realm=\"" + realm + "\", "
             + "nonce=\"" + nonce + "\", "
             + "opaque=\"SomeString\", "
             + "stale=false, "
@@ -375,7 +375,7 @@ public class TestDigestScheme {
         final Credentials creds = new UsernamePasswordCredentials(username, password.toCharArray());
         credentialsProvider.setCredentials(authScope, creds);
 
-        final String challenge=AuthSchemes.DIGEST.id + " realm=\"" + realm + "\", "
+        final String challenge=StandardAuthScheme.DIGEST.id + " realm=\"" + realm + "\", "
             + "nonce=\"" + nonce + "\", "
             + "opaque=\"SomeString\", "
             + "stale=false, "
@@ -410,7 +410,7 @@ public class TestDigestScheme {
         final Credentials creds = new UsernamePasswordCredentials(username, password.toCharArray());
         credentialsProvider.setCredentials(authScope, creds);
 
-        final String challenge=AuthSchemes.DIGEST.id + " realm=\"" + realm + "\", "
+        final String challenge=StandardAuthScheme.DIGEST.id + " realm=\"" + realm + "\", "
             + "nonce=\"" + nonce + "\", "
             + "opaque=\"SomeString\", "
             + "stale=false, "
@@ -428,7 +428,7 @@ public class TestDigestScheme {
 
     @Test
     public void testDigestAuthenticationWithStaleNonce() throws Exception {
-        final String challenge = AuthSchemes.DIGEST.id + " realm=\"realm1\", " +
+        final String challenge = StandardAuthScheme.DIGEST.id + " realm=\"realm1\", " +
                 "nonce=\"f2a3f18799759d4f1a1c068b92b573cb\", stale=\"true\"";
         final AuthChallenge authChallenge = parse(challenge);
         final AuthScheme authscheme = new DigestScheme();
@@ -438,7 +438,7 @@ public class TestDigestScheme {
     }
 
     private static Map<String, String> parseAuthResponse(final String authResponse) {
-        if (!authResponse.startsWith(AuthSchemes.DIGEST.id + " ")) {
+        if (!authResponse.startsWith(StandardAuthScheme.DIGEST.id + " ")) {
             return null;
         }
         final String s = authResponse.substring(7);
@@ -460,7 +460,7 @@ public class TestDigestScheme {
         final Credentials creds = new UsernamePasswordCredentials("username","password".toCharArray());
         credentialsProvider.setCredentials(authScope, creds);
 
-        final String challenge1 = AuthSchemes.DIGEST.id + " realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\", qop=auth";
+        final String challenge1 = StandardAuthScheme.DIGEST.id + " realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\", qop=auth";
         final AuthChallenge authChallenge1 = parse(challenge1);
 
         final DigestScheme authscheme = new DigestScheme();
@@ -476,7 +476,7 @@ public class TestDigestScheme {
 
         final Map<String, String> table2 = parseAuthResponse(authResponse2);
         Assert.assertEquals("00000002", table2.get("nc"));
-        final String challenge2 = AuthSchemes.DIGEST.id + " realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\", qop=auth";
+        final String challenge2 = StandardAuthScheme.DIGEST.id + " realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\", qop=auth";
         final AuthChallenge authChallenge2 = parse(challenge2);
         authscheme.processChallenge(authChallenge2, null);
 
@@ -485,7 +485,7 @@ public class TestDigestScheme {
 
         final Map<String, String> table3 = parseAuthResponse(authResponse3);
         Assert.assertEquals("00000003", table3.get("nc"));
-        final String challenge3 = AuthSchemes.DIGEST.id + " realm=\"realm1\", nonce=\"e273f1776275974f1a120d8b92c5b3cb\", qop=auth";
+        final String challenge3 = StandardAuthScheme.DIGEST.id + " realm=\"realm1\", nonce=\"e273f1776275974f1a120d8b92c5b3cb\", qop=auth";
         final AuthChallenge authChallenge3 = parse(challenge3);
         authscheme.processChallenge(authChallenge3, null);
 
@@ -505,7 +505,7 @@ public class TestDigestScheme {
         final Credentials creds = new UsernamePasswordCredentials("username","password".toCharArray());
         credentialsProvider.setCredentials(authScope, creds);
 
-        final String challenge1 = AuthSchemes.DIGEST.id + " qop=\"auth\", algorithm=MD5-sess, nonce=\"1234567890abcdef\", " +
+        final String challenge1 = StandardAuthScheme.DIGEST.id + " qop=\"auth\", algorithm=MD5-sess, nonce=\"1234567890abcdef\", " +
                 "charset=utf-8, realm=\"subnet.domain.com\"";
         final AuthChallenge authChallenge1 = parse(challenge1);
         final DigestScheme authscheme = new DigestScheme();
@@ -528,7 +528,7 @@ public class TestDigestScheme {
         Assert.assertEquals(cnonce1, cnonce2);
         Assert.assertEquals(sessionKey1, sessionKey2);
 
-        final String challenge2 = AuthSchemes.DIGEST.id + " qop=\"auth\", algorithm=MD5-sess, nonce=\"1234567890abcdef\", " +
+        final String challenge2 = StandardAuthScheme.DIGEST.id + " qop=\"auth\", algorithm=MD5-sess, nonce=\"1234567890abcdef\", " +
             "charset=utf-8, realm=\"subnet.domain.com\"";
         final AuthChallenge authChallenge2 = parse(challenge2);
         authscheme.processChallenge(authChallenge2, null);
@@ -543,7 +543,7 @@ public class TestDigestScheme {
         Assert.assertEquals(cnonce1, cnonce3);
         Assert.assertEquals(sessionKey1, sessionKey3);
 
-        final String challenge3 = AuthSchemes.DIGEST.id + " qop=\"auth\", algorithm=MD5-sess, nonce=\"fedcba0987654321\", " +
+        final String challenge3 = StandardAuthScheme.DIGEST.id + " qop=\"auth\", algorithm=MD5-sess, nonce=\"fedcba0987654321\", " +
             "charset=utf-8, realm=\"subnet.domain.com\"";
         final AuthChallenge authChallenge3 = parse(challenge3);
         authscheme.processChallenge(authChallenge3, null);
@@ -595,7 +595,7 @@ public class TestDigestScheme {
         final Credentials creds = new UsernamePasswordCredentials("username","password".toCharArray());
         credentialsProvider.setCredentials(authScope, creds);
 
-        final String challenge = AuthSchemes.DIGEST.id + " realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\", " +
+        final String challenge = StandardAuthScheme.DIGEST.id + " realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\", " +
                 "qop=\"auth,auth-int\"";
         final AuthChallenge authChallenge = parse(challenge);
         final DigestScheme authscheme = new DigestScheme();
@@ -622,7 +622,7 @@ public class TestDigestScheme {
         final Credentials creds = new UsernamePasswordCredentials("username","password".toCharArray());
         credentialsProvider.setCredentials(authScope, creds);
 
-        final String challenge = AuthSchemes.DIGEST.id + " realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\", " +
+        final String challenge = StandardAuthScheme.DIGEST.id + " realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\", " +
                 "qop=\"auth-int\"";
         final AuthChallenge authChallenge = parse(challenge);
         final DigestScheme authscheme = new DigestScheme();
@@ -650,7 +650,7 @@ public class TestDigestScheme {
         final Credentials creds = new UsernamePasswordCredentials("username","password".toCharArray());
         credentialsProvider.setCredentials(authScope, creds);
 
-        final String challenge = AuthSchemes.DIGEST.id + " realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\", " +
+        final String challenge = StandardAuthScheme.DIGEST.id + " realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\", " +
                 "qop=\"auth,auth-int\"";
         final AuthChallenge authChallenge = parse(challenge);
         final DigestScheme authscheme = new DigestScheme();
@@ -677,7 +677,7 @@ public class TestDigestScheme {
         final Credentials creds = new UsernamePasswordCredentials("username","password".toCharArray());
         credentialsProvider.setCredentials(authScope, creds);
 
-        final String challenge = AuthSchemes.DIGEST.id + " Realm=\"-\", " +
+        final String challenge = StandardAuthScheme.DIGEST.id + " Realm=\"-\", " +
                 "nonce=\"YjYuNGYyYmJhMzUuY2I5ZDhlZDE5M2ZlZDM 1Mjk3NGJkNTIyYjgyNTcwMjQ=\", " +
                 "opaque=\"98700A3D9CE17065E2246B41035C6609\", qop=\"auth\"";
         final AuthChallenge authChallenge = parse(challenge);
@@ -699,7 +699,7 @@ public class TestDigestScheme {
         final Credentials creds = new UsernamePasswordCredentials("username","password".toCharArray());
         credentialsProvider.setCredentials(authScope, creds);
 
-        final String challenge = AuthSchemes.DIGEST.id + " realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\", " +
+        final String challenge = StandardAuthScheme.DIGEST.id + " realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\", " +
                 "qop=\"auth-int\"";
         final AuthChallenge authChallenge = parse(challenge);
         final DigestScheme authscheme = new DigestScheme();
@@ -711,7 +711,7 @@ public class TestDigestScheme {
 
     @Test
     public void testSerialization() throws Exception {
-        final String challenge = AuthSchemes.DIGEST.id + " realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\", " +
+        final String challenge = StandardAuthScheme.DIGEST.id + " realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\", " +
                 "qop=\"auth,auth-int\"";
         final AuthChallenge authChallenge = parse(challenge);
         final DigestScheme digestScheme = new DigestScheme();

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestHttpAuthenticator.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestHttpAuthenticator.java
@@ -40,7 +40,7 @@ import org.apache.hc.client5.http.auth.ChallengeType;
 import org.apache.hc.client5.http.auth.Credentials;
 import org.apache.hc.client5.http.auth.CredentialsProvider;
 import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
-import org.apache.hc.client5.http.auth.AuthSchemes;
+import org.apache.hc.client5.http.auth.StandardAuthScheme;
 import org.apache.hc.client5.http.impl.DefaultAuthenticationStrategy;
 import org.apache.hc.client5.http.protocol.HttpClientContext;
 import org.apache.hc.core5.http.HttpHeaders;
@@ -69,7 +69,7 @@ public class TestHttpAuthenticator {
 
         @Override
         public String getName() {
-            return AuthSchemes.BASIC.id;
+            return StandardAuthScheme.BASIC.id;
         }
 
     }
@@ -94,9 +94,9 @@ public class TestHttpAuthenticator {
         this.credentialsProvider = Mockito.mock(CredentialsProvider.class);
         this.context.setAttribute(HttpClientContext.CREDS_PROVIDER, this.credentialsProvider);
         this.authSchemeRegistry = RegistryBuilder.<AuthSchemeFactory>create()
-            .register(AuthSchemes.BASIC.id, BasicSchemeFactory.INSTANCE)
-            .register(AuthSchemes.DIGEST.id, DigestSchemeFactory.INSTANCE)
-            .register(AuthSchemes.NTLM.id, NTLMSchemeFactory.INSTANCE).build();
+            .register(StandardAuthScheme.BASIC.id, BasicSchemeFactory.INSTANCE)
+            .register(StandardAuthScheme.DIGEST.id, DigestSchemeFactory.INSTANCE)
+            .register(StandardAuthScheme.NTLM.id, NTLMSchemeFactory.INSTANCE).build();
         this.context.setAttribute(HttpClientContext.AUTHSCHEME_REGISTRY, this.authSchemeRegistry);
         this.authCache = Mockito.mock(AuthCache.class);
         this.context.setAttribute(HttpClientContext.AUTH_CACHE, this.authCache);
@@ -106,7 +106,7 @@ public class TestHttpAuthenticator {
     @Test
     public void testUpdateAuthExchange() throws Exception {
         final HttpResponse response = new BasicHttpResponse(HttpStatus.SC_UNAUTHORIZED, "UNAUTHORIZED");
-        response.setHeader(HttpHeaders.WWW_AUTHENTICATE, AuthSchemes.BASIC.id + " realm=test");
+        response.setHeader(HttpHeaders.WWW_AUTHENTICATE, StandardAuthScheme.BASIC.id + " realm=test");
         Assert.assertTrue(this.httpAuthenticator.isChallenged(
                 this.defaultHost, ChallengeType.TARGET, response, this.authExchange, this.context));
         Mockito.verifyZeroInteractions(this.authCache);
@@ -115,7 +115,7 @@ public class TestHttpAuthenticator {
     @Test
     public void testAuthenticationRequestedAfterSuccess() throws Exception {
         final HttpResponse response = new BasicHttpResponse(HttpStatus.SC_UNAUTHORIZED, "UNAUTHORIZED");
-        response.setHeader(HttpHeaders.WWW_AUTHENTICATE, AuthSchemes.BASIC.id + " realm=test");
+        response.setHeader(HttpHeaders.WWW_AUTHENTICATE, StandardAuthScheme.BASIC.id + " realm=test");
 
         this.authExchange.select(this.authScheme);
         this.authExchange.setState(AuthExchange.State.SUCCESS);
@@ -165,8 +165,8 @@ public class TestHttpAuthenticator {
     public void testAuthentication() throws Exception {
         final HttpHost host = new HttpHost("somehost", 80);
         final HttpResponse response = new BasicHttpResponse(HttpStatus.SC_UNAUTHORIZED, "UNAUTHORIZED");
-        response.addHeader(new BasicHeader(HttpHeaders.WWW_AUTHENTICATE, AuthSchemes.BASIC.id + " realm=\"test\""));
-        response.addHeader(new BasicHeader(HttpHeaders.WWW_AUTHENTICATE, AuthSchemes.DIGEST.id + " realm=\"realm1\", nonce=\"1234\""));
+        response.addHeader(new BasicHeader(HttpHeaders.WWW_AUTHENTICATE, StandardAuthScheme.BASIC.id + " realm=\"test\""));
+        response.addHeader(new BasicHeader(HttpHeaders.WWW_AUTHENTICATE, StandardAuthScheme.DIGEST.id + " realm=\"realm1\", nonce=\"1234\""));
         response.addHeader(new BasicHeader(HttpHeaders.WWW_AUTHENTICATE, "whatever realm=\"realm1\", stuff=\"1234\""));
 
         final Credentials credentials = new UsernamePasswordCredentials("user", "pass".toCharArray());
@@ -183,10 +183,10 @@ public class TestHttpAuthenticator {
         Assert.assertNotNull(options);
         final AuthScheme authScheme1 = options.poll();
         Assert.assertNotNull(authScheme1);
-        Assert.assertEquals(AuthSchemes.DIGEST.id, authScheme1.getName());
+        Assert.assertEquals(StandardAuthScheme.DIGEST.id, authScheme1.getName());
         final AuthScheme authScheme2 = options.poll();
         Assert.assertNotNull(authScheme2);
-        Assert.assertEquals(AuthSchemes.BASIC.id, authScheme2.getName());
+        Assert.assertEquals(StandardAuthScheme.BASIC.id, authScheme2.getName());
         Assert.assertNull(options.poll());
     }
 
@@ -195,11 +195,11 @@ public class TestHttpAuthenticator {
         final HttpHost host = new HttpHost("somehost", 80);
         final HttpResponse response =
             new BasicHttpResponse(HttpStatus.SC_UNAUTHORIZED, "UNAUTHORIZED");
-        response.addHeader(new BasicHeader(HttpHeaders.WWW_AUTHENTICATE, AuthSchemes.BASIC.id + " realm=\"test\""));
-        response.addHeader(new BasicHeader(HttpHeaders.WWW_AUTHENTICATE, AuthSchemes.DIGEST.id + " realm=\"realm1\", nonce=\"1234\""));
+        response.addHeader(new BasicHeader(HttpHeaders.WWW_AUTHENTICATE, StandardAuthScheme.BASIC.id + " realm=\"test\""));
+        response.addHeader(new BasicHeader(HttpHeaders.WWW_AUTHENTICATE, StandardAuthScheme.DIGEST.id + " realm=\"realm1\", nonce=\"1234\""));
 
         final Credentials credentials = new UsernamePasswordCredentials("user", "pass".toCharArray());
-        Mockito.when(this.credentialsProvider.getCredentials(Mockito.eq(new AuthScope(host, "test", AuthSchemes.BASIC.id)),
+        Mockito.when(this.credentialsProvider.getCredentials(Mockito.eq(new AuthScope(host, "test", StandardAuthScheme.BASIC.id)),
                                                              Mockito.<HttpContext>any())).thenReturn(credentials);
 
         final DefaultAuthenticationStrategy authStrategy = new DefaultAuthenticationStrategy();
@@ -212,7 +212,7 @@ public class TestHttpAuthenticator {
         Assert.assertNotNull(options);
         final AuthScheme authScheme1 = options.poll();
         Assert.assertNotNull(authScheme1);
-        Assert.assertEquals(AuthSchemes.BASIC.id, authScheme1.getName());
+        Assert.assertEquals(StandardAuthScheme.BASIC.id, authScheme1.getName());
         Assert.assertNull(options.poll());
     }
 
@@ -244,8 +244,8 @@ public class TestHttpAuthenticator {
     public void testAuthenticationNoCredentials() throws Exception {
         final HttpHost host = new HttpHost("somehost", 80);
         final HttpResponse response = new BasicHttpResponse(HttpStatus.SC_UNAUTHORIZED, "UNAUTHORIZED");
-        response.addHeader(new BasicHeader(HttpHeaders.WWW_AUTHENTICATE, AuthSchemes.BASIC.id + " realm=\"test\""));
-        response.addHeader(new BasicHeader(HttpHeaders.WWW_AUTHENTICATE, AuthSchemes.DIGEST.id + " realm=\"realm1\", nonce=\"1234\""));
+        response.addHeader(new BasicHeader(HttpHeaders.WWW_AUTHENTICATE, StandardAuthScheme.BASIC.id + " realm=\"test\""));
+        response.addHeader(new BasicHeader(HttpHeaders.WWW_AUTHENTICATE, StandardAuthScheme.DIGEST.id + " realm=\"realm1\", nonce=\"1234\""));
 
         final DefaultAuthenticationStrategy authStrategy = new DefaultAuthenticationStrategy();
 
@@ -257,8 +257,8 @@ public class TestHttpAuthenticator {
     public void testAuthenticationFailed() throws Exception {
         final HttpHost host = new HttpHost("somehost", 80);
         final HttpResponse response = new BasicHttpResponse(HttpStatus.SC_UNAUTHORIZED, "UNAUTHORIZED");
-        response.addHeader(new BasicHeader(HttpHeaders.WWW_AUTHENTICATE, AuthSchemes.BASIC.id + " realm=\"test\""));
-        response.addHeader(new BasicHeader(HttpHeaders.WWW_AUTHENTICATE, AuthSchemes.DIGEST.id + " realm=\"realm1\", nonce=\"1234\""));
+        response.addHeader(new BasicHeader(HttpHeaders.WWW_AUTHENTICATE, StandardAuthScheme.BASIC.id + " realm=\"test\""));
+        response.addHeader(new BasicHeader(HttpHeaders.WWW_AUTHENTICATE, StandardAuthScheme.DIGEST.id + " realm=\"realm1\", nonce=\"1234\""));
 
         this.authExchange.setState(AuthExchange.State.CHALLENGED);
         this.authExchange.select(this.authScheme);
@@ -277,8 +277,8 @@ public class TestHttpAuthenticator {
     public void testAuthenticationFailedPreviously() throws Exception {
         final HttpHost host = new HttpHost("somehost", 80);
         final HttpResponse response = new BasicHttpResponse(HttpStatus.SC_UNAUTHORIZED, "UNAUTHORIZED");
-        response.addHeader(new BasicHeader(HttpHeaders.WWW_AUTHENTICATE, AuthSchemes.BASIC.id + " realm=\"test\""));
-        response.addHeader(new BasicHeader(HttpHeaders.WWW_AUTHENTICATE, AuthSchemes.DIGEST.id + " realm=\"realm1\", nonce=\"1234\""));
+        response.addHeader(new BasicHeader(HttpHeaders.WWW_AUTHENTICATE, StandardAuthScheme.BASIC.id + " realm=\"test\""));
+        response.addHeader(new BasicHeader(HttpHeaders.WWW_AUTHENTICATE, StandardAuthScheme.DIGEST.id + " realm=\"realm1\", nonce=\"1234\""));
 
         this.authExchange.setState(AuthExchange.State.FAILURE);
 
@@ -294,8 +294,8 @@ public class TestHttpAuthenticator {
     public void testAuthenticationFailure() throws Exception {
         final HttpHost host = new HttpHost("somehost", 80);
         final HttpResponse response = new BasicHttpResponse(HttpStatus.SC_UNAUTHORIZED, "UNAUTHORIZED");
-        response.addHeader(new BasicHeader(HttpHeaders.WWW_AUTHENTICATE, AuthSchemes.BASIC.id + " realm=\"test\""));
-        response.addHeader(new BasicHeader(HttpHeaders.WWW_AUTHENTICATE, AuthSchemes.DIGEST.id + " realm=\"realm1\", nonce=\"1234\""));
+        response.addHeader(new BasicHeader(HttpHeaders.WWW_AUTHENTICATE, StandardAuthScheme.BASIC.id + " realm=\"test\""));
+        response.addHeader(new BasicHeader(HttpHeaders.WWW_AUTHENTICATE, StandardAuthScheme.DIGEST.id + " realm=\"realm1\", nonce=\"1234\""));
         response.addHeader(new BasicHeader(HttpHeaders.WWW_AUTHENTICATE, "whatever realm=\"realm1\", stuff=\"1234\""));
 
         final DefaultAuthenticationStrategy authStrategy = new DefaultAuthenticationStrategy();
@@ -312,8 +312,8 @@ public class TestHttpAuthenticator {
     public void testAuthenticationHandshaking() throws Exception {
         final HttpHost host = new HttpHost("somehost", 80);
         final HttpResponse response = new BasicHttpResponse(HttpStatus.SC_UNAUTHORIZED, "UNAUTHORIZED");
-        response.addHeader(new BasicHeader(HttpHeaders.WWW_AUTHENTICATE, AuthSchemes.BASIC.id + " realm=\"test\""));
-        response.addHeader(new BasicHeader(HttpHeaders.WWW_AUTHENTICATE, AuthSchemes.DIGEST.id + " realm=\"realm1\", stale=true, nonce=\"1234\""));
+        response.addHeader(new BasicHeader(HttpHeaders.WWW_AUTHENTICATE, StandardAuthScheme.BASIC.id + " realm=\"test\""));
+        response.addHeader(new BasicHeader(HttpHeaders.WWW_AUTHENTICATE, StandardAuthScheme.DIGEST.id + " realm=\"realm1\", stale=true, nonce=\"1234\""));
         response.addHeader(new BasicHeader(HttpHeaders.WWW_AUTHENTICATE, "whatever realm=\"realm1\", stuff=\"1234\""));
 
         final DefaultAuthenticationStrategy authStrategy = new DefaultAuthenticationStrategy();
@@ -331,11 +331,11 @@ public class TestHttpAuthenticator {
     public void testAuthenticationNoMatchingChallenge() throws Exception {
         final HttpHost host = new HttpHost("somehost", 80);
         final HttpResponse response = new BasicHttpResponse(HttpStatus.SC_UNAUTHORIZED, "UNAUTHORIZED");
-        response.addHeader(new BasicHeader(HttpHeaders.WWW_AUTHENTICATE, AuthSchemes.DIGEST.id + " realm=\"realm1\", nonce=\"1234\""));
+        response.addHeader(new BasicHeader(HttpHeaders.WWW_AUTHENTICATE, StandardAuthScheme.DIGEST.id + " realm=\"realm1\", nonce=\"1234\""));
         response.addHeader(new BasicHeader(HttpHeaders.WWW_AUTHENTICATE, "whatever realm=\"realm1\", stuff=\"1234\""));
 
         final Credentials credentials = new UsernamePasswordCredentials("user", "pass".toCharArray());
-        Mockito.when(this.credentialsProvider.getCredentials(Mockito.eq(new AuthScope(host, "realm1", AuthSchemes.DIGEST.id)),
+        Mockito.when(this.credentialsProvider.getCredentials(Mockito.eq(new AuthScope(host, "realm1", StandardAuthScheme.DIGEST.id)),
                                                              Mockito.<HttpContext>any())).thenReturn(credentials);
 
         final DefaultAuthenticationStrategy authStrategy = new DefaultAuthenticationStrategy();
@@ -351,7 +351,7 @@ public class TestHttpAuthenticator {
         Assert.assertNotNull(options);
         final AuthScheme authScheme1 = options.poll();
         Assert.assertNotNull(authScheme1);
-        Assert.assertEquals(AuthSchemes.DIGEST.id, authScheme1.getName());
+        Assert.assertEquals(StandardAuthScheme.DIGEST.id, authScheme1.getName());
         Assert.assertNull(options.poll());
     }
 

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestSystemDefaultCredentialsProvider.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestSystemDefaultCredentialsProvider.java
@@ -32,7 +32,7 @@ import java.net.InetAddress;
 import java.net.PasswordAuthentication;
 import java.net.URL;
 
-import org.apache.hc.client5.http.auth.AuthSchemes;
+import org.apache.hc.client5.http.auth.StandardAuthScheme;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.Credentials;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
@@ -92,7 +92,7 @@ public class TestSystemDefaultCredentialsProvider {
         final AuthenticatorDelegate authenticatorDelegate = installAuthenticator(AUTH1);
 
         final URL httpRequestUrl = new URL(TARGET_SCHEME1, TARGET_HOST1, TARGET_PORT1, "/");
-        final AuthScope authScope = new AuthScope(PROXY_PROTOCOL1, PROXY_HOST1, PROXY_PORT1, PROMPT1, AuthSchemes.BASIC.id);
+        final AuthScope authScope = new AuthScope(PROXY_PROTOCOL1, PROXY_HOST1, PROXY_PORT1, PROMPT1, StandardAuthScheme.BASIC.id);
         final HttpCoreContext coreContext = new HttpCoreContext();
         coreContext.setAttribute(HttpCoreContext.HTTP_REQUEST, new HttpGet(httpRequestUrl.toURI()));
 
@@ -100,7 +100,7 @@ public class TestSystemDefaultCredentialsProvider {
             new SystemDefaultCredentialsProvider().getCredentials(authScope, coreContext);
 
         Mockito.verify(authenticatorDelegate).getPasswordAuthentication(PROXY_HOST1, null, PROXY_PORT1, PROXY_PROTOCOL1,
-                                                                        PROMPT1, AuthSchemes.BASIC.id, httpRequestUrl,
+                                                                        PROMPT1, StandardAuthScheme.BASIC.id, httpRequestUrl,
                                                                         RequestorType.SERVER);
         Assert.assertNotNull(receivedCredentials);
         Assert.assertEquals(AUTH1.getUserName(), receivedCredentials.getUserPrincipal().getName());
@@ -112,13 +112,13 @@ public class TestSystemDefaultCredentialsProvider {
 
         final AuthenticatorDelegate authenticatorDelegate = installAuthenticator(AUTH1);
 
-        final AuthScope authScope = new AuthScope(PROXY_PROTOCOL1, PROXY_HOST1, PROXY_PORT1, PROMPT1, AuthSchemes.BASIC.id);
+        final AuthScope authScope = new AuthScope(PROXY_PROTOCOL1, PROXY_HOST1, PROXY_PORT1, PROMPT1, StandardAuthScheme.BASIC.id);
 
         final Credentials receivedCredentials =
             new SystemDefaultCredentialsProvider().getCredentials(authScope, null);
 
         Mockito.verify(authenticatorDelegate).getPasswordAuthentication(PROXY_HOST1, null, PROXY_PORT1, PROXY_PROTOCOL1,
-                                                                        PROMPT1, AuthSchemes.BASIC.id, null,
+                                                                        PROMPT1, StandardAuthScheme.BASIC.id, null,
                                                                         RequestorType.SERVER);
         Assert.assertNotNull(receivedCredentials);
         Assert.assertEquals(AUTH1.getUserName(), receivedCredentials.getUserPrincipal().getName());

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/classic/TestConnectExec.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/classic/TestConnectExec.java
@@ -36,7 +36,7 @@ import org.apache.hc.client5.http.HttpRoute;
 import org.apache.hc.client5.http.RouteInfo;
 import org.apache.hc.client5.http.auth.AuthChallenge;
 import org.apache.hc.client5.http.auth.AuthScheme;
-import org.apache.hc.client5.http.auth.AuthSchemes;
+import org.apache.hc.client5.http.auth.StandardAuthScheme;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.ChallengeType;
 import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
@@ -245,7 +245,7 @@ public class TestConnectExec {
         final HttpClientContext context = new HttpClientContext();
         final ClassicHttpRequest request = new HttpGet("http://bar/test");
         final ClassicHttpResponse response1 = new BasicClassicHttpResponse(407, "Huh?");
-        response1.setHeader(HttpHeaders.PROXY_AUTHENTICATE, AuthSchemes.BASIC.id + " realm=test");
+        response1.setHeader(HttpHeaders.PROXY_AUTHENTICATE, StandardAuthScheme.BASIC.id + " realm=test");
         final InputStream inStream1 = Mockito.spy(new ByteArrayInputStream(new byte[] {1, 2, 3}));
         response1.setEntity(EntityBuilder.create()
                 .setStream(inStream1)
@@ -286,7 +286,7 @@ public class TestConnectExec {
         final HttpClientContext context = new HttpClientContext();
         final ClassicHttpRequest request = new HttpGet("http://bar/test");
         final ClassicHttpResponse response1 = new BasicClassicHttpResponse(407, "Huh?");
-        response1.setHeader(HttpHeaders.PROXY_AUTHENTICATE, AuthSchemes.BASIC.id + " realm=test");
+        response1.setHeader(HttpHeaders.PROXY_AUTHENTICATE, StandardAuthScheme.BASIC.id + " realm=test");
         final InputStream inStream1 = Mockito.spy(new ByteArrayInputStream(new byte[] {1, 2, 3}));
         response1.setEntity(EntityBuilder.create()
                 .setStream(inStream1)

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/classic/TestProtocolExec.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/classic/TestProtocolExec.java
@@ -39,7 +39,7 @@ import org.apache.hc.client5.http.HttpRoute;
 import org.apache.hc.client5.http.auth.AuthChallenge;
 import org.apache.hc.client5.http.auth.AuthExchange;
 import org.apache.hc.client5.http.auth.AuthScheme;
-import org.apache.hc.client5.http.auth.AuthSchemes;
+import org.apache.hc.client5.http.auth.StandardAuthScheme;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.ChallengeType;
 import org.apache.hc.client5.http.auth.Credentials;
@@ -214,7 +214,7 @@ public class TestProtocolExec {
         final HttpClientContext context = new HttpClientContext();
         final ClassicHttpRequest request = new HttpGet("http://foo/test");
         final ClassicHttpResponse response1 = new BasicClassicHttpResponse(401, "Huh?");
-        response1.setHeader(HttpHeaders.WWW_AUTHENTICATE, AuthSchemes.BASIC.id + " realm=test");
+        response1.setHeader(HttpHeaders.WWW_AUTHENTICATE, StandardAuthScheme.BASIC.id + " realm=test");
         final InputStream inStream1 = Mockito.spy(new ByteArrayInputStream(new byte[] {1, 2, 3}));
         response1.setEntity(EntityBuilder.create()
                 .setStream(inStream1)
@@ -253,7 +253,7 @@ public class TestProtocolExec {
         final HttpRoute route = new HttpRoute(target, proxy);
         final ClassicHttpRequest request = new HttpGet("http://foo/test");
         final ClassicHttpResponse response1 = new BasicClassicHttpResponse(401, "Huh?");
-        response1.setHeader(HttpHeaders.WWW_AUTHENTICATE, AuthSchemes.BASIC.id + " realm=test");
+        response1.setHeader(HttpHeaders.WWW_AUTHENTICATE, StandardAuthScheme.BASIC.id + " realm=test");
         final InputStream inStream1 = Mockito.spy(new ByteArrayInputStream(new byte[] {1, 2, 3}));
         response1.setEntity(EntityBuilder.create()
                 .setStream(inStream1)
@@ -305,7 +305,7 @@ public class TestProtocolExec {
                 .setStream(inStream0)
                 .build());
         final ClassicHttpResponse response1 = new BasicClassicHttpResponse(401, "Huh?");
-        response1.setHeader(HttpHeaders.WWW_AUTHENTICATE, AuthSchemes.BASIC.id + " realm=test");
+        response1.setHeader(HttpHeaders.WWW_AUTHENTICATE, StandardAuthScheme.BASIC.id + " realm=test");
         final InputStream inStream1 = new ByteArrayInputStream(new byte[] {1, 2, 3});
         response1.setEntity(EntityBuilder.create()
                 .setStream(inStream1)


### PR DESCRIPTION
I know, the branch say "core' in the name, but it's for the client.

https://issues.apache.org/jira/browse/HTTPCLIENT-2046