### PR TITLE
DefaultHostnameVerifier: Match DNS and CN names against ICANN domains

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/DefaultHostnameVerifier.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/DefaultHostnameVerifier.java
@@ -164,7 +164,7 @@ public final class DefaultHostnameVerifier implements HttpClientHostnameVerifier
             final SubjectName subjectAlt = subjectAlts.get(i);
             if (subjectAlt.getType() == SubjectName.DNS) {
                 final String normalizedSubjectAlt = subjectAlt.getValue().toLowerCase(Locale.ROOT);
-                if (matchIdentityStrict(normalizedHost, normalizedSubjectAlt, publicSuffixMatcher)) {
+                if (matchIdentityStrict(normalizedHost, normalizedSubjectAlt, publicSuffixMatcher, DomainType.ICANN)) {
                     return;
                 }
             }
@@ -177,7 +177,7 @@ public final class DefaultHostnameVerifier implements HttpClientHostnameVerifier
                  final PublicSuffixMatcher publicSuffixMatcher) throws SSLException {
         final String normalizedHost = host.toLowerCase(Locale.ROOT);
         final String normalizedCn = cn.toLowerCase(Locale.ROOT);
-        if (!matchIdentityStrict(normalizedHost, normalizedCn, publicSuffixMatcher)) {
+        if (!matchIdentityStrict(normalizedHost, normalizedCn, publicSuffixMatcher, DomainType.ICANN)) {
             throw new SSLPeerUnverifiedException("Certificate for <" + host + "> doesn't match " +
                     "common name of the certificate subject: " + cn);
         }


### PR DESCRIPTION
This change ensures that during hostname verification the public suffix
list is only used to prevent wildcard matching against entire TLDs (e.g.
`*.com`). Currently, private domains are also being matched against,
which is preventing reasonable wildcards (such as
`*.s3.eu-central-1.amazonaws.com`) from being respected.