### PR TITLE
HTTPCLIENT-2077: Migration from HttpClient v4.5.x to v5.0 causes NTLM…

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/NTLMScheme.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/NTLMScheme.java
@@ -99,9 +99,7 @@ public final class NTLMScheme implements AuthScheme {
             final AuthChallenge authChallenge,
             final HttpContext context) throws MalformedChallengeException {
         Args.notNull(authChallenge, "AuthChallenge");
-        if (authChallenge.getValue() == null) {
-            throw new MalformedChallengeException("Missing auth challenge");
-        }
+
         this.challenge = authChallenge.getValue();
         if (this.challenge == null || this.challenge.isEmpty()) {
             if (this.state == State.UNINITIATED) {

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestNTLMScheme.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestNTLMScheme.java
@@ -46,10 +46,10 @@ public class TestNTLMScheme {
         authScheme.processChallenge(authChallenge, null);
 
         Assert.assertFalse(
-                "Challenge with empty value received from NTML proxy must not interrupt authentication process.",
+                "Challenge with an empty value received from NTML proxy must not interrupt authentication process.",
                 authScheme.isChallengeComplete());
         Assert.assertTrue(
-                "Challenge with empty value received from NTML proxy must transit status of NTLMScheme to CHALLENGE_RECEIVED.",
+                "Challenge with an empty value received from NTML proxy must transit status of NTLMScheme to CHALLENGE_RECEIVED.",
                 authScheme.toString().contains(NTLMScheme.State.CHALLENGE_RECEIVED.toString()));
     }
 }

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestNTLMScheme.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestNTLMScheme.java
@@ -24,17 +24,19 @@
  * <http://www.apache.org/>.
  *
  */
+
 package org.apache.hc.client5.http.impl.auth;
 
 import org.apache.hc.client5.http.auth.AuthChallenge;
 import org.apache.hc.client5.http.auth.AuthScheme;
 import org.apache.hc.client5.http.auth.ChallengeType;
 import org.apache.hc.client5.http.auth.StandardAuthScheme;
-
 import org.junit.Assert;
 import org.junit.Test;
 
-
+/**
+ * Unit tests for {@link NTLMScheme}.
+ */
 public class TestNTLMScheme {
 
     @Test

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestNTLMScheme.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestNTLMScheme.java
@@ -1,0 +1,53 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.client5.http.impl.auth;
+
+import org.apache.hc.client5.http.auth.AuthChallenge;
+import org.apache.hc.client5.http.auth.AuthScheme;
+import org.apache.hc.client5.http.auth.ChallengeType;
+import org.apache.hc.client5.http.auth.StandardAuthScheme;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class TestNTLMScheme {
+
+    @Test
+    public void testNTLMAuthenticationEmptyProxyChallenge() throws Exception {
+        final AuthChallenge authChallenge = new AuthChallenge(ChallengeType.PROXY, StandardAuthScheme.NTLM);
+        final AuthScheme authScheme = new NTLMScheme();
+        authScheme.processChallenge(authChallenge, null);
+
+        Assert.assertFalse(
+                "Challenge with empty value received from NTML proxy must not interrupt authentication process.",
+                authScheme.isChallengeComplete());
+        Assert.assertTrue(
+                "Challenge with empty value received from NTML proxy must transit status of NTLMScheme to CHALLENGE_RECEIVED.",
+                authScheme.toString().contains(NTLMScheme.State.CHALLENGE_RECEIVED.toString()));
+    }
+}


### PR DESCRIPTION
… proxy authentication failure.

Fixes the issue [HTTPCLIENT-2077](https://issues.apache.org/jira/browse/HTTPCLIENT-2077)

The failure was caused by an unnecessary null condition check `authChallenge.getValue()==null` throwing a MalformedChallengeException in the method `org.apache.hc.client5.http.impl.auth.NTLMScheme# processChallenge` :

```
    @Override
    public void processChallenge(
            final AuthChallenge authChallenge,
            final HttpContext context) throws MalformedChallengeException {
        Args.notNull(authChallenge, "AuthChallenge");
        if (authChallenge.getValue() == null) {    <----------------- NOT NECESSARY CHECK 
            throw new MalformedChallengeException("Missing auth challenge");
        }
        this.challenge = authChallenge.getValue();
        if (this.challenge == null || this.challenge.isEmpty()) {  <--- CORRECT CONDITION CHECK
            if (this.state == State.UNINITIATED) {
                this.state = State.CHALLENGE_RECEIVED;
            } else {
                this.state = State.FAILED;
            }
        } else {
            if (this.state.compareTo(State.MSG_TYPE1_GENERATED) < 0) {
                this.state = State.FAILED;
                throw new MalformedChallengeException("Out of sequence NTLM response message");
            } else if (this.state == State.MSG_TYPE1_GENERATED) {
                this.state = State.MSG_TYPE2_RECEVIED;
            }
        }
    }

```

