### PR TITLE
Fix NPE for null HttpContext in MinimalHttpAsyncClient and MinimalH2AsyncClient

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/MinimalH2AsyncClient.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/MinimalH2AsyncClient.java
@@ -136,7 +136,7 @@ public final class MinimalH2AsyncClient extends AbstractMinimalHttpAsyncClientBa
             final HttpContext context) {
         ensureRunning();
         final ComplexCancellable cancellable = new ComplexCancellable();
-        final HttpClientContext clientContext = HttpClientContext.adapt(context);
+        final HttpClientContext clientContext = context != null ? HttpClientContext.adapt(context) : HttpClientContext.create();
         try {
             exchangeHandler.produceRequest(new RequestChannel() {
 

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/MinimalHttpAsyncClient.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/MinimalHttpAsyncClient.java
@@ -248,7 +248,7 @@ public final class MinimalHttpAsyncClient extends AbstractMinimalHttpAsyncClient
             final HttpContext context) {
         ensureRunning();
         final ComplexCancellable cancellable = new ComplexCancellable();
-        final HttpClientContext clientContext = HttpClientContext.adapt(context);
+        final HttpClientContext clientContext = context != null ? HttpClientContext.adapt(context) : HttpClientContext.create();
         try {
             exchangeHandler.produceRequest(new RequestChannel() {
 


### PR DESCRIPTION
Fixes JIRA HTTPCLIENT-2059
According to the javadoc in `HttpAsyncClient`, the `HttpContext` parameter can be null. However, `MinimalHttpAsyncClient` and `MinimalH2AsyncClient` both reject null `HttpContext`.