### PR TITLE
re-add validateAfterInactivity to pool manager

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java
@@ -187,6 +187,7 @@ public class PoolingHttpClientConnectionManager
             final TimeValue timeToLive,
             final HttpConnectionFactory<ManagedHttpClientConnection> connFactory) {
         super();
+        this.setValidateAfterInactivity(2000);
         this.connectionOperator = Args.notNull(httpClientConnectionOperator, "Connection operator");
         switch (poolConcurrencyPolicy != null ? poolConcurrencyPolicy : PoolConcurrencyPolicy.STRICT) {
             case STRICT:

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java
@@ -187,7 +187,7 @@ public class PoolingHttpClientConnectionManager
             final TimeValue timeToLive,
             final HttpConnectionFactory<ManagedHttpClientConnection> connFactory) {
         super();
-        this.setValidateAfterInactivity(2000);
+        this.setValidateAfterInactivity(TimeValue.ofMilliseconds(2000));
         this.connectionOperator = Args.notNull(httpClientConnectionOperator, "Connection operator");
         switch (poolConcurrencyPolicy != null ? poolConcurrencyPolicy : PoolConcurrencyPolicy.STRICT) {
             case STRICT:


### PR DESCRIPTION
It is really ugly that this setting was removed with https://github.com/apache/httpcomponents-client/commit/e48091da3d945b056d9ad9ea46a62b91e142d33f#diff-66a448bdca2ba2ef9a7c3f8d93784078L187. This default value is responsible for checking bad connections and people will not notice this change if they upgrade, because it will not happen very frequently: https://github.com/apache/httpcomponents-client/blob/rel/v4.5.9/httpclient/src/main/java/org/apache/http/impl/conn/PoolingHttpClientConnectionManager.java#L182