### PR TITLE
Rename CookieSpecs enum to StandardCookieSpec final class

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/cookie/StandardCookieSpec.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/cookie/StandardCookieSpec.java
@@ -28,33 +28,31 @@
 package org.apache.hc.client5.http.cookie;
 
 /**
- * Supported cookie specifications.
+ * Cookie specifications by their names supported by the HttpClient.
  *
  * @since 4.3
  */
-public enum CookieSpecs {
+public final class StandardCookieSpec {
+
+    private StandardCookieSpec() {
+        // no instances
+    }
 
     /**
      * The RFC 6265 compliant policy (interoprability profile).
      */
-    STANDARD("standard"),
+    public static final String RELAXED = "relaxed";
 
     /**
      * The RFC 6265 compliant policy (strict profile).
      *
      * @since 4.4
      */
-    STANDARD_STRICT("standard-strict"),
+    public static final String STRICT = "strict";
 
     /**
      * The policy that ignores cookies.
      */
-    IGNORE_COOKIES("ignoreCookies");
-
-    public final String id;
-
-    CookieSpecs(final String id) {
-        this.id = id;
-    }
+    public static final String IGNORE = "ignore";
 
 }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/CookieSpecSupport.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/CookieSpecSupport.java
@@ -27,7 +27,7 @@
 
 package org.apache.hc.client5.http.impl;
 
-import org.apache.hc.client5.http.cookie.CookieSpecs;
+import org.apache.hc.client5.http.cookie.StandardCookieSpec;
 import org.apache.hc.client5.http.cookie.CookieSpecFactory;
 import org.apache.hc.client5.http.impl.cookie.IgnoreCookieSpecFactory;
 import org.apache.hc.client5.http.impl.cookie.RFC6265CookieSpecFactory;
@@ -50,11 +50,11 @@ public final class CookieSpecSupport {
      */
     public static RegistryBuilder<CookieSpecFactory> createDefaultBuilder(final PublicSuffixMatcher publicSuffixMatcher) {
         return RegistryBuilder.<CookieSpecFactory>create()
-                .register(CookieSpecs.STANDARD.id, new RFC6265CookieSpecFactory(
+                .register(StandardCookieSpec.RELAXED, new RFC6265CookieSpecFactory(
                         RFC6265CookieSpecFactory.CompatibilityLevel.RELAXED, publicSuffixMatcher))
-                .register(CookieSpecs.STANDARD_STRICT.id, new RFC6265CookieSpecFactory(
+                .register(StandardCookieSpec.STRICT, new RFC6265CookieSpecFactory(
                         RFC6265CookieSpecFactory.CompatibilityLevel.STRICT, publicSuffixMatcher))
-                .register(CookieSpecs.IGNORE_COOKIES.id, new IgnoreCookieSpecFactory());
+                .register(StandardCookieSpec.IGNORE, new IgnoreCookieSpecFactory());
     }
 
     /**

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/protocol/RequestAddCookies.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/protocol/RequestAddCookies.java
@@ -33,7 +33,7 @@ import java.util.Date;
 import java.util.List;
 
 import org.apache.hc.client5.http.RouteInfo;
-import org.apache.hc.client5.http.cookie.CookieSpecs;
+import org.apache.hc.client5.http.cookie.StandardCookieSpec;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.cookie.Cookie;
 import org.apache.hc.client5.http.cookie.CookieOrigin;
@@ -106,12 +106,12 @@ public class RequestAddCookies implements HttpRequestInterceptor {
         }
 
         final RequestConfig config = clientContext.getRequestConfig();
-        String policy = config.getCookieSpec();
-        if (policy == null) {
-            policy = CookieSpecs.STANDARD.id;
+        String cookieSpecName = config.getCookieSpec();
+        if (cookieSpecName == null) {
+            cookieSpecName = StandardCookieSpec.STRICT;
         }
         if (this.log.isDebugEnabled()) {
-            this.log.debug("CookieSpec selected: " + policy);
+            this.log.debug("Cookie spec selected: " + cookieSpecName);
         }
 
         final URIAuthority authority = request.getAuthority();
@@ -130,15 +130,15 @@ public class RequestAddCookies implements HttpRequestInterceptor {
         final CookieOrigin cookieOrigin = new CookieOrigin(hostName, port, path, route.isSecure());
 
         // Get an instance of the selected cookie policy
-        final CookieSpecFactory provider = registry.lookup(policy);
-        if (provider == null) {
+        final CookieSpecFactory factory = registry.lookup(cookieSpecName);
+        if (factory == null) {
             if (this.log.isDebugEnabled()) {
-                this.log.debug("Unsupported cookie policy: " + policy);
+                this.log.debug("Unsupported cookie spec: " + cookieSpecName);
             }
 
             return;
         }
-        final CookieSpec cookieSpec = provider.create(clientContext);
+        final CookieSpec cookieSpec = factory.create(clientContext);
         // Get all cookies available in the HTTP state
         final List<Cookie> cookies = cookieStore.getCookies();
         // Find cookies matching the given origin

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/config/TestRequestConfig.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/config/TestRequestConfig.java
@@ -31,7 +31,7 @@ import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.hc.client5.http.auth.StandardAuthScheme;
-import org.apache.hc.client5.http.cookie.CookieSpecs;
+import org.apache.hc.client5.http.cookie.StandardCookieSpec;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.util.TimeValue;
 import org.apache.hc.core5.util.Timeout;
@@ -73,7 +73,7 @@ public class TestRequestConfig {
                 .setRedirectsEnabled(false)
                 .setCircularRedirectsAllowed(true)
                 .setMaxRedirects(100)
-                .setCookieSpec(CookieSpecs.STANDARD.id)
+                .setCookieSpec(StandardCookieSpec.STRICT)
                 .setProxy(new HttpHost("someproxy"))
                 .setTargetPreferredAuthSchemes(Collections.singletonList(StandardAuthScheme.NTLM))
                 .setProxyPreferredAuthSchemes(Collections.singletonList(StandardAuthScheme.DIGEST))
@@ -87,7 +87,7 @@ public class TestRequestConfig {
         Assert.assertEquals(false, config.isRedirectsEnabled());
         Assert.assertEquals(true, config.isCircularRedirectsAllowed());
         Assert.assertEquals(100, config.getMaxRedirects());
-        Assert.assertEquals(CookieSpecs.STANDARD.id, config.getCookieSpec());
+        Assert.assertEquals(StandardCookieSpec.STRICT, config.getCookieSpec());
         Assert.assertEquals(new HttpHost("someproxy"), config.getProxy());
         Assert.assertEquals(Collections.singletonList(StandardAuthScheme.NTLM), config.getTargetPreferredAuthSchemes());
         Assert.assertEquals(Collections.singletonList(StandardAuthScheme.DIGEST), config.getProxyPreferredAuthSchemes());

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClientConfiguration.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClientConfiguration.java
@@ -43,7 +43,7 @@ import org.apache.hc.client5.http.auth.CredentialsProvider;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.cookie.BasicCookieStore;
-import org.apache.hc.client5.http.cookie.CookieSpecs;
+import org.apache.hc.client5.http.cookie.StandardCookieSpec;
 import org.apache.hc.client5.http.cookie.CookieStore;
 import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
@@ -193,7 +193,7 @@ public class ClientConfiguration {
         final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
         // Create global request configuration
         final RequestConfig defaultRequestConfig = RequestConfig.custom()
-            .setCookieSpec(CookieSpecs.STANDARD.id)
+            .setCookieSpec(StandardCookieSpec.STRICT)
             .setExpectContinueEnabled(true)
             .setTargetPreferredAuthSchemes(Arrays.asList(StandardAuthScheme.NTLM, StandardAuthScheme.DIGEST))
             .setProxyPreferredAuthSchemes(Arrays.asList(StandardAuthScheme.BASIC))

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClientCustomPublicSuffixList.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClientCustomPublicSuffixList.java
@@ -29,7 +29,7 @@ package org.apache.hc.client5.http.examples;
 import java.net.URL;
 
 import org.apache.hc.client5.http.classic.methods.HttpGet;
-import org.apache.hc.client5.http.cookie.CookieSpecs;
+import org.apache.hc.client5.http.cookie.StandardCookieSpec;
 import org.apache.hc.client5.http.cookie.CookieSpecFactory;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
@@ -61,10 +61,10 @@ public class ClientCustomPublicSuffixList {
         // Please use the publicsuffix.org URL to download the list no more than once per day !!!
         // Please consider making a local copy !!!
 
-        final RFC6265CookieSpecFactory cookieSpecProvider = new RFC6265CookieSpecFactory(publicSuffixMatcher);
+        final RFC6265CookieSpecFactory cookieSpecFactory = new RFC6265CookieSpecFactory(publicSuffixMatcher);
         final Lookup<CookieSpecFactory> cookieSpecRegistry = RegistryBuilder.<CookieSpecFactory>create()
-                .register(CookieSpecs.STANDARD.id, cookieSpecProvider)
-                .register(CookieSpecs.STANDARD_STRICT.id, cookieSpecProvider)
+                .register(StandardCookieSpec.RELAXED, cookieSpecFactory)
+                .register(StandardCookieSpec.STRICT, cookieSpecFactory)
                 .build();
         final SSLConnectionSocketFactory sslsf = new SSLConnectionSocketFactory(
                 SSLContexts.createDefault(),

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/protocol/TestRequestAddCookies.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/protocol/TestRequestAddCookies.java
@@ -31,7 +31,7 @@ import java.util.Date;
 import org.apache.hc.client5.http.HttpRoute;
 import org.apache.hc.client5.http.RouteInfo.LayerType;
 import org.apache.hc.client5.http.RouteInfo.TunnelType;
-import org.apache.hc.client5.http.cookie.CookieSpecs;
+import org.apache.hc.client5.http.cookie.StandardCookieSpec;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.cookie.BasicCookieStore;
 import org.apache.hc.client5.http.cookie.CookieOrigin;
@@ -76,11 +76,11 @@ public class TestRequestAddCookies {
         this.cookieStore.addCookie(cookie2);
 
         this.cookieSpecRegistry = RegistryBuilder.<CookieSpecFactory>create()
-            .register(CookieSpecs.STANDARD.id, new RFC6265CookieSpecFactory(
+            .register(StandardCookieSpec.RELAXED, new RFC6265CookieSpecFactory(
                     RFC6265CookieSpecFactory.CompatibilityLevel.RELAXED, null))
-            .register(CookieSpecs.STANDARD_STRICT.id,  new RFC6265CookieSpecFactory(
+            .register(StandardCookieSpec.STRICT,  new RFC6265CookieSpecFactory(
                     RFC6265CookieSpecFactory.CompatibilityLevel.STRICT, null))
-            .register(CookieSpecs.IGNORE_COOKIES.id, new IgnoreCookieSpecFactory())
+            .register(StandardCookieSpec.IGNORE, new IgnoreCookieSpecFactory())
             .build();
     }
 
@@ -203,7 +203,7 @@ public class TestRequestAddCookies {
     public void testAddCookiesUsingExplicitCookieSpec() throws Exception {
         final HttpRequest request = new BasicHttpRequest("GET", "/");
         final RequestConfig config = RequestConfig.custom()
-                .setCookieSpec(CookieSpecs.STANDARD_STRICT.id)
+                .setCookieSpec(StandardCookieSpec.STRICT)
                 .build();
         final HttpRoute route = new HttpRoute(this.target, null, false);
 


### PR DESCRIPTION
Modeled after StandardCharsets, the new class indicates a non-exhaustive
list of standard cookie specifications by name supported by the HttpClient.
The previous enum suffered from two issues:

* it was exhaustive implying that no more cookie specifications can be supported
* its sole purpose was to contain an id for the declared cookie specification;
  the enum values theirselves were never used directly

@ok2c  This also reuses the naming approach of HttpMultipartMode of symbolic names for
implementation behavior.

This closes #197