### PR TITLE
Now that ClassicHttpRequests is no longer an enum, we need to way to

### DIFF
--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -1,10 +1,20 @@
 ﻿Release 5.0-BETA8
 -----------------
 
-* Build requests from method names in ClassicHttpRequests #204.
+* GitHub #204: Build requests from method names in ClassicHttpRequests:
   ClassicHttpRequests.create(String, String)
   ClassicHttpRequests.create(String, URI)
   Contributed by Gary Gregory <ggregory at apache.org>
+
+* GitHub #205: Update request factory classes with matching APIs for Method and String method name inputs:
+  BasicHttpRequests.create(String, URI)
+  BasicHttpRequests.create(String, String)
+  ClassicHttpRequests.create(Method, String)
+  ClassicHttpRequests.create(Method, URI)
+  SimpleHttpRequests.create(String, URI)
+  SimpleHttpRequests.create(String, String)
+  Contributed by Gary Gregory <ggregory at apache.org>
+
 
 Release 5.0-BETA7
 -----------------

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/async/methods/BasicHttpRequests.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/async/methods/BasicHttpRequests.java
@@ -29,11 +29,11 @@ package org.apache.hc.client5.http.async.methods;
 
 import java.net.URI;
 import java.util.Locale;
-import java.util.Objects;
 
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.Method;
 import org.apache.hc.core5.http.message.BasicHttpRequest;
+import org.apache.hc.core5.util.Args;
 
 /**
  * Common HTTP methods using {@link BasicHttpRequest} as a HTTP request message representation.
@@ -45,7 +45,7 @@ public final class BasicHttpRequests {
     // TODO Next version of HttpCore:
     // Method.normalizedValueOf(method)
     private static Method normalizedValueOf(final String method) {
-        return Method.valueOf(Objects.requireNonNull(method, "method").toUpperCase(Locale.ROOT));
+        return Method.valueOf(Args.notNull(method, "method").toUpperCase(Locale.ROOT));
     }
 
     /**

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/async/methods/BasicHttpRequests.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/async/methods/BasicHttpRequests.java
@@ -28,6 +28,8 @@
 package org.apache.hc.client5.http.async.methods;
 
 import java.net.URI;
+import java.util.Locale;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.Method;
@@ -39,6 +41,38 @@ import org.apache.hc.core5.http.message.BasicHttpRequest;
  * @since 5.0
  */
 public final class BasicHttpRequests {
+
+    // TODO Next version of HttpCore:
+    // Method.normalizedValueOf(method)
+    private static Method normalizedValueOf(final String method) {
+        return Method.valueOf(Objects.requireNonNull(method, "method").toUpperCase(Locale.ROOT));
+    }
+
+    /**
+     * Creates a new BasicHttpRequest for the given {@code method} and {@code String} URI.
+     *
+     * @param method A method supported by this class.
+     * @param uri a non-null request string URI.
+     * @return A new BasicHttpRequest.
+     */
+    public static BasicHttpRequest create(final String method, final String uri) {
+        // TODO Next version of HttpCore:
+        // return create(Method.normalizedValueOf(method), uri);
+        return create(normalizedValueOf(method), uri);
+    }
+
+    /**
+     * Creates a new BasicHttpRequest for the given {@code method} and {@code URI}.
+     *
+     * @param method A method supported by this class.
+     * @param uri a non-null request URI.
+     * @return A new BasicHttpRequest.
+     */
+    public static BasicHttpRequest create(final String method, final URI uri) {
+        // TODO Next version of HttpCore:
+        // return create(Method.normalizedValueOf(method), uri);
+        return create(normalizedValueOf(method), uri);
+    }
 
     public static BasicHttpRequest delete(final String uri) {
         return delete(URI.create(uri));

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/async/methods/SimpleHttpRequests.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/async/methods/SimpleHttpRequests.java
@@ -29,10 +29,10 @@ package org.apache.hc.client5.http.async.methods;
 
 import java.net.URI;
 import java.util.Locale;
-import java.util.Objects;
 
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.Method;
+import org.apache.hc.core5.util.Args;
 
 /**
  * Common HTTP methods using {@link SimpleHttpRequest} as a HTTP request message representation.
@@ -44,7 +44,7 @@ public final class SimpleHttpRequests {
     // TODO Next version of HttpCore:
     // Method.normalizedValueOf(method)
     private static Method normalizedValueOf(final String method) {
-        return Method.valueOf(Objects.requireNonNull(method, "method").toUpperCase(Locale.ROOT));
+        return Method.valueOf(Args.notNull(method, "method").toUpperCase(Locale.ROOT));
     }
 
     /**

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/async/methods/SimpleHttpRequests.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/async/methods/SimpleHttpRequests.java
@@ -28,6 +28,8 @@
 package org.apache.hc.client5.http.async.methods;
 
 import java.net.URI;
+import java.util.Locale;
+import java.util.Objects;
 
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.Method;
@@ -38,6 +40,38 @@ import org.apache.hc.core5.http.Method;
  * @since 5.0
  */
 public final class SimpleHttpRequests {
+
+    // TODO Next version of HttpCore:
+    // Method.normalizedValueOf(method)
+    private static Method normalizedValueOf(final String method) {
+        return Method.valueOf(Objects.requireNonNull(method, "method").toUpperCase(Locale.ROOT));
+    }
+
+    /**
+     * Creates a new BasicHttpRequest for the given {@code method} and {@code String} URI.
+     *
+     * @param method A method supported by this class.
+     * @param uri a non-null request string URI.
+     * @return A new BasicHttpRequest.
+     */
+    public static SimpleHttpRequest create(final String method, final String uri) {
+        // TODO Next version of HttpCore:
+        // return create(Method.normalizedValueOf(method), uri);
+        return create(normalizedValueOf(method), uri);
+    }
+
+    /**
+     * Creates a new BasicHttpRequest for the given {@code method} and {@code URI}.
+     *
+     * @param method A method supported by this class.
+     * @param uri a non-null request URI.
+     * @return A new BasicHttpRequest.
+     */
+    public static SimpleHttpRequest create(final String method, final URI uri) {
+        // TODO Next version of HttpCore:
+        // return create(Method.normalizedValueOf(method), uri);
+        return create(normalizedValueOf(method), uri);
+    }
 
     public static SimpleHttpRequest delete(final String uri) {
         return delete(URI.create(uri));

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/classic/methods/ClassicHttpRequests.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/classic/methods/ClassicHttpRequests.java
@@ -31,6 +31,8 @@ import java.net.URI;
 import java.util.Locale;
 import java.util.Objects;
 
+import org.apache.hc.core5.http.Method;
+
 
 /**
  * Common HTTP methods using {@link HttpUriRequest} as a HTTP request message representation.
@@ -42,8 +44,51 @@ import java.util.Objects;
  */
 public final class ClassicHttpRequests {
 
-    private static String cleanMethod(final String method) {
-        return Objects.requireNonNull(method, "method").toUpperCase(Locale.ROOT);
+    private static Method normalizedValueOf(final String method) {
+        // TODO Next version of HttpCore:
+        // Method.normalizedValueOf(method)
+        return Method.valueOf(Objects.requireNonNull(method, "method").toUpperCase(Locale.ROOT));
+    }
+
+    /**
+     * Creates a new HttpUriRequest for the given {@code Method} and {@code String} URI.
+     *
+     * @param method A method.
+     * @param uri a URI.
+     * @return a new HttpUriRequest.
+     */
+    public static HttpUriRequest create(final Method method, final String uri) {
+        return create(method, URI.create(uri));
+    }
+
+    /**
+     * Creates a new HttpUriRequest for the given {@code Method} and {@code URI}.
+     *
+     * @param method A method.
+     * @param uri a URI.
+     * @return a new HttpUriRequest.
+     */
+    public static HttpUriRequest create(final Method method, final URI uri) {
+        switch (Objects.requireNonNull(method, "method")) {
+        case DELETE:
+            return delete(uri);
+        case GET:
+            return get(uri);
+        case HEAD:
+            return head(uri);
+        case OPTIONS:
+            return options(uri);
+        case PATCH:
+            return patch(uri);
+        case POST:
+            return post(uri);
+        case PUT:
+            return put(uri);
+        case TRACE:
+            return trace(uri);
+        default:
+            throw new IllegalArgumentException(method.toString());
+        }
     }
 
     /**
@@ -56,26 +101,7 @@ public final class ClassicHttpRequests {
      * @return A new HttpUriRequest.
      */
     public static HttpUriRequest create(final String method, final String uri) {
-        switch (cleanMethod(method)) {
-        case HttpDelete.METHOD_NAME:
-            return ClassicHttpRequests.delete(uri);
-        case HttpGet.METHOD_NAME:
-            return ClassicHttpRequests.get(uri);
-        case HttpHead.METHOD_NAME:
-            return ClassicHttpRequests.head(uri);
-        case HttpOptions.METHOD_NAME:
-            return ClassicHttpRequests.options(uri);
-        case HttpPatch.METHOD_NAME:
-            return ClassicHttpRequests.patch(uri);
-        case HttpPost.METHOD_NAME:
-            return ClassicHttpRequests.post(uri);
-        case HttpPut.METHOD_NAME:
-            return ClassicHttpRequests.put(uri);
-        case HttpTrace.METHOD_NAME:
-            return ClassicHttpRequests.trace(uri);
-        default:
-            throw new IllegalArgumentException(method);
-        }
+        return create(normalizedValueOf(method), uri);
     }
 
     /**
@@ -88,26 +114,7 @@ public final class ClassicHttpRequests {
      * @return A new HttpUriRequest.
      */
     public static HttpUriRequest create(final String method, final URI uri) {
-        switch (cleanMethod(method)) {
-        case HttpDelete.METHOD_NAME:
-            return ClassicHttpRequests.delete(uri);
-        case HttpGet.METHOD_NAME:
-            return ClassicHttpRequests.get(uri);
-        case HttpHead.METHOD_NAME:
-            return ClassicHttpRequests.head(uri);
-        case HttpOptions.METHOD_NAME:
-            return ClassicHttpRequests.options(uri);
-        case HttpPatch.METHOD_NAME:
-            return ClassicHttpRequests.patch(uri);
-        case HttpPost.METHOD_NAME:
-            return ClassicHttpRequests.post(uri);
-        case HttpPut.METHOD_NAME:
-            return ClassicHttpRequests.put(uri);
-        case HttpTrace.METHOD_NAME:
-            return ClassicHttpRequests.trace(uri);
-        default:
-            throw new IllegalArgumentException(method);
-        }
+        return create(normalizedValueOf(method), uri);
     }
 
     public static HttpUriRequest delete(final String uri) {

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/classic/methods/ClassicHttpRequests.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/classic/methods/ClassicHttpRequests.java
@@ -29,9 +29,9 @@ package org.apache.hc.client5.http.classic.methods;
 
 import java.net.URI;
 import java.util.Locale;
-import java.util.Objects;
 
 import org.apache.hc.core5.http.Method;
+import org.apache.hc.core5.util.Args;
 
 
 /**
@@ -47,7 +47,7 @@ public final class ClassicHttpRequests {
     private static Method normalizedValueOf(final String method) {
         // TODO Next version of HttpCore:
         // Method.normalizedValueOf(method)
-        return Method.valueOf(Objects.requireNonNull(method, "method").toUpperCase(Locale.ROOT));
+        return Method.valueOf(Args.notNull(method, "method").toUpperCase(Locale.ROOT));
     }
 
     /**
@@ -69,7 +69,7 @@ public final class ClassicHttpRequests {
      * @return a new HttpUriRequest.
      */
     public static HttpUriRequest create(final Method method, final URI uri) {
-        switch (Objects.requireNonNull(method, "method")) {
+        switch (Args.notNull(method, "method")) {
         case DELETE:
             return delete(uri);
         case GET:

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/async/methods/SimpleBasicHttpRequests.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/async/methods/SimpleBasicHttpRequests.java
@@ -32,7 +32,6 @@ import java.net.URI;
 import java.util.Arrays;
 
 import org.apache.hc.core5.http.HttpRequest;
-import org.apache.hc.core5.http.message.BasicHttpRequest;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -40,7 +39,7 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
 @RunWith(Parameterized.class)
-public class TestBasicHttpRequests {
+public class SimpleBasicHttpRequests {
 
     private static final String URI_STRING_FIXTURE = "http://localhost";
     private static final URI URI_FIXTURE = URI.create(URI_STRING_FIXTURE);
@@ -65,28 +64,28 @@ public class TestBasicHttpRequests {
 
   private final String expectedMethod;
 
-  public TestBasicHttpRequests(final String methodName, final String expectedMethod) {
+  public SimpleBasicHttpRequests(final String methodName, final String expectedMethod) {
     this.methodName = methodName;
     this.expectedMethod = expectedMethod;
   }
 
   @Test
   public void testCreateMethodUri() {
-      Assert.assertEquals(BasicHttpRequest.class, BasicHttpRequests.create(methodName, URI_FIXTURE).getClass());
-      Assert.assertEquals(BasicHttpRequest.class, BasicHttpRequests.create(expectedMethod, URI_FIXTURE).getClass());
+      Assert.assertEquals(SimpleHttpRequest.class, SimpleHttpRequests.create(methodName, URI_FIXTURE).getClass());
+      Assert.assertEquals(SimpleHttpRequest.class, SimpleHttpRequests.create(expectedMethod, URI_FIXTURE).getClass());
   }
 
   @Test
   public void testCreateMethodUriString() {
-      Assert.assertEquals(BasicHttpRequest.class, BasicHttpRequests.create(methodName, URI_STRING_FIXTURE).getClass());
-      Assert.assertEquals(BasicHttpRequest.class, BasicHttpRequests.create(expectedMethod, URI_STRING_FIXTURE).getClass());
+      Assert.assertEquals(SimpleHttpRequest.class, SimpleHttpRequests.create(methodName, URI_STRING_FIXTURE).getClass());
+      Assert.assertEquals(SimpleHttpRequest.class, SimpleHttpRequests.create(expectedMethod, URI_STRING_FIXTURE).getClass());
   }
 
   @Test
   public void testCreateClassicHttpRequest() throws Exception {
-    final Method httpMethod = BasicHttpRequests.class.getMethod(methodName, URI.class);
+    final Method httpMethod = SimpleHttpRequests.class.getMethod(methodName, URI.class);
     final HttpRequest basicHttpRequest = (HttpRequest) httpMethod.invoke(null, URI_FIXTURE);
-    Assert.assertEquals(BasicHttpRequest.class, basicHttpRequest.getClass());
+    Assert.assertEquals(SimpleHttpRequest.class, basicHttpRequest.getClass());
     Assert.assertEquals(expectedMethod, basicHttpRequest.getMethod());
   }
 }


### PR DESCRIPTION
generically build requests from method names. Update all factory classes
with matching APIs for Method and String method name inputs.