### PR TITLE
Disable SNI extension for a specific SSLConnectionSocketFactory

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/SSLConnectionSocketFactory.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/SSLConnectionSocketFactory.java
@@ -175,7 +175,7 @@ public class SSLConnectionSocketFactory implements LayeredConnectionSocketFactor
             final HostnameVerifier hostnameVerifier) {
        this(socketFactory, supportedProtocols, supportedCipherSuites, hostnameVerifier, false);
     }
-    
+
     /**
      * @since 5.0.1
      */
@@ -287,14 +287,14 @@ public class SSLConnectionSocketFactory implements LayeredConnectionSocketFactor
             this.log.debug("Enabled protocols: " + Arrays.asList(sslsock.getEnabledProtocols()));
             this.log.debug("Enabled cipher suites:" + Arrays.asList(sslsock.getEnabledCipherSuites()));
         }
-        
+
         // Patch for some websites - SSLHandshakeException : received handshake warning: unrecognized_name
- 		// Same as -Djsse.enableSNIExtension=false but only for this factory
- 		if (disableSNIExtension) {
- 			SSLParameters p = sslsock.getSSLParameters();
- 			p.setServerNames(new ArrayList<SNIServerName>());
- 			sslsock.setSSLParameters(p);
- 		}
+        // Same as -Djsse.enableSNIExtension=false but only for this factory
+        if (disableSNIExtension) {
+            final SSLParameters p = sslsock.getSSLParameters();
+            p.setServerNames(new ArrayList<SNIServerName>());
+            sslsock.setSSLParameters(p);
+        }
 
         prepareSocket(sslsock);
         this.log.debug("Starting handshake");

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/SSLConnectionSocketFactoryBuilder.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/SSLConnectionSocketFactoryBuilder.java
@@ -71,7 +71,7 @@ public class SSLConnectionSocketFactoryBuilder {
     private HostnameVerifier hostnameVerifier;
     private boolean systemProperties;
     private boolean disableSNIExtension;
-    
+
     /**
      * Disable the SNI extension for this specific SSLConnectionSocketFactory.
      * Acts as the -DenableSNIExtension=false JVM option but only for this factory.
@@ -162,7 +162,7 @@ public class SSLConnectionSocketFactoryBuilder {
                 tlsVersionsCopy,
                 ciphersCopy,
                 hostnameVerifier != null ? hostnameVerifier : HttpsSupport.getDefaultHostnameVerifier(),
-        		disableSNIExtension);
+                disableSNIExtension);
     }
 
 }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/SSLConnectionSocketFactoryBuilder.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/SSLConnectionSocketFactoryBuilder.java
@@ -70,6 +70,16 @@ public class SSLConnectionSocketFactoryBuilder {
     private String[] ciphers;
     private HostnameVerifier hostnameVerifier;
     private boolean systemProperties;
+    private boolean disableSNIExtension;
+    
+    /**
+     * Disable the SNI extension for this specific SSLConnectionSocketFactory.
+     * Acts as the -DenableSNIExtension=false JVM option but only for this factory.
+     */
+    public final SSLConnectionSocketFactoryBuilder disableSNIExtension() {
+        this.disableSNIExtension = true;
+        return this;
+    }
 
     /**
      * Assigns {@link SSLContext} instance.
@@ -151,7 +161,8 @@ public class SSLConnectionSocketFactoryBuilder {
                 socketFactory,
                 tlsVersionsCopy,
                 ciphersCopy,
-                hostnameVerifier != null ? hostnameVerifier : HttpsSupport.getDefaultHostnameVerifier());
+                hostnameVerifier != null ? hostnameVerifier : HttpsSupport.getDefaultHostnameVerifier(),
+        		disableSNIExtension);
     }
 
 }


### PR DESCRIPTION
Some website have badly configured their SSL/TLS and it is not correctly managed by java, thus having an exception instead of  simple warning : "javax.net.ssl.SSLHandshakeException: received handshake warning: unrecognized_name". This is a know problem for java > 8

The solution to bypass this problem is to disable the SNI extension but it could only be done at the JVM level with a -D option of programmatically with System.setProperty("jsse.enableSNIExtension", "false")

This patch allows to disable the SNI verification for a single SSLConnectionSocketFactory, as explained here : https://stackoverflow.com/questions/55903477/received-handshake-warning-unrecognized-name