### PR TITLE
HTTPCLIENT-2095: Use slf4j interpolation instead of string concatenation where possible

### DIFF
--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/BasicHttpAsyncCache.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/BasicHttpAsyncCache.java
@@ -98,7 +98,7 @@ class BasicHttpAsyncCache implements HttpAsyncCache {
     public Cancellable flushCacheEntriesFor(
             final HttpHost host, final HttpRequest request, final FutureCallback<Boolean> callback) {
         if (log.isDebugEnabled()) {
-            log.debug("Flush cache entries: " + host + "; " + new RequestLine(request));
+            log.debug("Flush cache entries: {}; {}", host, new RequestLine(request));
         }
         if (!Method.isSafe(request.getMethod())) {
             final String cacheKey = cacheKeyGenerator.generateKey(host, request);
@@ -113,7 +113,7 @@ class BasicHttpAsyncCache implements HttpAsyncCache {
                 public void failed(final Exception ex) {
                     if (ex instanceof ResourceIOException) {
                         if (log.isWarnEnabled()) {
-                            log.warn("I/O error removing cache entry with key " + cacheKey);
+                            log.warn("I/O error removing cache entry with key {}", cacheKey);
                         }
                         callback.completed(Boolean.TRUE);
                     } else {
@@ -136,7 +136,7 @@ class BasicHttpAsyncCache implements HttpAsyncCache {
     public Cancellable flushCacheEntriesInvalidatedByRequest(
             final HttpHost host, final HttpRequest request, final FutureCallback<Boolean> callback) {
         if (log.isDebugEnabled()) {
-            log.debug("Flush cache entries invalidated by request: " + host + "; " + new RequestLine(request));
+            log.debug("Flush cache entries invalidated by request: {}; {}", host, new RequestLine(request));
         }
         return cacheInvalidator.flushCacheEntriesInvalidatedByRequest(host, request, cacheKeyGenerator, storage, callback);
     }
@@ -145,7 +145,7 @@ class BasicHttpAsyncCache implements HttpAsyncCache {
     public Cancellable flushCacheEntriesInvalidatedByExchange(
             final HttpHost host, final HttpRequest request, final HttpResponse response, final FutureCallback<Boolean> callback) {
         if (log.isDebugEnabled()) {
-            log.debug("Flush cache entries invalidated by exchange: " + host + "; " + new RequestLine(request) + " -> " + new StatusLine(response));
+            log.debug("Flush cache entries invalidated by exchange: {}; {} -> {}", host, new RequestLine(request), new StatusLine(response));
         }
         if (!Method.isSafe(request.getMethod())) {
             return cacheInvalidator.flushCacheEntriesInvalidatedByExchange(host, request, response, cacheKeyGenerator, storage, callback);
@@ -182,7 +182,7 @@ class BasicHttpAsyncCache implements HttpAsyncCache {
             public void failed(final Exception ex) {
                 if (ex instanceof ResourceIOException) {
                     if (log.isWarnEnabled()) {
-                        log.warn("I/O error storing cache entry with key " + cacheKey);
+                        log.warn("I/O error storing cache entry with key {}", cacheKey);
                     }
                     callback.completed(Boolean.TRUE);
                 } else {
@@ -230,11 +230,11 @@ class BasicHttpAsyncCache implements HttpAsyncCache {
                             public void failed(final Exception ex) {
                                 if (ex instanceof HttpCacheUpdateException) {
                                     if (log.isWarnEnabled()) {
-                                        log.warn("Cannot update cache entry with key " + cacheKey);
+                                        log.warn("Cannot update cache entry with key {}", cacheKey);
                                     }
                                 } else if (ex instanceof ResourceIOException) {
                                     if (log.isWarnEnabled()) {
-                                        log.warn("I/O error updating cache entry with key " + cacheKey);
+                                        log.warn("I/O error updating cache entry with key {}", cacheKey);
                                     }
                                 } else {
                                     callback.failed(ex);
@@ -253,7 +253,7 @@ class BasicHttpAsyncCache implements HttpAsyncCache {
             public void failed(final Exception ex) {
                 if (ex instanceof ResourceIOException) {
                     if (log.isWarnEnabled()) {
-                        log.warn("I/O error updating cache entry with key " + variantCacheKey);
+                        log.warn("I/O error updating cache entry with key {}", variantCacheKey);
                     }
                     callback.completed(Boolean.TRUE);
                 } else {
@@ -273,7 +273,7 @@ class BasicHttpAsyncCache implements HttpAsyncCache {
     public Cancellable reuseVariantEntryFor(
             final HttpHost host, final HttpRequest request, final Variant variant, final FutureCallback<Boolean> callback) {
         if (log.isDebugEnabled()) {
-            log.debug("Re-use variant entry: " + host + "; " + new RequestLine(request) + " / " + variant);
+            log.debug("Re-use variant entry: {}; {} / {}", host, new RequestLine(request), variant);
         }
         final String cacheKey = cacheKeyGenerator.generateKey(host, request);
         final HttpCacheEntry entry = variant.getEntry();
@@ -299,11 +299,11 @@ class BasicHttpAsyncCache implements HttpAsyncCache {
                     public void failed(final Exception ex) {
                         if (ex instanceof HttpCacheUpdateException) {
                             if (log.isWarnEnabled()) {
-                                log.warn("Cannot update cache entry with key " + cacheKey);
+                                log.warn("Cannot update cache entry with key {}", cacheKey);
                             }
                         } else if (ex instanceof ResourceIOException) {
                             if (log.isWarnEnabled()) {
-                                log.warn("I/O error updating cache entry with key " + cacheKey);
+                                log.warn("I/O error updating cache entry with key {}", cacheKey);
                             }
                         } else {
                             callback.failed(ex);
@@ -328,7 +328,7 @@ class BasicHttpAsyncCache implements HttpAsyncCache {
             final Date responseReceived,
             final FutureCallback<HttpCacheEntry> callback) {
         if (log.isDebugEnabled()) {
-            log.debug("Update cache entry: " + host + "; " + new RequestLine(request));
+            log.debug("Update cache entry: {}; {}", host, new RequestLine(request));
         }
         final String cacheKey = cacheKeyGenerator.generateKey(host, request);
         try {
@@ -358,7 +358,7 @@ class BasicHttpAsyncCache implements HttpAsyncCache {
             });
         } catch (final ResourceIOException ex) {
             if (log.isWarnEnabled()) {
-                log.warn("I/O error updating cache entry with key " + cacheKey);
+                log.warn("I/O error updating cache entry with key {}", cacheKey);
             }
             callback.completed(stale);
             return Operations.nonCancellable();
@@ -375,7 +375,7 @@ class BasicHttpAsyncCache implements HttpAsyncCache {
             final Date responseReceived,
             final FutureCallback<HttpCacheEntry> callback) {
         if (log.isDebugEnabled()) {
-            log.debug("Update variant cache entry: " + host + "; " + new RequestLine(request) + " / " + variant);
+            log.debug("Update variant cache entry: {}; {} / {}", host, new RequestLine(request), variant);
         }
         final HttpCacheEntry entry = variant.getEntry();
         final String cacheKey = variant.getCacheKey();
@@ -406,7 +406,7 @@ class BasicHttpAsyncCache implements HttpAsyncCache {
             });
         } catch (final ResourceIOException ex) {
             if (log.isWarnEnabled()) {
-                log.warn("I/O error updating cache entry with key " + cacheKey);
+                log.warn("I/O error updating cache entry with key {}", cacheKey);
             }
             callback.completed(entry);
             return Operations.nonCancellable();
@@ -423,7 +423,7 @@ class BasicHttpAsyncCache implements HttpAsyncCache {
             final Date responseReceived,
             final FutureCallback<HttpCacheEntry> callback) {
         if (log.isDebugEnabled()) {
-            log.debug("Create cache entry: " + host + "; " + new RequestLine(request));
+            log.debug("Create cache entry: {}; {}", host, new RequestLine(request));
         }
         final String cacheKey = cacheKeyGenerator.generateKey(host, request);
         try {
@@ -448,7 +448,7 @@ class BasicHttpAsyncCache implements HttpAsyncCache {
             });
         } catch (final ResourceIOException ex) {
             if (log.isWarnEnabled()) {
-                log.warn("I/O error creating cache entry with key " + cacheKey);
+                log.warn("I/O error creating cache entry with key {}", cacheKey);
             }
             callback.completed(new HttpCacheEntry(
                     requestSent,
@@ -463,7 +463,7 @@ class BasicHttpAsyncCache implements HttpAsyncCache {
     @Override
     public Cancellable getCacheEntry(final HttpHost host, final HttpRequest request, final FutureCallback<HttpCacheEntry> callback) {
         if (log.isDebugEnabled()) {
-            log.debug("Get cache entry: " + host + "; " + new RequestLine(request));
+            log.debug("Get cache entry: {}; {}", host, new RequestLine(request));
         }
         final ComplexCancellable complexCancellable = new ComplexCancellable();
         final String cacheKey = cacheKeyGenerator.generateKey(host, request);
@@ -489,7 +489,7 @@ class BasicHttpAsyncCache implements HttpAsyncCache {
                                         public void failed(final Exception ex) {
                                             if (ex instanceof ResourceIOException) {
                                                 if (log.isWarnEnabled()) {
-                                                    log.warn("I/O error retrieving cache entry with key " + variantCacheKey);
+                                                    log.warn("I/O error retrieving cache entry with key {}", variantCacheKey);
                                                 }
                                                 callback.completed(null);
                                             } else {
@@ -514,7 +514,7 @@ class BasicHttpAsyncCache implements HttpAsyncCache {
             public void failed(final Exception ex) {
                 if (ex instanceof ResourceIOException) {
                     if (log.isWarnEnabled()) {
-                        log.warn("I/O error retrieving cache entry with key " + cacheKey);
+                        log.warn("I/O error retrieving cache entry with key {}", cacheKey);
                     }
                     callback.completed(null);
                 } else {
@@ -535,7 +535,7 @@ class BasicHttpAsyncCache implements HttpAsyncCache {
     public Cancellable getVariantCacheEntriesWithEtags(
             final HttpHost host, final HttpRequest request, final FutureCallback<Map<String, Variant>> callback) {
         if (log.isDebugEnabled()) {
-            log.debug("Get variant cache entries: " + host + "; " + new RequestLine(request));
+            log.debug("Get variant cache entries: {}; {}", host, new RequestLine(request));
         }
         final ComplexCancellable complexCancellable = new ComplexCancellable();
         final String cacheKey = cacheKeyGenerator.generateKey(host, request);
@@ -567,7 +567,7 @@ class BasicHttpAsyncCache implements HttpAsyncCache {
                                 public void failed(final Exception ex) {
                                     if (ex instanceof ResourceIOException) {
                                         if (log.isWarnEnabled()) {
-                                            log.warn("I/O error retrieving cache entry with keys " + variantCacheKeys);
+                                            log.warn("I/O error retrieving cache entry with keys {}", variantCacheKeys);
                                         }
                                         callback.completed(variants);
                                     } else {
@@ -590,7 +590,7 @@ class BasicHttpAsyncCache implements HttpAsyncCache {
             public void failed(final Exception ex) {
                 if (ex instanceof ResourceIOException) {
                     if (log.isWarnEnabled()) {
-                        log.warn("I/O error retrieving cache entry with key " + cacheKey);
+                        log.warn("I/O error retrieving cache entry with key {}", cacheKey);
                     }
                     callback.completed(variants);
                 } else {

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/BasicHttpCache.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/BasicHttpCache.java
@@ -100,7 +100,7 @@ class BasicHttpCache implements HttpCache {
     @Override
     public void flushCacheEntriesFor(final HttpHost host, final HttpRequest request) {
         if (log.isDebugEnabled()) {
-            log.debug("Flush cache entries: " + host + "; " + new RequestLine(request));
+            log.debug("Flush cache entries: {}; {}", host, new RequestLine(request));
         }
         if (!Method.isSafe(request.getMethod())) {
             final String cacheKey = cacheKeyGenerator.generateKey(host, request);
@@ -108,7 +108,7 @@ class BasicHttpCache implements HttpCache {
                 storage.removeEntry(cacheKey);
             } catch (final ResourceIOException ex) {
                 if (log.isWarnEnabled()) {
-                    log.warn("I/O error removing cache entry with key " + cacheKey);
+                    log.warn("I/O error removing cache entry with key {}", cacheKey);
                 }
             }
         }
@@ -117,7 +117,7 @@ class BasicHttpCache implements HttpCache {
     @Override
     public void flushCacheEntriesInvalidatedByRequest(final HttpHost host, final HttpRequest request) {
         if (log.isDebugEnabled()) {
-            log.debug("Flush cache entries invalidated by request: " + host + "; " + new RequestLine(request));
+            log.debug("Flush cache entries invalidated by request: {}; {}", host, new RequestLine(request));
         }
         cacheInvalidator.flushCacheEntriesInvalidatedByRequest(host, request, cacheKeyGenerator, storage);
     }
@@ -125,7 +125,7 @@ class BasicHttpCache implements HttpCache {
     @Override
     public void flushCacheEntriesInvalidatedByExchange(final HttpHost host, final HttpRequest request, final HttpResponse response) {
         if (log.isDebugEnabled()) {
-            log.debug("Flush cache entries invalidated by exchange: " + host + "; " + new RequestLine(request) + " -> " + new StatusLine(response));
+            log.debug("Flush cache entries invalidated by exchange: {}; {} -> {}", host, new RequestLine(request), new StatusLine(response));
         }
         if (!Method.isSafe(request.getMethod())) {
             cacheInvalidator.flushCacheEntriesInvalidatedByExchange(host, request, response, cacheKeyGenerator, storage);
@@ -149,7 +149,7 @@ class BasicHttpCache implements HttpCache {
             storage.putEntry(cacheKey, entry);
         } catch (final ResourceIOException ex) {
             if (log.isWarnEnabled()) {
-                log.warn("I/O error storing cache entry with key " + cacheKey);
+                log.warn("I/O error storing cache entry with key {}", cacheKey);
             }
         }
     }
@@ -173,11 +173,11 @@ class BasicHttpCache implements HttpCache {
             });
         } catch (final HttpCacheUpdateException ex) {
             if (log.isWarnEnabled()) {
-                log.warn("Cannot update cache entry with key " + cacheKey);
+                log.warn("Cannot update cache entry with key {}", cacheKey);
             }
         } catch (final ResourceIOException ex) {
             if (log.isWarnEnabled()) {
-                log.warn("I/O error updating cache entry with key " + cacheKey);
+                log.warn("I/O error updating cache entry with key {}", cacheKey);
             }
         }
     }
@@ -186,7 +186,7 @@ class BasicHttpCache implements HttpCache {
     public void reuseVariantEntryFor(
             final HttpHost host, final HttpRequest request, final Variant variant) {
         if (log.isDebugEnabled()) {
-            log.debug("Re-use variant entry: " + host + "; " + new RequestLine(request) + " / " + variant);
+            log.debug("Re-use variant entry: {}; {} / {}", host, new RequestLine(request), variant);
         }
         final String cacheKey = cacheKeyGenerator.generateKey(host, request);
         final HttpCacheEntry entry = variant.getEntry();
@@ -204,11 +204,11 @@ class BasicHttpCache implements HttpCache {
             });
         } catch (final HttpCacheUpdateException ex) {
             if (log.isWarnEnabled()) {
-                log.warn("Cannot update cache entry with key " + cacheKey);
+                log.warn("Cannot update cache entry with key {}", cacheKey);
             }
         } catch (final ResourceIOException ex) {
             if (log.isWarnEnabled()) {
-                log.warn("I/O error updating cache entry with key " + cacheKey);
+                log.warn("I/O error updating cache entry with key {}", cacheKey);
             }
         }
     }
@@ -222,7 +222,7 @@ class BasicHttpCache implements HttpCache {
             final Date requestSent,
             final Date responseReceived) {
         if (log.isDebugEnabled()) {
-            log.debug("Update cache entry: " + host + "; " + new RequestLine(request));
+            log.debug("Update cache entry: {}; {}", host, new RequestLine(request));
         }
         final String cacheKey = cacheKeyGenerator.generateKey(host, request);
         try {
@@ -236,7 +236,7 @@ class BasicHttpCache implements HttpCache {
             return updatedEntry;
         } catch (final ResourceIOException ex) {
             if (log.isWarnEnabled()) {
-                log.warn("I/O error updating cache entry with key " + cacheKey);
+                log.warn("I/O error updating cache entry with key {}", cacheKey);
             }
             return stale;
         }
@@ -251,7 +251,7 @@ class BasicHttpCache implements HttpCache {
             final Date requestSent,
             final Date responseReceived) {
         if (log.isDebugEnabled()) {
-            log.debug("Update variant cache entry: " + host + "; " + new RequestLine(request) + " / " + variant);
+            log.debug("Update variant cache entry: {}; {} / {}", host, new RequestLine(request), variant);
         }
         final HttpCacheEntry entry = variant.getEntry();
         final String cacheKey = variant.getCacheKey();
@@ -266,7 +266,7 @@ class BasicHttpCache implements HttpCache {
             return updatedEntry;
         } catch (final ResourceIOException ex) {
             if (log.isWarnEnabled()) {
-                log.warn("I/O error updating cache entry with key " + cacheKey);
+                log.warn("I/O error updating cache entry with key {}", cacheKey);
             }
             return entry;
         }
@@ -281,7 +281,7 @@ class BasicHttpCache implements HttpCache {
             final Date requestSent,
             final Date responseReceived) {
         if (log.isDebugEnabled()) {
-            log.debug("Create cache entry: " + host + "; " + new RequestLine(request));
+            log.debug("Create cache entry: {}; {}", host, new RequestLine(request));
         }
         final String cacheKey = cacheKeyGenerator.generateKey(host, request);
         try {
@@ -290,7 +290,7 @@ class BasicHttpCache implements HttpCache {
             return entry;
         } catch (final ResourceIOException ex) {
             if (log.isWarnEnabled()) {
-                log.warn("I/O error creating cache entry with key " + cacheKey);
+                log.warn("I/O error creating cache entry with key {}", cacheKey);
             }
             return new HttpCacheEntry(
                     requestSent,
@@ -304,7 +304,7 @@ class BasicHttpCache implements HttpCache {
     @Override
     public HttpCacheEntry getCacheEntry(final HttpHost host, final HttpRequest request) {
         if (log.isDebugEnabled()) {
-            log.debug("Get cache entry: " + host + "; " + new RequestLine(request));
+            log.debug("Get cache entry: {}; {}", host, new RequestLine(request));
         }
         final String cacheKey = cacheKeyGenerator.generateKey(host, request);
         final HttpCacheEntry root;
@@ -312,7 +312,7 @@ class BasicHttpCache implements HttpCache {
             root = storage.getEntry(cacheKey);
         } catch (final ResourceIOException ex) {
             if (log.isWarnEnabled()) {
-                log.warn("I/O error retrieving cache entry with key " + cacheKey);
+                log.warn("I/O error retrieving cache entry with key {}", cacheKey);
             }
             return null;
         }
@@ -331,7 +331,7 @@ class BasicHttpCache implements HttpCache {
             return storage.getEntry(variantCacheKey);
         } catch (final ResourceIOException ex) {
             if (log.isWarnEnabled()) {
-                log.warn("I/O error retrieving cache entry with key " + variantCacheKey);
+                log.warn("I/O error retrieving cache entry with key {}", variantCacheKey);
             }
             return null;
         }
@@ -340,7 +340,7 @@ class BasicHttpCache implements HttpCache {
     @Override
     public Map<String, Variant> getVariantCacheEntriesWithEtags(final HttpHost host, final HttpRequest request) {
         if (log.isDebugEnabled()) {
-            log.debug("Get variant cache entries: " + host + "; " + new RequestLine(request));
+            log.debug("Get variant cache entries: {}; {}", host, new RequestLine(request));
         }
         final Map<String,Variant> variants = new HashMap<>();
         final String cacheKey = cacheKeyGenerator.generateKey(host, request);
@@ -349,7 +349,7 @@ class BasicHttpCache implements HttpCache {
             root = storage.getEntry(cacheKey);
         } catch (final ResourceIOException ex) {
             if (log.isWarnEnabled()) {
-                log.warn("I/O error retrieving cache entry with key " + cacheKey);
+                log.warn("I/O error retrieving cache entry with key {}", cacheKey);
             }
             return variants;
         }
@@ -366,7 +366,7 @@ class BasicHttpCache implements HttpCache {
                     }
                 } catch (final ResourceIOException ex) {
                     if (log.isWarnEnabled()) {
-                        log.warn("I/O error retrieving cache entry with key " + variantCacheKey);
+                        log.warn("I/O error retrieving cache entry with key {}", variantCacheKey);
                     }
                     return variants;
                 }

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CacheRevalidatorBase.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CacheRevalidatorBase.java
@@ -131,7 +131,7 @@ class CacheRevalidatorBase implements Closeable {
                     scheduledExecutor.schedule(command, executionTime);
                     pendingRequest.add(cacheKey);
                 } catch (final RejectedExecutionException ex) {
-                    log.debug("Revalidation of cache entry with key {}could not be scheduled: {}", cacheKey, ex);
+                    log.debug("Revalidation of cache entry with key {} could not be scheduled", cacheKey, ex);
                 }
             }
         }

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CacheRevalidatorBase.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CacheRevalidatorBase.java
@@ -131,7 +131,7 @@ class CacheRevalidatorBase implements Closeable {
                     scheduledExecutor.schedule(command, executionTime);
                     pendingRequest.add(cacheKey);
                 } catch (final RejectedExecutionException ex) {
-                    log.debug("Revalidation of cache entry with key " + cacheKey + "could not be scheduled: " + ex);
+                    log.debug("Revalidation of cache entry with key {}could not be scheduled: {}", cacheKey, ex);
                 }
             }
         }

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CacheableRequestPolicy.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CacheableRequestPolicy.java
@@ -62,7 +62,7 @@ class CacheableRequestPolicy {
 
         if (!method.equals(HeaderConstants.GET_METHOD) && !method.equals(HeaderConstants.HEAD_METHOD)) {
             if (log.isDebugEnabled()) {
-                log.debug(method + " request is not serveable from cache");
+                log.debug("{} request is not serveable from cache", method);
             }
             return false;
         }

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachedResponseSuitabilityChecker.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachedResponseSuitabilityChecker.java
@@ -195,7 +195,7 @@ class CachedResponseSuitabilityChecker {
                     }
                 } catch (final NumberFormatException ex) {
                     // err conservatively
-                    log.debug("Response from cache was malformed{}", ex.getMessage());
+                    log.debug("Response from cache was malformed: {}", ex.getMessage());
                     return false;
                 }
             }

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachedResponseSuitabilityChecker.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachedResponseSuitabilityChecker.java
@@ -195,7 +195,7 @@ class CachedResponseSuitabilityChecker {
                     }
                 } catch (final NumberFormatException ex) {
                     // err conservatively
-                    log.debug("Response from cache was malformed" + ex.getMessage());
+                    log.debug("Response from cache was malformed{}", ex.getMessage());
                     return false;
                 }
             }
@@ -210,7 +210,7 @@ class CachedResponseSuitabilityChecker {
                     }
                 } catch (final NumberFormatException ex) {
                     // err conservatively
-                    log.debug("Response from cache was malformed: " + ex.getMessage());
+                    log.debug("Response from cache was malformed: {}", ex.getMessage());
                     return false;
                 }
             }
@@ -231,7 +231,7 @@ class CachedResponseSuitabilityChecker {
                     }
                 } catch (final NumberFormatException ex) {
                     // err conservatively
-                    log.debug("Response from cache was malformed: " + ex.getMessage());
+                    log.debug("Response from cache was malformed: {}", ex.getMessage());
                     return false;
                 }
             }

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingExecBase.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingExecBase.java
@@ -153,21 +153,21 @@ public class CachingExecBase {
 
     void recordCacheMiss(final HttpHost target, final HttpRequest request) {
         cacheMisses.getAndIncrement();
-        if (log.isTraceEnabled()) {
+        if (log.isDebugEnabled()) {
             log.debug("Cache miss [host: {}; uri: {}]", target, request.getRequestUri());
         }
     }
 
     void recordCacheHit(final HttpHost target, final HttpRequest request) {
         cacheHits.getAndIncrement();
-        if (log.isTraceEnabled()) {
+        if (log.isDebugEnabled()) {
             log.debug("Cache hit [host: {}; uri: {}]", target, request.getRequestUri());
         }
     }
 
     void recordCacheFailure(final HttpHost target, final HttpRequest request) {
         cacheMisses.getAndIncrement();
-        if (log.isTraceEnabled()) {
+        if (log.isDebugEnabled()) {
             log.debug("Cache failure [host: {}; uri: {}]", target, request.getRequestUri());
         }
     }

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingExecBase.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingExecBase.java
@@ -154,21 +154,21 @@ public class CachingExecBase {
     void recordCacheMiss(final HttpHost target, final HttpRequest request) {
         cacheMisses.getAndIncrement();
         if (log.isTraceEnabled()) {
-            log.debug("Cache miss [host: " + target + "; uri: " + request.getRequestUri() + "]");
+            log.debug("Cache miss [host: {}; uri: {}]", target, request.getRequestUri());
         }
     }
 
     void recordCacheHit(final HttpHost target, final HttpRequest request) {
         cacheHits.getAndIncrement();
         if (log.isTraceEnabled()) {
-            log.debug("Cache hit [host: " + target + "; uri: " + request.getRequestUri() + "]");
+            log.debug("Cache hit [host: {}; uri: {}]", target, request.getRequestUri());
         }
     }
 
     void recordCacheFailure(final HttpHost target, final HttpRequest request) {
         cacheMisses.getAndIncrement();
         if (log.isTraceEnabled()) {
-            log.debug("Cache failure [host: " + target + "; uri: " + request.getRequestUri() + "]");
+            log.debug("Cache failure [host: {}; uri: {}]", target, request.getRequestUri());
         }
     }
 

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/DefaultAsyncCacheInvalidator.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/DefaultAsyncCacheInvalidator.java
@@ -71,9 +71,9 @@ public class DefaultAsyncCacheInvalidator extends CacheInvalidatorBase implement
             public void completed(final Boolean result) {
                 if (log.isDebugEnabled()) {
                     if (result) {
-                        log.debug("Cache entry with key " + cacheKey + " successfully flushed");
+                        log.debug("Cache entry with key {} successfully flushed", cacheKey);
                     } else {
-                        log.debug("Cache entry with key " + cacheKey + " could not be flushed");
+                        log.debug("Cache entry with key {} could not be flushed", cacheKey);
                     }
                 }
             }
@@ -81,7 +81,7 @@ public class DefaultAsyncCacheInvalidator extends CacheInvalidatorBase implement
             @Override
             public void failed(final Exception ex) {
                 if (log.isWarnEnabled()) {
-                    log.warn("Unable to flush cache entry with key " + cacheKey, ex);
+                    log.warn("Unable to flush cache entry with key {}", cacheKey, ex);
                 }
             }
 
@@ -109,7 +109,7 @@ public class DefaultAsyncCacheInvalidator extends CacheInvalidatorBase implement
                 if (requestShouldNotBeCached(request) || shouldInvalidateHeadCacheEntry(request, parentEntry)) {
                     if (parentEntry != null) {
                         if (log.isDebugEnabled()) {
-                            log.debug("Invalidating parentEntry cache entry with key " + cacheKey);
+                            log.debug("Invalidating parentEntry cache entry with key {}", cacheKey);
                         }
                         for (final String variantURI : parentEntry.getVariantMap().values()) {
                             removeEntry(storage, variantURI);
@@ -118,7 +118,7 @@ public class DefaultAsyncCacheInvalidator extends CacheInvalidatorBase implement
                     }
                     if (uri != null) {
                         if (log.isWarnEnabled()) {
-                            log.warn(s + " is not a valid URI");
+                            log.warn("{} is not a valid URI", s);
                         }
                         final Header clHdr = request.getFirstHeader("Content-Location");
                         if (clHdr != null) {

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/DefaultCacheInvalidator.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/DefaultCacheInvalidator.java
@@ -63,7 +63,7 @@ public class DefaultCacheInvalidator extends CacheInvalidatorBase implements Htt
             return storage.getEntry(cacheKey);
         } catch (final ResourceIOException ex) {
             if (log.isWarnEnabled()) {
-                log.warn("Unable to get cache entry with key " + cacheKey, ex);
+                log.warn("Unable to get cache entry with key {}", cacheKey, ex);
             }
             return null;
         }
@@ -74,7 +74,7 @@ public class DefaultCacheInvalidator extends CacheInvalidatorBase implements Htt
             storage.removeEntry(cacheKey);
         } catch (final ResourceIOException ex) {
             if (log.isWarnEnabled()) {
-                log.warn("Unable to flush cache entry with key " + cacheKey, ex);
+                log.warn("Unable to flush cache entry with key {}", cacheKey, ex);
             }
         }
     }
@@ -93,7 +93,7 @@ public class DefaultCacheInvalidator extends CacheInvalidatorBase implements Htt
         if (requestShouldNotBeCached(request) || shouldInvalidateHeadCacheEntry(request, parent)) {
             if (parent != null) {
                 if (log.isDebugEnabled()) {
-                    log.debug("Invalidating parent cache entry with key " + cacheKey);
+                    log.debug("Invalidating parent cache entry with key {}", cacheKey);
                 }
                 for (final String variantURI : parent.getVariantMap().values()) {
                     removeEntry(storage, variantURI);
@@ -102,7 +102,7 @@ public class DefaultCacheInvalidator extends CacheInvalidatorBase implements Htt
             }
             if (uri != null) {
                 if (log.isWarnEnabled()) {
-                    log.warn(s + " is not a valid URI");
+                    log.warn("{} is not a valid URI", s);
                 }
                 final Header clHdr = request.getFirstHeader("Content-Location");
                 if (clHdr != null) {

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/RequestProtocolCompliance.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/RequestProtocolCompliance.java
@@ -129,7 +129,7 @@ class RequestProtocolCompliance {
             } else {
                 first = false;
             }
-            newHdr.append(elt.toString());
+            newHdr.append(elt);
         }
         return newHdr.toString();
     }

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/ResponseCachingPolicy.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/ResponseCachingPolicy.java
@@ -104,7 +104,7 @@ class ResponseCachingPolicy {
 
         if (!HeaderConstants.GET_METHOD.equals(httpMethod) && !HeaderConstants.HEAD_METHOD.equals(httpMethod)) {
             if (log.isDebugEnabled()) {
-                log.debug(httpMethod + " method response is not cacheable");
+                log.debug("{} method response is not cacheable", httpMethod);
             }
             return false;
         }
@@ -115,14 +115,14 @@ class ResponseCachingPolicy {
             cacheable = true;
         } else if (uncacheableStatusCodes.contains(status)) {
             if (log.isDebugEnabled()) {
-                log.debug(status + " response is not cacheable");
+                log.debug("{} response is not cacheable", status);
             }
             return false;
         } else if (unknownStatusCode(status)) {
             // a response with an unknown status code MUST NOT be
             // cached
             if (log.isDebugEnabled()) {
-                log.debug(status + " response is unknown");
+                log.debug("{} response is unknown", status);
             }
             return false;
         }
@@ -132,7 +132,7 @@ class ResponseCachingPolicy {
             final long contentLengthValue = Long.parseLong(contentLength.getValue());
             if (contentLengthValue > this.maxObjectSizeBytes) {
                 if (log.isDebugEnabled()) {
-                    log.debug("Response content length exceeds " + this.maxObjectSizeBytes);
+                    log.debug("Response content length exceeds {}", this.maxObjectSizeBytes);
                 }
                 return false;
             }
@@ -247,7 +247,7 @@ class ResponseCachingPolicy {
         final ProtocolVersion version = request.getVersion() != null ? request.getVersion() : HttpVersion.DEFAULT;
         if (version.compareToVersion(HttpVersion.HTTP_1_1) > 0) {
             if (log.isDebugEnabled()) {
-                log.debug("Protocol version " + version + " is non-cacheable");
+                log.debug("Protocol version {} is non-cacheable", version);
             }
             return false;
         }

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/ResponseProtocolCompliance.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/ResponseProtocolCompliance.java
@@ -133,7 +133,7 @@ class ResponseProtocolCompliance {
                     if (!first) {
                         buf.append(",");
                     }
-                    buf.append(elt.toString());
+                    buf.append(elt);
                     first = false;
                 }
             }

--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/external/CachingHttpAsyncClientCompatibilityTest.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/external/CachingHttpAsyncClientCompatibilityTest.java
@@ -122,7 +122,7 @@ public class CachingHttpAsyncClientCompatibilityTest {
         if (message != null && !TextUtils.isBlank(message)) {
             buf.append(" -> ").append(message);
         }
-        System.out.println(buf.toString());
+        System.out.println(buf);
     }
 
     void execute() throws Exception {

--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/external/CachingHttpClientCompatibilityTest.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/external/CachingHttpClientCompatibilityTest.java
@@ -109,7 +109,7 @@ public class CachingHttpClientCompatibilityTest {
         if (message != null && !TextUtils.isBlank(message)) {
             buf.append(" -> ").append(message);
         }
-        System.out.println(buf.toString());
+        System.out.println(buf);
     }
 
     void execute() {

--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/external/HttpAsyncClientCompatibilityTest.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/external/HttpAsyncClientCompatibilityTest.java
@@ -157,7 +157,7 @@ public class HttpAsyncClientCompatibilityTest {
         if (message != null && !TextUtils.isBlank(message)) {
             buf.append(" -> ").append(message);
         }
-        System.out.println(buf.toString());
+        System.out.println(buf);
     }
 
     void execute() throws Exception {

--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/external/HttpClientCompatibilityTest.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/external/HttpClientCompatibilityTest.java
@@ -133,7 +133,7 @@ public class HttpClientCompatibilityTest {
         if (message != null && !TextUtils.isBlank(message)) {
             buf.append(" -> ").append(message);
         }
-        System.out.println(buf.toString());
+        System.out.println(buf);
     }
 
     void execute() {

--- a/httpclient5-win/src/main/java/org/apache/hc/client5/http/impl/win/WindowsNegotiateScheme.java
+++ b/httpclient5-win/src/main/java/org/apache/hc/client5/http/impl/win/WindowsNegotiateScheme.java
@@ -92,7 +92,7 @@ public class WindowsNegotiateScheme implements AuthScheme {
         this.servicePrincipalName = servicePrincipalName;
 
         if (this.log.isDebugEnabled()) {
-            this.log.debug("Created WindowsNegotiateScheme using " + this.schemeName);
+            this.log.debug("Created WindowsNegotiateScheme using {}", this.schemeName);
         }
     }
 
@@ -258,7 +258,7 @@ public class WindowsNegotiateScheme implements AuthScheme {
             }
         }
         if (this.log.isDebugEnabled()) {
-            this.log.debug("Using SPN: " + spn);
+            this.log.debug("Using SPN: {}", spn);
         }
         return spn;
     }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/DefaultAuthenticationStrategy.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/DefaultAuthenticationStrategy.java
@@ -94,7 +94,7 @@ public class DefaultAuthenticationStrategy implements AuthenticationStrategy {
             authPrefs = DEFAULT_SCHEME_PRIORITY;
         }
         if (this.log.isDebugEnabled()) {
-            this.log.debug("Authentication schemes in the order of preference: " + authPrefs);
+            this.log.debug("Authentication schemes in the order of preference: {}", authPrefs);
         }
 
         for (final String schemeName: authPrefs) {
@@ -103,7 +103,7 @@ public class DefaultAuthenticationStrategy implements AuthenticationStrategy {
                 final AuthSchemeFactory authSchemeFactory = registry.lookup(schemeName);
                 if (authSchemeFactory == null) {
                     if (this.log.isWarnEnabled()) {
-                        this.log.warn("Authentication scheme " + schemeName + " not supported");
+                        this.log.warn("Authentication scheme {} not supported", schemeName);
                         // Try again
                     }
                     continue;
@@ -112,7 +112,7 @@ public class DefaultAuthenticationStrategy implements AuthenticationStrategy {
                 options.add(authScheme);
             } else {
                 if (this.log.isDebugEnabled()) {
-                    this.log.debug("Challenge for " + schemeName + " authentication scheme not available");
+                    this.log.debug("Challenge for {} authentication scheme not available", schemeName);
                 }
             }
         }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/InMemoryDnsResolver.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/InMemoryDnsResolver.java
@@ -87,7 +87,7 @@ public class InMemoryDnsResolver implements DnsResolver {
     public InetAddress[] resolve(final String host) throws UnknownHostException {
         final InetAddress[] resolvedAddresses = dnsMap.get(host);
         if (log.isInfoEnabled()) {
-            log.info("Resolving " + host + " to " + Arrays.deepToString(resolvedAddresses));
+            log.info("Resolving {} to {}", host, Arrays.deepToString(resolvedAddresses));
         }
         if(resolvedAddresses == null){
             throw new UnknownHostException(host + " cannot be resolved");

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/Wire.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/Wire.java
@@ -86,11 +86,11 @@ public class Wire {
             if (ch == 13) {
                 buffer.append("[\\r]");
             } else if (ch == 10) {
-                    buffer.append("[\\n]\"");
-                    buffer.insert(0, "\"");
-                    buffer.insert(0, header);
+                buffer.append("[\\n]\"");
+                buffer.insert(0, "\"");
+                buffer.insert(0, header);
                 this.log.debug("{} {}", this.id, buffer.toString());
-                    buffer.setLength(0);
+                buffer.setLength(0);
             } else if ((ch < 32) || (ch >= 127)) {
                 buffer.append("[0x");
                 buffer.append(Integer.toHexString(ch));

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/Wire.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/Wire.java
@@ -89,7 +89,7 @@ public class Wire {
                 buffer.append("[\\n]\"");
                 buffer.insert(0, "\"");
                 buffer.insert(0, header);
-                this.log.debug("{} {}", this.id, buffer.toString());
+                this.log.debug("{} {}", this.id, buffer);
                 buffer.setLength(0);
             } else if ((ch < 32) || (ch >= 127)) {
                 buffer.append("[0x");
@@ -103,7 +103,7 @@ public class Wire {
             buffer.append('\"');
             buffer.insert(0, '\"');
             buffer.insert(0, header);
-            this.log.debug("{} {}", this.id, buffer.toString());
+            this.log.debug("{} {}", this.id, buffer);
         }
     }
 

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/Wire.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/Wire.java
@@ -89,7 +89,7 @@ public class Wire {
                     buffer.append("[\\n]\"");
                     buffer.insert(0, "\"");
                     buffer.insert(0, header);
-                    this.log.debug(this.id + " " + buffer.toString());
+                this.log.debug("{} {}", this.id, buffer.toString());
                     buffer.setLength(0);
             } else if ((ch < 32) || (ch >= 127)) {
                 buffer.append("[0x");
@@ -103,7 +103,7 @@ public class Wire {
             buffer.append('\"');
             buffer.insert(0, '\"');
             buffer.insert(0, header);
-            this.log.debug(this.id + " " + buffer.toString());
+            this.log.debug("{} {}", this.id, buffer.toString());
         }
     }
 

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/AbstractHttpAsyncClientBase.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/AbstractHttpAsyncClientBase.java
@@ -113,7 +113,7 @@ abstract class AbstractHttpAsyncClientBase extends CloseableHttpAsyncClient {
     @Override
     public final void close(final CloseMode closeMode) {
         if (log.isDebugEnabled()) {
-            log.debug("Shutdown " + closeMode);
+            log.debug("Shutdown {}", closeMode);
         }
         ioReactor.initiateShutdown();
         ioReactor.close(closeMode);

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/AsyncConnectExec.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/AsyncConnectExec.java
@@ -129,7 +129,7 @@ public final class AsyncConnectExec implements AsyncExecChainHandler {
         if (!execRuntime.isEndpointAcquired()) {
             final Object userToken = clientContext.getUserToken();
             if (log.isDebugEnabled()) {
-                log.debug(exchangeId + ": acquiring connection with route " + route);
+                log.debug("{}: acquiring connection with route {}", exchangeId, route);
             }
             cancellableDependency.setDependency(execRuntime.acquireEndpoint(
                     exchangeId, route, userToken, clientContext, new FutureCallback<AsyncExecRuntime>() {
@@ -198,7 +198,7 @@ public final class AsyncConnectExec implements AsyncExecChainHandler {
                         public void completed(final AsyncExecRuntime execRuntime) {
                             tracker.connectTarget(route.isSecure());
                             if (log.isDebugEnabled()) {
-                                log.debug(exchangeId + ": connected to target");
+                                log.debug("{}: connected to target", exchangeId);
                             }
                             proceedToNextHop(state, request, entityProducer, scope, chain, asyncExecCallback);
                         }
@@ -224,7 +224,7 @@ public final class AsyncConnectExec implements AsyncExecChainHandler {
                             final HttpHost proxy  = route.getProxyHost();
                             tracker.connectProxy(proxy, route.isSecure() && !route.isTunnelled());
                             if (log.isDebugEnabled()) {
-                                log.debug(exchangeId + ": connected to proxy");
+                                log.debug("{}: connected to proxy", exchangeId);
                             }
                             proceedToNextHop(state, request, entityProducer, scope, chain, asyncExecCallback);
                         }
@@ -264,7 +264,7 @@ public final class AsyncConnectExec implements AsyncExecChainHandler {
                             @Override
                             public void completed() {
                                 if (log.isDebugEnabled()) {
-                                    log.debug(exchangeId + ": tunnel to target created");
+                                    log.debug("{}: tunnel to target created", exchangeId);
                                 }
                                 tracker.tunnelTarget(false);
                                 proceedToNextHop(state, request, entityProducer, scope, chain, asyncExecCallback);
@@ -292,7 +292,7 @@ public final class AsyncConnectExec implements AsyncExecChainHandler {
                 case HttpRouteDirector.LAYER_PROTOCOL:
                     execRuntime.upgradeTls(clientContext);
                     if (log.isDebugEnabled()) {
-                        log.debug(exchangeId + ": upgraded to TLS");
+                        log.debug("{}: upgraded to TLS", exchangeId);
                     }
                     tracker.layerProtocol(route.isSecure());
                     break;
@@ -304,7 +304,7 @@ public final class AsyncConnectExec implements AsyncExecChainHandler {
 
                 case HttpRouteDirector.COMPLETE:
                     if (log.isDebugEnabled()) {
-                        log.debug(exchangeId + ": route fully established");
+                        log.debug("{}: route fully established", exchangeId);
                     }
                     try {
                         chain.proceed(request, entityProducer, scope, asyncExecCallback);

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/AsyncProtocolExec.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/AsyncProtocolExec.java
@@ -165,13 +165,13 @@ public final class AsyncProtocolExec implements AsyncExecChainHandler {
 
         if (!request.containsHeader(HttpHeaders.AUTHORIZATION)) {
             if (log.isDebugEnabled()) {
-                log.debug(exchangeId + ": target auth state: " + targetAuthExchange.getState());
+                log.debug("{}: target auth state: {}", exchangeId, targetAuthExchange.getState());
             }
             authenticator.addAuthResponse(target, ChallengeType.TARGET, request, targetAuthExchange, clientContext);
         }
         if (!request.containsHeader(HttpHeaders.PROXY_AUTHORIZATION) && !route.isTunnelled()) {
             if (log.isDebugEnabled()) {
-                log.debug(exchangeId + ": proxy auth state: " + proxyAuthExchange.getState());
+                log.debug("{}: proxy auth state: {}", exchangeId, proxyAuthExchange.getState());
             }
             authenticator.addAuthResponse(proxy, ChallengeType.PROXY, request, proxyAuthExchange, clientContext);
         }
@@ -210,14 +210,14 @@ public final class AsyncProtocolExec implements AsyncExecChainHandler {
                     if (proxyAuthExchange.getState() == AuthExchange.State.SUCCESS
                             && proxyAuthExchange.isConnectionBased()) {
                         if (log.isDebugEnabled()) {
-                            log.debug(exchangeId + ": resetting proxy auth state");
+                            log.debug("{}: resetting proxy auth state", exchangeId);
                         }
                         proxyAuthExchange.reset();
                     }
                     if (targetAuthExchange.getState() == AuthExchange.State.SUCCESS
                             && targetAuthExchange.isConnectionBased()) {
                         if (log.isDebugEnabled()) {
-                            log.debug(exchangeId + ": resetting target auth state");
+                            log.debug("{}: resetting target auth state", exchangeId);
                         }
                         targetAuthExchange.reset();
                     }
@@ -226,7 +226,7 @@ public final class AsyncProtocolExec implements AsyncExecChainHandler {
                 if (challenged.get()) {
                     if (entityProducer != null && !entityProducer.isRepeatable()) {
                         if (log.isDebugEnabled()) {
-                            log.debug(exchangeId + ": cannot retry non-repeatable request");
+                            log.debug("{}: cannot retry non-repeatable request", exchangeId);
                         }
                         asyncExecCallback.completed();
                     } else {

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/AsyncRedirectExec.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/AsyncRedirectExec.java
@@ -127,7 +127,7 @@ public final class AsyncRedirectExec implements AsyncExecChainHandler {
 
                     final URI redirectUri = redirectStrategy.getLocationURI(request, response, clientContext);
                     if (log.isDebugEnabled()) {
-                        log.debug(exchangeId + ": redirect requested to location '" + redirectUri + "'");
+                        log.debug("{}: redirect requested to location '{}'", exchangeId, redirectUri);
                     }
                     if (!config.isCircularRedirectsAllowed()) {
                         if (state.redirectLocations.contains(redirectUri)) {
@@ -171,14 +171,14 @@ public final class AsyncRedirectExec implements AsyncExecChainHandler {
                             state.reroute = true;
                             final AuthExchange targetAuthExchange = clientContext.getAuthExchange(currentRoute.getTargetHost());
                             if (log.isDebugEnabled()) {
-                                log.debug(exchangeId + ": resetting target auth state");
+                                log.debug("{}: resetting target auth state", exchangeId);
                             }
                             targetAuthExchange.reset();
                             if (currentRoute.getProxyHost() != null) {
                                 final AuthExchange proxyAuthExchange = clientContext.getAuthExchange(currentRoute.getProxyHost());
                                 if (proxyAuthExchange.isConnectionBased()) {
                                     if (log.isDebugEnabled()) {
-                                        log.debug(exchangeId + ": resetting proxy auth state");
+                                        log.debug("{}: resetting proxy auth state", exchangeId);
                                     }
                                     proxyAuthExchange.reset();
                                 }
@@ -190,7 +190,7 @@ public final class AsyncRedirectExec implements AsyncExecChainHandler {
                 }
                 if (state.redirectURI != null) {
                     if (log.isDebugEnabled()) {
-                        log.debug(exchangeId + ": redirecting to '" + state.redirectURI + "' via " + currentRoute);
+                        log.debug("{}: redirecting to '{}' via {}", exchangeId, state.redirectURI, currentRoute);
                     }
                     return null;
                 }
@@ -211,7 +211,7 @@ public final class AsyncRedirectExec implements AsyncExecChainHandler {
                     final AsyncEntityProducer entityProducer = state.currentEntityProducer;
                     if (entityProducer != null && !entityProducer.isRepeatable()) {
                         if (log.isDebugEnabled()) {
-                            log.debug(exchangeId + ": cannot redirect non-repeatable request");
+                            log.debug("{}: cannot redirect non-repeatable request", exchangeId);
                         }
                         asyncExecCallback.completed();
                     } else {

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/H2AsyncClientEventHandlerFactory.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/H2AsyncClientEventHandlerFactory.java
@@ -118,7 +118,7 @@ class H2AsyncClientEventHandlerFactory implements IOEventHandlerFactory {
                         public void onHeaderInput(final HttpConnection connection, final int streamId, final List<? extends Header> headers) {
                             if (headerLog.isDebugEnabled()) {
                                 for (int i = 0; i < headers.size(); i++) {
-                                    headerLog.debug(id + " << " + headers.get(i));
+                                    headerLog.debug("{} << {}", id, headers.get(i));
                                 }
                             }
                         }
@@ -127,7 +127,7 @@ class H2AsyncClientEventHandlerFactory implements IOEventHandlerFactory {
                         public void onHeaderOutput(final HttpConnection connection, final int streamId, final List<? extends Header> headers) {
                             if (headerLog.isDebugEnabled()) {
                                 for (int i = 0; i < headers.size(); i++) {
-                                    headerLog.debug(id + " >> " + headers.get(i));
+                                    headerLog.debug("{} >> {}", id, headers.get(i));
                                 }
                             }
                         }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/H2AsyncMainClientExec.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/H2AsyncMainClientExec.java
@@ -83,7 +83,7 @@ public class H2AsyncMainClientExec implements AsyncExecChainHandler {
         final AsyncExecRuntime execRuntime = scope.execRuntime;
 
         if (log.isDebugEnabled()) {
-            log.debug(exchangeId + ": executing " + new RequestLine(request));
+            log.debug("{}: executing {}", exchangeId, new RequestLine(request));
         }
 
         final AsyncClientExchangeHandler internalExchangeHandler = new AsyncClientExchangeHandler() {

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncClientEventHandlerFactory.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncClientEventHandlerFactory.java
@@ -121,9 +121,9 @@ class HttpAsyncClientEventHandlerFactory implements IOEventHandlerFactory {
                         @Override
                         public void onRequestHead(final HttpConnection connection, final HttpRequest request) {
                             if (headerLog.isDebugEnabled()) {
-                                headerLog.debug(id + " >> " + new RequestLine(request));
+                                headerLog.debug("{} >> {}", id, new RequestLine(request));
                                 for (final Iterator<Header> it = request.headerIterator(); it.hasNext(); ) {
-                                    headerLog.debug(id + " >> " + it.next());
+                                    headerLog.debug("{} >> {}", id, it.next());
                                 }
                             }
                         }
@@ -131,9 +131,9 @@ class HttpAsyncClientEventHandlerFactory implements IOEventHandlerFactory {
                         @Override
                         public void onResponseHead(final HttpConnection connection, final HttpResponse response) {
                             if (headerLog.isDebugEnabled()) {
-                                headerLog.debug(id + " << " + new StatusLine(response));
+                                headerLog.debug("{} << {}", id, new StatusLine(response));
                                 for (final Iterator<Header> it = response.headerIterator(); it.hasNext(); ) {
-                                    headerLog.debug(id + " << " + it.next());
+                                    headerLog.debug("{} << {}", id, it.next());
                                 }
                             }
                         }
@@ -142,9 +142,9 @@ class HttpAsyncClientEventHandlerFactory implements IOEventHandlerFactory {
                         public void onExchangeComplete(final HttpConnection connection, final boolean keepAlive) {
                             if (streamLog.isDebugEnabled()) {
                                 if (keepAlive) {
-                                    streamLog.debug(id + " Connection is kept alive");
+                                    streamLog.debug("{} Connection is kept alive", id);
                                 } else {
-                                    streamLog.debug(id + " Connection is not kept alive");
+                                    streamLog.debug("{} Connection is not kept alive", id);
                                 }
                             }
                         }
@@ -189,7 +189,7 @@ class HttpAsyncClientEventHandlerFactory implements IOEventHandlerFactory {
                         public void onHeaderInput(final HttpConnection connection, final int streamId, final List<? extends Header> headers) {
                             if (headerLog.isDebugEnabled()) {
                                 for (int i = 0; i < headers.size(); i++) {
-                                    headerLog.debug(id + " << " + headers.get(i));
+                                    headerLog.debug("{} << {}", id, headers.get(i));
                                 }
                             }
                         }
@@ -198,7 +198,7 @@ class HttpAsyncClientEventHandlerFactory implements IOEventHandlerFactory {
                         public void onHeaderOutput(final HttpConnection connection, final int streamId, final List<? extends Header> headers) {
                             if (headerLog.isDebugEnabled()) {
                                 for (int i = 0; i < headers.size(); i++) {
-                                    headerLog.debug(id + " >> " + headers.get(i));
+                                    headerLog.debug("{} >> {}", id, headers.get(i));
                                 }
                             }
                         }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncMainClientExec.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncMainClientExec.java
@@ -98,7 +98,7 @@ class HttpAsyncMainClientExec implements AsyncExecChainHandler {
         final AsyncExecRuntime execRuntime = scope.execRuntime;
 
         if (log.isDebugEnabled()) {
-            log.debug(exchangeId + ": executing " + new RequestLine(request));
+            log.debug("{}: executing {}", exchangeId, new RequestLine(request));
         }
 
         final AtomicInteger messageCountDown = new AtomicInteger(2);

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalAbstractHttpAsyncClient.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalAbstractHttpAsyncClient.java
@@ -177,7 +177,7 @@ abstract class InternalAbstractHttpAsyncClient extends AbstractHttpAsyncClientBa
                             clientContext);
                     final String exchangeId = ExecSupport.getNextExchangeId();
                     if (log.isDebugEnabled()) {
-                        log.debug(exchangeId + ": preparing request execution");
+                        log.debug("{}: preparing request execution", exchangeId);
                     }
                     final AsyncExecRuntime execRuntime = createAsyncExecRuntime(pushHandlerFactory);
 
@@ -287,7 +287,7 @@ abstract class InternalAbstractHttpAsyncClient extends AbstractHttpAsyncClientBa
                                 @Override
                                 public void completed() {
                                     if (log.isDebugEnabled()) {
-                                        log.debug(exchangeId + ": message exchange successfully completed");
+                                        log.debug("{}: message exchange successfully completed", exchangeId);
                                     }
                                     try {
                                         execRuntime.releaseEndpoint();
@@ -300,7 +300,7 @@ abstract class InternalAbstractHttpAsyncClient extends AbstractHttpAsyncClientBa
                                 @Override
                                 public void failed(final Exception cause) {
                                     if (log.isDebugEnabled()) {
-                                        log.debug(exchangeId + ": request failed: " + cause.getMessage());
+                                        log.debug("{}: request failed: {}", exchangeId, cause.getMessage());
                                     }
                                     try {
                                         execRuntime.discardEndpoint();

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalH2AsyncExecRuntime.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalH2AsyncExecRuntime.java
@@ -89,7 +89,7 @@ class InternalH2AsyncExecRuntime implements AsyncExecRuntime {
             final RequestConfig requestConfig = context.getRequestConfig();
             final Timeout connectTimeout = requestConfig.getConnectTimeout();
             if (log.isDebugEnabled()) {
-                log.debug(id + ": acquiring endpoint (" + connectTimeout + ")");
+                log.debug("{}: acquiring endpoint ({})", id, connectTimeout);
             }
             return Operations.cancellable(connPool.getSession(
                     target,
@@ -101,7 +101,7 @@ class InternalH2AsyncExecRuntime implements AsyncExecRuntime {
                             sessionRef.set(new Endpoint(target, ioSession));
                             reusable = true;
                             if (log.isDebugEnabled()) {
-                                log.debug(id + ": acquired endpoint");
+                                log.debug("{}: acquired endpoint", id);
                             }
                             callback.completed(InternalH2AsyncExecRuntime.this);
                         }
@@ -125,7 +125,7 @@ class InternalH2AsyncExecRuntime implements AsyncExecRuntime {
     private void closeEndpoint(final Endpoint endpoint) {
         endpoint.session.close(CloseMode.GRACEFUL);
         if (log.isDebugEnabled()) {
-            log.debug(ConnPoolSupport.getId(endpoint) + ": endpoint closed");
+            log.debug("{}: endpoint closed", ConnPoolSupport.getId(endpoint));
         }
     }
 
@@ -186,7 +186,7 @@ class InternalH2AsyncExecRuntime implements AsyncExecRuntime {
         final RequestConfig requestConfig = context.getRequestConfig();
         final Timeout connectTimeout = requestConfig.getConnectTimeout();
         if (log.isDebugEnabled()) {
-            log.debug(ConnPoolSupport.getId(endpoint) + ": connecting endpoint (" + connectTimeout + ")");
+            log.debug("{}: connecting endpoint ({})", ConnPoolSupport.getId(endpoint), connectTimeout);
         }
         return Operations.cancellable(connPool.getSession(target, connectTimeout,
             new FutureCallback<IOSession>() {
@@ -196,7 +196,7 @@ class InternalH2AsyncExecRuntime implements AsyncExecRuntime {
                 sessionRef.set(new Endpoint(target, ioSession));
                 reusable = true;
                 if (log.isDebugEnabled()) {
-                    log.debug(ConnPoolSupport.getId(endpoint) + ": endpoint connected");
+                    log.debug("{}: endpoint connected", ConnPoolSupport.getId(endpoint));
                 }
                 callback.completed(InternalH2AsyncExecRuntime.this);
             }
@@ -229,7 +229,7 @@ class InternalH2AsyncExecRuntime implements AsyncExecRuntime {
         final IOSession session = endpoint.session;
         if (session.isOpen()) {
             if (log.isDebugEnabled()) {
-                log.debug(ConnPoolSupport.getId(endpoint) + ": start execution " + id);
+                log.debug("{}: start execution {}", ConnPoolSupport.getId(endpoint), id);
             }
             session.enqueue(
                     new RequestExecutionCommand(exchangeHandler, pushHandlerFactory, complexCancellable, context),
@@ -245,7 +245,7 @@ class InternalH2AsyncExecRuntime implements AsyncExecRuntime {
                     sessionRef.set(new Endpoint(target, ioSession));
                     reusable = true;
                     if (log.isDebugEnabled()) {
-                        log.debug(ConnPoolSupport.getId(endpoint) + ": start execution " + id);
+                        log.debug("{}: start execution {}", ConnPoolSupport.getId(endpoint), id);
                     }
                     session.enqueue(
                             new RequestExecutionCommand(exchangeHandler, pushHandlerFactory, complexCancellable, context),

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalHttpAsyncExecRuntime.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalHttpAsyncExecRuntime.java
@@ -95,7 +95,7 @@ class InternalHttpAsyncExecRuntime implements AsyncExecRuntime {
             final RequestConfig requestConfig = context.getRequestConfig();
             final Timeout connectionRequestTimeout = requestConfig.getConnectionRequestTimeout();
             if (log.isDebugEnabled()) {
-                log.debug(id + ": acquiring endpoint (" + connectionRequestTimeout + ")");
+                log.debug("{}: acquiring endpoint ({})", id, connectionRequestTimeout);
             }
             return Operations.cancellable(manager.lease(
                     id,
@@ -109,7 +109,7 @@ class InternalHttpAsyncExecRuntime implements AsyncExecRuntime {
                             endpointRef.set(connectionEndpoint);
                             reusable = connectionEndpoint.isConnected();
                             if (log.isDebugEnabled()) {
-                                log.debug(id + ": acquired endpoint " + ConnPoolSupport.getId(connectionEndpoint));
+                                log.debug("{}: acquired endpoint {}", id, ConnPoolSupport.getId(connectionEndpoint));
                             }
                             callback.completed(InternalHttpAsyncExecRuntime.this);
                         }
@@ -133,11 +133,11 @@ class InternalHttpAsyncExecRuntime implements AsyncExecRuntime {
         try {
             endpoint.close(CloseMode.IMMEDIATE);
             if (log.isDebugEnabled()) {
-                log.debug(ConnPoolSupport.getId(endpoint) + ": endpoint closed");
+                log.debug("{}: endpoint closed", ConnPoolSupport.getId(endpoint));
             }
         } finally {
             if (log.isDebugEnabled()) {
-                log.debug(ConnPoolSupport.getId(endpoint) + ": discarding endpoint");
+                log.debug("{}: discarding endpoint", ConnPoolSupport.getId(endpoint));
             }
             manager.release(endpoint, null, TimeValue.ZERO_MILLISECONDS);
         }
@@ -149,7 +149,7 @@ class InternalHttpAsyncExecRuntime implements AsyncExecRuntime {
         if (endpoint != null) {
             if (reusable) {
                 if (log.isDebugEnabled()) {
-                    log.debug(ConnPoolSupport.getId(endpoint) + ": releasing valid endpoint");
+                    log.debug("{}: releasing valid endpoint", ConnPoolSupport.getId(endpoint));
                 }
                 manager.release(endpoint, state, validDuration);
             } else {
@@ -205,7 +205,7 @@ class InternalHttpAsyncExecRuntime implements AsyncExecRuntime {
         final RequestConfig requestConfig = context.getRequestConfig();
         final Timeout connectTimeout = requestConfig.getConnectTimeout();
         if (log.isDebugEnabled()) {
-            log.debug(ConnPoolSupport.getId(endpoint) + ": connecting endpoint (" + connectTimeout + ")");
+            log.debug("{}: connecting endpoint ({})", ConnPoolSupport.getId(endpoint), connectTimeout);
         }
         return Operations.cancellable(manager.connect(
                 endpoint,
@@ -218,7 +218,7 @@ class InternalHttpAsyncExecRuntime implements AsyncExecRuntime {
                     @Override
                     public void completed(final AsyncConnectionEndpoint endpoint) {
                         if (log.isDebugEnabled()) {
-                            log.debug(ConnPoolSupport.getId(endpoint) + ": endpoint connected");
+                            log.debug("{}: endpoint connected", ConnPoolSupport.getId(endpoint));
                         }
                         callback.completed(InternalHttpAsyncExecRuntime.this);
                     }
@@ -241,7 +241,7 @@ class InternalHttpAsyncExecRuntime implements AsyncExecRuntime {
     public void upgradeTls(final HttpClientContext context) {
         final AsyncConnectionEndpoint endpoint = ensureValid();
         if (log.isDebugEnabled()) {
-            log.debug(ConnPoolSupport.getId(endpoint) + ": upgrading endpoint");
+            log.debug("{}: upgrading endpoint", ConnPoolSupport.getId(endpoint));
         }
         manager.upgrade(endpoint, versionPolicy, context);
     }
@@ -252,7 +252,7 @@ class InternalHttpAsyncExecRuntime implements AsyncExecRuntime {
         final AsyncConnectionEndpoint endpoint = ensureValid();
         if (endpoint.isConnected()) {
             if (log.isDebugEnabled()) {
-                log.debug(ConnPoolSupport.getId(endpoint) + ": start execution " + id);
+                log.debug("{}: start execution {}", ConnPoolSupport.getId(endpoint), id);
             }
             final RequestConfig requestConfig = context.getRequestConfig();
             final Timeout responseTimeout = requestConfig.getResponseTimeout();
@@ -275,7 +275,7 @@ class InternalHttpAsyncExecRuntime implements AsyncExecRuntime {
                 @Override
                 public void completed(final AsyncExecRuntime runtime) {
                     if (log.isDebugEnabled()) {
-                        log.debug(ConnPoolSupport.getId(endpoint) + ": start execution " + id);
+                        log.debug("{}: start execution {}", ConnPoolSupport.getId(endpoint), id);
                     }
                     try {
                         endpoint.execute(id, exchangeHandler, pushHandlerFactory, context);

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/LogAppendable.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/LogAppendable.java
@@ -60,7 +60,7 @@ final class LogAppendable implements Appendable {
     @Override
     public Appendable append(final char ch) throws IOException {
         if (ch == '\n') {
-            log.debug("{} {}", prefix, buffer.toString());
+            log.debug("{} {}", prefix, buffer);
             buffer.setLength(0);
         } else if (ch != '\r') {
             buffer.append(ch);
@@ -70,7 +70,7 @@ final class LogAppendable implements Appendable {
 
     public void flush() {
         if (buffer.length() > 0) {
-            log.debug("{} {}", prefix, buffer.toString());
+            log.debug("{} {}", prefix, buffer);
             buffer.setLength(0);
         }
     }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/LogAppendable.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/LogAppendable.java
@@ -60,7 +60,7 @@ final class LogAppendable implements Appendable {
     @Override
     public Appendable append(final char ch) throws IOException {
         if (ch == '\n') {
-            log.debug(prefix + " " + buffer.toString());
+            log.debug("{} {}", prefix, buffer.toString());
             buffer.setLength(0);
         } else if (ch != '\r') {
             buffer.append(ch);
@@ -70,7 +70,7 @@ final class LogAppendable implements Appendable {
 
     public void flush() {
         if (buffer.length() > 0) {
-            log.debug(prefix + " " + buffer.toString());
+            log.debug("{} {}", prefix, buffer.toString());
             buffer.setLength(0);
         }
     }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/LoggingAsyncClientExchangeHandler.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/LoggingAsyncClientExchangeHandler.java
@@ -77,8 +77,7 @@ final class LoggingAsyncClientExchangeHandler implements AsyncClientExchangeHand
                     final EntityDetails entityDetails,
                     final HttpContext context) throws HttpException, IOException {
                 if (log.isDebugEnabled()) {
-                    log.debug(exchangeId + ": send request " + new RequestLine(request) + ", " +
-                            (entityDetails != null ? "entity len " + entityDetails.getContentLength() : "null entity"));
+                    log.debug("{}: send request {}, {}", exchangeId, new RequestLine(request), entityDetails != null ? "entity len " + entityDetails.getContentLength() : "null entity");
                 }
                 channel.sendRequest(request, entityDetails, context);
             }
@@ -94,7 +93,7 @@ final class LoggingAsyncClientExchangeHandler implements AsyncClientExchangeHand
     @Override
     public void produce(final DataStreamChannel channel) throws IOException {
         if (log.isDebugEnabled()) {
-            log.debug(exchangeId + ": produce request data");
+            log.debug("{}: produce request data", exchangeId);
         }
         handler.produce(new DataStreamChannel() {
 
@@ -106,7 +105,7 @@ final class LoggingAsyncClientExchangeHandler implements AsyncClientExchangeHand
             @Override
             public int write(final ByteBuffer src) throws IOException {
                 if (log.isDebugEnabled()) {
-                    log.debug(exchangeId + ": produce request data, len " + src.remaining() + " bytes");
+                    log.debug("{}: produce request data, len {} bytes", exchangeId, src.remaining());
                 }
                 return channel.write(src);
             }
@@ -114,7 +113,7 @@ final class LoggingAsyncClientExchangeHandler implements AsyncClientExchangeHand
             @Override
             public void endStream() throws IOException {
                 if (log.isDebugEnabled()) {
-                    log.debug(exchangeId + ": end of request data");
+                    log.debug("{}: end of request data", exchangeId);
                 }
                 channel.endStream();
             }
@@ -122,7 +121,7 @@ final class LoggingAsyncClientExchangeHandler implements AsyncClientExchangeHand
             @Override
             public void endStream(final List<? extends Header> trailers) throws IOException {
                 if (log.isDebugEnabled()) {
-                    log.debug(exchangeId + ": end of request data");
+                    log.debug("{}: end of request data", exchangeId);
                 }
                 channel.endStream(trailers);
             }
@@ -135,7 +134,7 @@ final class LoggingAsyncClientExchangeHandler implements AsyncClientExchangeHand
             final HttpResponse response,
             final HttpContext context) throws HttpException, IOException {
         if (log.isDebugEnabled()) {
-            log.debug(exchangeId + ": information response " + new StatusLine(response));
+            log.debug("{}: information response {}", exchangeId, new StatusLine(response));
         }
         handler.consumeInformation(response, context);
     }
@@ -146,8 +145,7 @@ final class LoggingAsyncClientExchangeHandler implements AsyncClientExchangeHand
             final EntityDetails entityDetails,
             final HttpContext context) throws HttpException, IOException {
         if (log.isDebugEnabled()) {
-            log.debug(exchangeId + ": consume response " + new StatusLine(response) + ", " +
-                    (entityDetails != null ? "entity len " + entityDetails.getContentLength() : " null entity"));
+            log.debug("{}: consume response {}, {}", exchangeId, new StatusLine(response), entityDetails != null ? "entity len " + entityDetails.getContentLength() : " null entity");
         }
         handler.consumeResponse(response, entityDetails, context);
     }
@@ -160,7 +158,7 @@ final class LoggingAsyncClientExchangeHandler implements AsyncClientExchangeHand
             @Override
             public void update(final int increment) throws IOException {
                 if (log.isDebugEnabled()) {
-                    log.debug(exchangeId + ": capacity update " + increment);
+                    log.debug("{}: capacity update {}", exchangeId, increment);
                 }
                 capacityChannel.update(increment);
             }
@@ -171,7 +169,7 @@ final class LoggingAsyncClientExchangeHandler implements AsyncClientExchangeHand
     @Override
     public void consume(final ByteBuffer src) throws IOException {
         if (log.isDebugEnabled()) {
-            log.debug(exchangeId + ": consume response data, len " + src.remaining() + " bytes");
+            log.debug("{}: consume response data, len {} bytes", exchangeId, src.remaining());
         }
         handler.consume(src);
     }
@@ -179,7 +177,7 @@ final class LoggingAsyncClientExchangeHandler implements AsyncClientExchangeHand
     @Override
     public void streamEnd(final List<? extends Header> trailers) throws HttpException, IOException {
         if (log.isDebugEnabled()) {
-            log.debug(exchangeId + ": end of response data");
+            log.debug("{}: end of response data", exchangeId);
         }
         handler.streamEnd(trailers);
     }
@@ -187,7 +185,7 @@ final class LoggingAsyncClientExchangeHandler implements AsyncClientExchangeHand
     @Override
     public void failed(final Exception cause) {
         if (log.isDebugEnabled()) {
-            log.debug(exchangeId + ": execution failed: " + cause.getMessage());
+            log.debug("{}: execution failed: {}", exchangeId, cause.getMessage());
         }
         handler.failed(cause);
     }
@@ -195,7 +193,7 @@ final class LoggingAsyncClientExchangeHandler implements AsyncClientExchangeHand
     @Override
     public void cancel() {
         if (log.isDebugEnabled()) {
-            log.debug(exchangeId + ": execution cancelled");
+            log.debug("{}: execution cancelled", exchangeId);
         }
         handler.cancel();
     }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/LoggingIOSession.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/LoggingIOSession.java
@@ -257,7 +257,7 @@ class LoggingIOSession implements IOSession {
 
     @Override
     public String toString() {
-        return this.id + " " + this.session.toString();
+        return this.id + " " + this.session;
     }
 
 }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/LoggingIOSession.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/LoggingIOSession.java
@@ -81,7 +81,7 @@ class LoggingIOSession implements IOSession {
     public void enqueue(final Command command, final Command.Priority priority) {
         this.session.enqueue(command, priority);
         if (this.log.isDebugEnabled()) {
-            this.log.debug(this.session + " Enqueued " + command.getClass().getSimpleName() + " with priority " + priority);
+            this.log.debug("{} Enqueued {} with priority {}", this.session, command.getClass().getSimpleName(), priority);
         }
     }
 
@@ -128,7 +128,7 @@ class LoggingIOSession implements IOSession {
     public void setEventMask(final int ops) {
         this.session.setEventMask(ops);
         if (this.log.isDebugEnabled()) {
-            this.log.debug(this.id + " " + this.session + ": Event mask set " + formatOps(ops));
+            this.log.debug("{} {}: Event mask set {}", this.id, this.session, formatOps(ops));
         }
     }
 
@@ -136,7 +136,7 @@ class LoggingIOSession implements IOSession {
     public void setEvent(final int op) {
         this.session.setEvent(op);
         if (this.log.isDebugEnabled()) {
-            this.log.debug(this.id + " " + this.session + ": Event set " + formatOps(op));
+            this.log.debug("{} {}: Event set {}", this.id, this.session, formatOps(op));
         }
     }
 
@@ -144,7 +144,7 @@ class LoggingIOSession implements IOSession {
     public void clearEvent(final int op) {
         this.session.clearEvent(op);
         if (this.log.isDebugEnabled()) {
-            this.log.debug(this.id + " " + this.session + ": Event cleared " + formatOps(op));
+            this.log.debug("{} {}: Event cleared {}", this.id, this.session, formatOps(op));
         }
     }
 
@@ -156,7 +156,7 @@ class LoggingIOSession implements IOSession {
     @Override
     public void close() {
         if (this.log.isDebugEnabled()) {
-            this.log.debug(this.id + " " + this.session + ": Close");
+            this.log.debug("{} {}: Close", this.id, this.session);
         }
         this.session.close();
     }
@@ -169,7 +169,7 @@ class LoggingIOSession implements IOSession {
     @Override
     public void close(final CloseMode closeMode) {
         if (this.log.isDebugEnabled()) {
-            this.log.debug(this.id + " " + this.session + ": Close " + closeMode);
+            this.log.debug("{} {}: Close {}", this.id, this.session, closeMode);
         }
         this.session.close(closeMode);
     }
@@ -182,7 +182,7 @@ class LoggingIOSession implements IOSession {
     @Override
     public void setSocketTimeout(final Timeout timeout) {
         if (this.log.isDebugEnabled()) {
-            this.log.debug(this.id + " " + this.session + ": Set timeout " + timeout);
+            this.log.debug("{} {}: Set timeout {}", this.id, this.session, timeout);
         }
         this.session.setSocketTimeout(timeout);
     }
@@ -226,7 +226,7 @@ class LoggingIOSession implements IOSession {
     public int read(final ByteBuffer dst) throws IOException {
         final int bytesRead = this.session.channel().read(dst);
         if (this.log.isDebugEnabled()) {
-            this.log.debug(this.id + " " + this.session + ": " + bytesRead + " bytes read");
+            this.log.debug("{} {}: {} bytes read", this.id, this.session, bytesRead);
         }
         if (bytesRead > 0 && this.wireLog.isEnabled()) {
             final ByteBuffer b = dst.duplicate();
@@ -243,7 +243,7 @@ class LoggingIOSession implements IOSession {
     public int write(final ByteBuffer src) throws IOException {
         final int byteWritten = session.channel().write(src);
         if (this.log.isDebugEnabled()) {
-            this.log.debug(this.id + " " + this.session + ": " + byteWritten + " bytes written");
+            this.log.debug("{} {}: {} bytes written", this.id, this.session, byteWritten);
         }
         if (byteWritten > 0 && this.wireLog.isEnabled()) {
             final ByteBuffer b = src.duplicate();

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/MinimalH2AsyncClient.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/MinimalH2AsyncClient.java
@@ -232,7 +232,7 @@ public final class MinimalH2AsyncClient extends AbstractMinimalHttpAsyncClientBa
                             };
                             if (log.isDebugEnabled()) {
                                 final String exchangeId = ExecSupport.getNextExchangeId();
-                                log.debug(ConnPoolSupport.getId(session) + ": executing message exchange " + exchangeId);
+                                log.debug("{}: executing message exchange {}", ConnPoolSupport.getId(session), exchangeId);
                                 session.enqueue(
                                         new RequestExecutionCommand(
                                                 new LoggingAsyncClientExchangeHandler(log, exchangeId, internalExchangeHandler),

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/MinimalHttpAsyncClient.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/MinimalHttpAsyncClient.java
@@ -466,7 +466,7 @@ public final class MinimalHttpAsyncClient extends AbstractMinimalHttpAsyncClient
 
             final String exchangeId = ExecSupport.getNextExchangeId();
             if (log.isDebugEnabled()) {
-                log.debug(ConnPoolSupport.getId(connectionEndpoint) + ": executing message exchange " + exchangeId);
+                log.debug("{}: executing message exchange {}", ConnPoolSupport.getId(connectionEndpoint), exchangeId);
                 connectionEndpoint.execute(
                         exchangeId,
                         new LoggingAsyncClientExchangeHandler(log, exchangeId, exchangeHandler),

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/BasicAuthCache.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/BasicAuthCache.java
@@ -101,7 +101,7 @@ public class BasicAuthCache implements AuthCache {
             }
         } else {
             if (log.isDebugEnabled()) {
-                log.debug("Auth scheme " + authScheme.getClass() + " is not serializable");
+                log.debug("Auth scheme {} is not serializable", authScheme.getClass());
             }
         }
     }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/BasicScheme.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/BasicScheme.java
@@ -197,7 +197,7 @@ public class BasicScheme implements AuthScheme, Serializable {
 
     @Override
     public String toString() {
-        return getName() + this.paramMap.toString();
+        return getName() + this.paramMap;
     }
 
 }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/DigestScheme.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/DigestScheme.java
@@ -465,7 +465,7 @@ public class DigestScheme implements AuthScheme, Serializable {
 
     @Override
     public String toString() {
-        return getName() + this.paramMap.toString();
+        return getName() + this.paramMap;
     }
 
 }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/GGSSchemeBase.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/GGSSchemeBase.java
@@ -220,7 +220,7 @@ public abstract class GGSSchemeBase implements AuthScheme {
                 final String serviceName = host.getSchemeName().toUpperCase(Locale.ROOT);
 
                 if (log.isDebugEnabled()) {
-                    log.debug("init " + authServer);
+                    log.debug("init {}", authServer);
                 }
                 token = generateToken(token, serviceName, authServer);
                 state = State.TOKEN_GENERATED;
@@ -245,7 +245,7 @@ public abstract class GGSSchemeBase implements AuthScheme {
             final Base64 codec = new Base64(0);
             final String tokenstr = new String(codec.encode(token));
             if (log.isDebugEnabled()) {
-                log.debug("Sending response '" + tokenstr + "' back to the auth server");
+                log.debug("Sending response '{}' back to the auth server", tokenstr);
             }
             return StandardAuthScheme.SPNEGO + " " + tokenstr;
         default:

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/HttpAuthenticator.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/HttpAuthenticator.java
@@ -161,7 +161,7 @@ public final class HttpAuthenticator {
             final HttpContext context) {
 
         if (this.log.isDebugEnabled()) {
-            this.log.debug(host.toHostString() + " requested authentication");
+            this.log.debug("{} requested authentication", host.toHostString());
         }
 
         final HttpClientContext clientContext = HttpClientContext.adapt(context);
@@ -190,7 +190,7 @@ public final class HttpAuthenticator {
                 authChallenges = parser.parse(challengeType, buffer, cursor);
             } catch (final ParseException ex) {
                 if (this.log.isWarnEnabled()) {
-                    this.log.warn("Malformed challenge: " + header.getValue());
+                    this.log.warn("Malformed challenge: {}", header.getValue());
                 }
                 continue;
             }
@@ -274,7 +274,7 @@ public final class HttpAuthenticator {
         }
         if (!authOptions.isEmpty()) {
             if (this.log.isDebugEnabled()) {
-                this.log.debug("Selected authentication options: " + authOptions);
+                this.log.debug("Selected authentication options: {}", authOptions);
             }
             authExchange.reset();
             authExchange.setState(AuthExchange.State.CHALLENGED);
@@ -320,8 +320,7 @@ public final class HttpAuthenticator {
                     authScheme = authOptions.remove();
                     authExchange.select(authScheme);
                     if (this.log.isDebugEnabled()) {
-                        this.log.debug("Generating response to an authentication challenge using "
-                                + authScheme.getName() + " scheme");
+                        this.log.debug("Generating response to an authentication challenge using {} scheme", authScheme.getName());
                     }
                     try {
                         final String authResponse = authScheme.generateAuthResponse(host, request, context);
@@ -332,7 +331,7 @@ public final class HttpAuthenticator {
                         break;
                     } catch (final AuthenticationException ex) {
                         if (this.log.isWarnEnabled()) {
-                            this.log.warn(authScheme + " authentication error: " + ex.getMessage());
+                            this.log.warn("{} authentication error: {}", authScheme, ex.getMessage());
                         }
                     }
                 }
@@ -350,7 +349,7 @@ public final class HttpAuthenticator {
                 request.addHeader(header);
             } catch (final AuthenticationException ex) {
                 if (this.log.isErrorEnabled()) {
-                    this.log.error(authScheme + " authentication error: " + ex.getMessage());
+                    this.log.error("{} authentication error: {}", authScheme, ex.getMessage());
                 }
             }
         }
@@ -365,7 +364,7 @@ public final class HttpAuthenticator {
                 clientContext.setAuthCache(authCache);
             }
             if (this.log.isDebugEnabled()) {
-                this.log.debug("Caching '" + authScheme.getName() + "' auth scheme for " + host);
+                this.log.debug("Caching '{}' auth scheme for {}", authScheme.getName(), host);
             }
             authCache.put(host, authScheme);
         }
@@ -376,7 +375,7 @@ public final class HttpAuthenticator {
         final AuthCache authCache = clientContext.getAuthCache();
         if (authCache != null) {
             if (this.log.isDebugEnabled()) {
-                this.log.debug("Clearing cached auth scheme for " + host);
+                this.log.debug("Clearing cached auth scheme for {}", host);
             }
             authCache.remove(host);
         }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/ConnectExec.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/ConnectExec.java
@@ -113,14 +113,14 @@ public final class ConnectExec implements ExecChainHandler {
         if (!execRuntime.isEndpointAcquired()) {
             final Object userToken = context.getUserToken();
             if (log.isDebugEnabled()) {
-                log.debug(exchangeId + ": acquiring connection with route " + route);
+                log.debug("{}: acquiring connection with route {}", exchangeId, route);
             }
             execRuntime.acquireEndpoint(exchangeId, route, userToken, context);
         }
         try {
             if (!execRuntime.isEndpointConnected()) {
                 if (log.isDebugEnabled()) {
-                    log.debug(exchangeId + ": opening connection " + route);
+                    log.debug("{}: opening connection {}", exchangeId, route);
                 }
 
                 final RouteTracker tracker = new RouteTracker(route);
@@ -143,7 +143,7 @@ public final class ConnectExec implements ExecChainHandler {
                         case HttpRouteDirector.TUNNEL_TARGET: {
                             final boolean secure = createTunnelToTarget(exchangeId, route, request, execRuntime, context);
                             if (log.isDebugEnabled()) {
-                                log.debug(exchangeId + ": tunnel to target created.");
+                                log.debug("{}: tunnel to target created.", exchangeId);
                             }
                             tracker.tunnelTarget(secure);
                         }   break;
@@ -156,7 +156,7 @@ public final class ConnectExec implements ExecChainHandler {
                             final int hop = fact.getHopCount()-1; // the hop to establish
                             final boolean secure = createTunnelToProxy(route, hop, context);
                             if (log.isDebugEnabled()) {
-                                log.debug(exchangeId + ": tunnel to proxy created.");
+                                log.debug("{}: tunnel to proxy created.", exchangeId);
                             }
                             tracker.tunnelProxy(route.getHopTarget(hop), secure);
                         }   break;
@@ -234,7 +234,7 @@ public final class ConnectExec implements ExecChainHandler {
                         // Retry request
                         if (this.reuseStrategy.keepAlive(request, response, context)) {
                             if (log.isDebugEnabled()) {
-                                log.debug(exchangeId + ": connection kept alive");
+                                log.debug("{}: connection kept alive", exchangeId);
                             }
                             // Consume response content
                             final HttpEntity entity = response.getEntity();

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/InternalExecRuntime.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/InternalExecRuntime.java
@@ -98,7 +98,7 @@ class InternalExecRuntime implements ExecRuntime, Cancellable {
             final RequestConfig requestConfig = context.getRequestConfig();
             final Timeout connectionRequestTimeout = requestConfig.getConnectionRequestTimeout();
             if (log.isDebugEnabled()) {
-                log.debug(id + ": acquiring endpoint (" + connectionRequestTimeout + ")");
+                log.debug("{}: acquiring endpoint ({})", id, connectionRequestTimeout);
             }
             final LeaseRequest connRequest = manager.lease(id, route, connectionRequestTimeout, object);
             state = object;
@@ -117,7 +117,7 @@ class InternalExecRuntime implements ExecRuntime, Cancellable {
                     cancellableDependency.setDependency(this);
                 }
                 if (log.isDebugEnabled()) {
-                    log.debug(id + ": acquired endpoint " + ConnPoolSupport.getId(connectionEndpoint));
+                    log.debug("{}: acquired endpoint {}", id, ConnPoolSupport.getId(connectionEndpoint));
                 }
             } catch(final TimeoutException ex) {
                 throw new ConnectionRequestTimeoutException(ex.getMessage());
@@ -159,11 +159,11 @@ class InternalExecRuntime implements ExecRuntime, Cancellable {
         final RequestConfig requestConfig = context.getRequestConfig();
         final Timeout connectTimeout = requestConfig.getConnectTimeout();
         if (log.isDebugEnabled()) {
-            log.debug(ConnPoolSupport.getId(endpoint) + ": connecting endpoint (" + connectTimeout + ")");
+            log.debug("{}: connecting endpoint ({})", ConnPoolSupport.getId(endpoint), connectTimeout);
         }
         manager.connect(endpoint, connectTimeout, context);
         if (log.isDebugEnabled()) {
-            log.debug(ConnPoolSupport.getId(endpoint) + ": endpoint connected");
+            log.debug("{}: endpoint connected", ConnPoolSupport.getId(endpoint));
         }
     }
 
@@ -181,7 +181,7 @@ class InternalExecRuntime implements ExecRuntime, Cancellable {
         if (endpoint != null) {
             endpoint.close();
             if (log.isDebugEnabled()) {
-                log.debug(ConnPoolSupport.getId(endpoint) + ": endpoint closed");
+                log.debug("{}: endpoint closed", ConnPoolSupport.getId(endpoint));
             }
         }
     }
@@ -190,7 +190,7 @@ class InternalExecRuntime implements ExecRuntime, Cancellable {
     public void upgradeTls(final HttpClientContext context) throws IOException {
         final ConnectionEndpoint endpoint = ensureValid();
         if (log.isDebugEnabled()) {
-            log.debug(ConnPoolSupport.getId(endpoint) + ": upgrading endpoint");
+            log.debug("{}: upgrading endpoint", ConnPoolSupport.getId(endpoint));
         }
         manager.upgrade(endpoint, context);
     }
@@ -210,7 +210,7 @@ class InternalExecRuntime implements ExecRuntime, Cancellable {
             endpoint.setSocketTimeout(responseTimeout);
         }
         if (log.isDebugEnabled()) {
-            log.debug(ConnPoolSupport.getId(endpoint) + ": start execution " + id);
+            log.debug("{}: start execution {}", ConnPoolSupport.getId(endpoint), id);
         }
         return endpoint.execute(id, request, requestExecutor, context);
     }
@@ -236,11 +236,11 @@ class InternalExecRuntime implements ExecRuntime, Cancellable {
         try {
             endpoint.close(CloseMode.IMMEDIATE);
             if (log.isDebugEnabled()) {
-                log.debug(ConnPoolSupport.getId(endpoint) + ": endpoint closed");
+                log.debug("{}: endpoint closed", ConnPoolSupport.getId(endpoint));
             }
         } finally {
             if (log.isDebugEnabled()) {
-                log.debug(ConnPoolSupport.getId(endpoint) + ": discarding endpoint");
+                log.debug("{}: discarding endpoint", ConnPoolSupport.getId(endpoint));
             }
             manager.release(endpoint, null, TimeValue.ZERO_MILLISECONDS);
         }
@@ -252,7 +252,7 @@ class InternalExecRuntime implements ExecRuntime, Cancellable {
         if (endpoint != null) {
             if (reusable) {
                 if (log.isDebugEnabled()) {
-                    log.debug(ConnPoolSupport.getId(endpoint) + ": releasing valid endpoint");
+                    log.debug("{}: releasing valid endpoint", ConnPoolSupport.getId(endpoint));
                 }
                 manager.release(endpoint, state, validDuration);
             } else {
@@ -275,7 +275,7 @@ class InternalExecRuntime implements ExecRuntime, Cancellable {
         final ConnectionEndpoint endpoint = endpointRef.getAndSet(null);
         if (endpoint != null) {
             if (log.isDebugEnabled()) {
-                log.debug(ConnPoolSupport.getId(endpoint) + ": cancel");
+                log.debug("{}: cancel", ConnPoolSupport.getId(endpoint));
             }
             discardEndpoint(endpoint);
         }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/InternalHttpClient.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/InternalHttpClient.java
@@ -169,7 +169,7 @@ class InternalHttpClient extends CloseableHttpClient implements Configurable {
             final HttpRoute route = determineRoute(target, request, localcontext);
             final String exchangeId = ExecSupport.getNextExchangeId();
             if (log.isDebugEnabled()) {
-                log.debug(exchangeId + ": preparing request execution");
+                log.debug("{}: preparing request execution", exchangeId);
             }
 
             final ExecRuntime execRuntime = new InternalExecRuntime(log, connManager, requestExecutor,

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/MainClientExec.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/MainClientExec.java
@@ -99,7 +99,7 @@ public final class MainClientExec implements ExecChainHandler {
         final ExecRuntime execRuntime = scope.execRuntime;
 
         if (log.isDebugEnabled()) {
-            log.debug(exchangeId + ": executing " + new RequestLine(request));
+            log.debug("{}: executing {}", exchangeId, new RequestLine(request));
         }
         try {
             RequestEntityProxy.enhance(request);
@@ -123,7 +123,7 @@ public final class MainClientExec implements ExecChainHandler {
                     } else {
                         s = "indefinitely";
                     }
-                    this.log.debug(exchangeId + ": connection can be kept alive " + s);
+                    this.log.debug("{}: connection can be kept alive {}", exchangeId, s);
                 }
                 execRuntime.markConnectionReusable(userToken, duration);
             } else {

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/ProtocolExec.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/ProtocolExec.java
@@ -155,13 +155,13 @@ public final class ProtocolExec implements ExecChainHandler {
 
                 if (!request.containsHeader(HttpHeaders.AUTHORIZATION)) {
                     if (log.isDebugEnabled()) {
-                        log.debug(exchangeId + ": target auth state: " + targetAuthExchange.getState());
+                        log.debug("{}: target auth state: {}", exchangeId, targetAuthExchange.getState());
                     }
                     authenticator.addAuthResponse(target, ChallengeType.TARGET, request, targetAuthExchange, context);
                 }
                 if (!request.containsHeader(HttpHeaders.PROXY_AUTHORIZATION) && !route.isTunnelled()) {
                     if (log.isDebugEnabled()) {
-                        log.debug(exchangeId + ": proxy auth state: " + proxyAuthExchange.getState());
+                        log.debug("{}: proxy auth state: {}", exchangeId, proxyAuthExchange.getState());
                     }
                     authenticator.addAuthResponse(proxy, ChallengeType.PROXY, request, proxyAuthExchange, context);
                 }
@@ -178,7 +178,7 @@ public final class ProtocolExec implements ExecChainHandler {
                 final HttpEntity requestEntity = request.getEntity();
                 if (requestEntity != null && !requestEntity.isRepeatable()) {
                     if (log.isDebugEnabled()) {
-                        log.debug(exchangeId + ": Cannot retry non-repeatable request");
+                        log.debug("{}: Cannot retry non-repeatable request", exchangeId);
                     }
                     return response;
                 }
@@ -192,14 +192,14 @@ public final class ProtocolExec implements ExecChainHandler {
                         if (proxyAuthExchange.getState() == AuthExchange.State.SUCCESS
                                 && proxyAuthExchange.isConnectionBased()) {
                             if (log.isDebugEnabled()) {
-                                log.debug(exchangeId + ": resetting proxy auth state");
+                                log.debug("{}: resetting proxy auth state", exchangeId);
                             }
                             proxyAuthExchange.reset();
                         }
                         if (targetAuthExchange.getState() == AuthExchange.State.SUCCESS
                                 && targetAuthExchange.isConnectionBased()) {
                             if (log.isDebugEnabled()) {
-                                log.debug(exchangeId + ": resetting target auth state");
+                                log.debug("{}: resetting target auth state", exchangeId);
                             }
                             targetAuthExchange.reset();
                         }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/RedirectExec.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/RedirectExec.java
@@ -119,7 +119,7 @@ public final class RedirectExec implements ExecChainHandler {
                     final HttpEntity requestEntity = request.getEntity();
                     if (requestEntity != null && !requestEntity.isRepeatable()) {
                         if (log.isDebugEnabled()) {
-                            log.debug(exchangeId + ": cannot redirect non-repeatable request");
+                            log.debug("{}: cannot redirect non-repeatable request", exchangeId);
                         }
                         return response;
                     }
@@ -130,7 +130,7 @@ public final class RedirectExec implements ExecChainHandler {
 
                     final URI redirectUri = this.redirectStrategy.getLocationURI(currentRequest, response, context);
                     if (log.isDebugEnabled()) {
-                        log.debug(exchangeId + ": redirect requested to location '" + redirectUri + "'");
+                        log.debug("{}: redirect requested to location '{}'", exchangeId, redirectUri);
                     }
                     if (!config.isCircularRedirectsAllowed()) {
                         if (redirectLocations.contains(redirectUri)) {
@@ -171,18 +171,18 @@ public final class RedirectExec implements ExecChainHandler {
                         final HttpRoute newRoute = this.routePlanner.determineRoute(newTarget, context);
                         if (!LangUtils.equals(currentRoute, newRoute)) {
                             if (log.isDebugEnabled()) {
-                                log.debug(exchangeId + ": new route required");
+                                log.debug("{}: new route required", exchangeId);
                             }
                             final AuthExchange targetAuthExchange = context.getAuthExchange(currentRoute.getTargetHost());
                             if (log.isDebugEnabled()) {
-                                log.debug(exchangeId + ": resetting target auth state");
+                                log.debug("{}: resetting target auth state", exchangeId);
                             }
                             targetAuthExchange.reset();
                             if (currentRoute.getProxyHost() != null) {
                                 final AuthExchange proxyAuthExchange = context.getAuthExchange(currentRoute.getProxyHost());
                                 if (proxyAuthExchange.isConnectionBased()) {
                                     if (log.isDebugEnabled()) {
-                                        log.debug(exchangeId + ": resetting proxy auth state");
+                                        log.debug("{}: resetting proxy auth state", exchangeId);
                                     }
                                     proxyAuthExchange.reset();
                                 }
@@ -197,7 +197,7 @@ public final class RedirectExec implements ExecChainHandler {
                     }
 
                     if (log.isDebugEnabled()) {
-                        log.debug(exchangeId + ": redirecting to '" + redirectUri + "' via " + currentRoute);
+                        log.debug("{}: redirecting to '{}' via {}", exchangeId, redirectUri, currentRoute);
                     }
                     currentRequest = redirect;
                     RequestEntityProxy.enhance(currentRequest);
@@ -217,7 +217,7 @@ public final class RedirectExec implements ExecChainHandler {
                     EntityUtils.consume(response.getEntity());
                 } catch (final IOException ioex) {
                     if (log.isDebugEnabled()) {
-                        log.debug(exchangeId + ": I/O error while releasing connection", ioex);
+                        log.debug("{}: I/O error while releasing connection", exchangeId, ioex);
                     }
                 } finally {
                     response.close();

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/cookie/RFC6265CookieSpec.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/cookie/RFC6265CookieSpec.java
@@ -112,7 +112,7 @@ public class RFC6265CookieSpec implements CookieSpec {
         Args.notNull(header, "Header");
         Args.notNull(origin, "Cookie origin");
         if (!header.getName().equalsIgnoreCase("Set-Cookie")) {
-            throw new MalformedCookieException("Unrecognized cookie header: '" + header.toString() + "'");
+            throw new MalformedCookieException("Unrecognized cookie header: '" + header + "'");
         }
         final CharArrayBuffer buffer;
         final ParserCursor cursor;
@@ -138,7 +138,7 @@ public class RFC6265CookieSpec implements CookieSpec {
         final int valueDelim = buffer.charAt(cursor.getPos());
         cursor.updatePos(cursor.getPos() + 1);
         if (valueDelim != '=') {
-            throw new MalformedCookieException("Cookie value is invalid: '" + header.toString() + "'");
+            throw new MalformedCookieException("Cookie value is invalid: '" + header + "'");
         }
         final String value = tokenParser.parseValue(buffer, cursor, VALUE_DELIMS);
         if (!cursor.atEnd()) {

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/BasicHttpClientConnectionManager.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/BasicHttpClientConnectionManager.java
@@ -206,7 +206,7 @@ public class BasicHttpClientConnectionManager implements HttpClientConnectionMan
 
     private synchronized void closeConnection(final CloseMode closeMode) {
         if (this.conn != null) {
-            this.log.debug("Closing connection " + closeMode);
+            this.log.debug("Closing connection {}", closeMode);
             this.conn.close(closeMode);
             this.conn = null;
         }
@@ -215,7 +215,7 @@ public class BasicHttpClientConnectionManager implements HttpClientConnectionMan
     private void checkExpiry() {
         if (this.conn != null && System.currentTimeMillis() >= this.expiry) {
             if (this.log.isDebugEnabled()) {
-                this.log.debug("Connection expired @ " + new Date(this.expiry));
+                this.log.debug("Connection expired @ {}", new Date(this.expiry));
             }
             closeConnection(CloseMode.GRACEFUL);
         }
@@ -224,7 +224,7 @@ public class BasicHttpClientConnectionManager implements HttpClientConnectionMan
     synchronized ManagedHttpClientConnection getConnection(final HttpRoute route, final Object state) throws IOException {
         Asserts.check(!this.closed.get(), "Connection manager has been shut down");
         if (this.log.isDebugEnabled()) {
-            this.log.debug("Get connection for route " + route);
+            this.log.debug("Get connection for route {}", route);
         }
         Asserts.check(!this.leased, "Connection is still allocated");
         if (!LangUtils.equals(this.route, route) || !LangUtils.equals(this.state, state)) {
@@ -255,7 +255,7 @@ public class BasicHttpClientConnectionManager implements HttpClientConnectionMan
         final InternalConnectionEndpoint internalEndpoint = cast(endpoint);
         final ManagedHttpClientConnection conn = internalEndpoint.detach();
         if (conn != null && this.log.isDebugEnabled()) {
-            this.log.debug("Releasing connection " + conn);
+            this.log.debug("Releasing connection {}", conn);
         }
         if (this.closed.get()) {
             return;
@@ -278,7 +278,7 @@ public class BasicHttpClientConnectionManager implements HttpClientConnectionMan
                 conn.passivate();
                 if (TimeValue.isPositive(keepAlive)) {
                     if (this.log.isDebugEnabled()) {
-                        this.log.debug("Connection can be kept alive for " + keepAlive);
+                        this.log.debug("Connection can be kept alive for {}", keepAlive);
                     }
                     this.expiry = this.updated + keepAlive.toMilliseconds();
                 } else {

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/DefaultHttpClientConnectionOperator.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/DefaultHttpClientConnectionOperator.java
@@ -142,13 +142,13 @@ public class DefaultHttpClientConnectionOperator implements HttpClientConnection
 
             final InetSocketAddress remoteAddress = new InetSocketAddress(address, port);
             if (this.log.isDebugEnabled()) {
-                this.log.debug(ConnPoolSupport.getId(conn) + ": connecting to " + remoteAddress);
+                this.log.debug("{}: connecting to {}", ConnPoolSupport.getId(conn), remoteAddress);
             }
             try {
                 sock = sf.connectSocket(connectTimeout, sock, host, remoteAddress, localAddress, context);
                 conn.bind(sock);
                 if (this.log.isDebugEnabled()) {
-                    this.log.debug(ConnPoolSupport.getId(conn) + ": connection established " + conn);
+                    this.log.debug("{}: connection established {}", ConnPoolSupport.getId(conn), conn);
                 }
                 return;
             } catch (final IOException ex) {
@@ -157,8 +157,7 @@ public class DefaultHttpClientConnectionOperator implements HttpClientConnection
                 }
             }
             if (this.log.isDebugEnabled()) {
-                this.log.debug(ConnPoolSupport.getId(conn) + ": connect to " + remoteAddress + " timed out. " +
-                        "Connection will be retried using another IP address");
+                this.log.debug("{}: connect to {} timed out. Connection will be retried using another IP address", ConnPoolSupport.getId(conn), remoteAddress);
             }
         }
     }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/DefaultManagedHttpClientConnection.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/DefaultManagedHttpClientConnection.java
@@ -158,7 +158,7 @@ final class DefaultManagedHttpClientConnection
             this.headerLog.debug("{} << {}", this.id, new StatusLine(response));
             final Header[] headers = response.getHeaders();
             for (final Header header : headers) {
-                this.headerLog.debug("{} << {}", this.id, header.toString());
+                this.headerLog.debug("{} << {}", this.id, header);
             }
         }
     }
@@ -169,7 +169,7 @@ final class DefaultManagedHttpClientConnection
             this.headerLog.debug("{} >> {}", this.id, new RequestLine(request));
             final Header[] headers = request.getHeaders();
             for (final Header header : headers) {
-                this.headerLog.debug("{} >> {}", this.id, header.toString());
+                this.headerLog.debug("{} >> {}", this.id, header);
             }
         }
     }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/DefaultManagedHttpClientConnection.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/DefaultManagedHttpClientConnection.java
@@ -122,7 +122,7 @@ final class DefaultManagedHttpClientConnection
     public void close() throws IOException {
         if (this.closed.compareAndSet(false, true)) {
             if (this.log.isDebugEnabled()) {
-                this.log.debug(this.id + ": Close connection");
+                this.log.debug("{}: Close connection", this.id);
             }
             super.close();
         }
@@ -131,7 +131,7 @@ final class DefaultManagedHttpClientConnection
     @Override
     public void setSocketTimeout(final Timeout timeout) {
         if (this.log.isDebugEnabled()) {
-            this.log.debug(this.id + ": set socket timeout to " + timeout);
+            this.log.debug("{}: set socket timeout to {}", this.id, timeout);
         }
         super.setSocketTimeout(timeout);
     }
@@ -140,7 +140,7 @@ final class DefaultManagedHttpClientConnection
     public void close(final CloseMode closeMode) {
         if (this.closed.compareAndSet(false, true)) {
             if (this.log.isDebugEnabled()) {
-                this.log.debug(this.id + ": close connection " + closeMode);
+                this.log.debug("{}: close connection {}", this.id, closeMode);
             }
             super.close(closeMode);
         }
@@ -155,10 +155,10 @@ final class DefaultManagedHttpClientConnection
     @Override
     protected void onResponseReceived(final ClassicHttpResponse response) {
         if (response != null && this.headerLog.isDebugEnabled()) {
-            this.headerLog.debug(this.id + " << " + new StatusLine(response));
+            this.headerLog.debug("{} << {}", this.id, new StatusLine(response));
             final Header[] headers = response.getHeaders();
             for (final Header header : headers) {
-                this.headerLog.debug(this.id + " << " + header.toString());
+                this.headerLog.debug("{} << {}", this.id, header.toString());
             }
         }
     }
@@ -166,10 +166,10 @@ final class DefaultManagedHttpClientConnection
     @Override
     protected void onRequestSubmitted(final ClassicHttpRequest request) {
         if (request != null && this.headerLog.isDebugEnabled()) {
-            this.headerLog.debug(this.id + " >> " + new RequestLine(request));
+            this.headerLog.debug("{} >> {}", this.id, new RequestLine(request));
             final Header[] headers = request.getHeaders();
             for (final Header header : headers) {
-                this.headerLog.debug(this.id + " >> " + header.toString());
+                this.headerLog.debug("{} >> {}", this.id, header.toString());
             }
         }
     }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/LenientHttpResponseParser.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/LenientHttpResponseParser.java
@@ -85,7 +85,7 @@ public class LenientHttpResponseParser extends DefaultHttpResponseParser {
             return super.createMessage(buffer);
         } catch (final HttpException ex) {
             if (this.log.isDebugEnabled()) {
-                this.log.debug("Garbage in response: {}", buffer.toString());
+                this.log.debug("Garbage in response: {}", buffer);
             }
             return null;
         }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/LenientHttpResponseParser.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/LenientHttpResponseParser.java
@@ -85,7 +85,7 @@ public class LenientHttpResponseParser extends DefaultHttpResponseParser {
             return super.createMessage(buffer);
         } catch (final HttpException ex) {
             if (this.log.isDebugEnabled()) {
-                this.log.debug("Garbage in response: " + buffer.toString());
+                this.log.debug("Garbage in response: {}", buffer.toString());
             }
             return null;
         }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java
@@ -232,7 +232,7 @@ public class PoolingHttpClientConnectionManager
     public void close(final CloseMode closeMode) {
         if (this.closed.compareAndSet(false, true)) {
             if (this.log.isDebugEnabled()) {
-                this.log.debug("Shutdown connection pool " + closeMode);
+                this.log.debug("Shutdown connection pool {}", closeMode);
             }
             this.pool.close(closeMode);
             this.log.debug("Connection pool shut down");
@@ -258,8 +258,7 @@ public class PoolingHttpClientConnectionManager
             final Object state) {
         Args.notNull(route, "HTTP route");
         if (log.isDebugEnabled()) {
-            log.debug(id + ": endpoint lease request (" + requestTimeout + ") " +
-                    ConnPoolSupport.formatStats(route, state, pool));
+            log.debug("{}: endpoint lease request ({}) {}", id, requestTimeout, ConnPoolSupport.formatStats(route, state, pool));
         }
         final Future<PoolEntry<HttpRoute, ManagedHttpClientConnection>> leaseFuture = this.pool.lease(route, state, requestTimeout, null);
         return new LeaseRequest() {
@@ -284,7 +283,7 @@ public class PoolingHttpClientConnectionManager
                     throw ex;
                 }
                 if (log.isDebugEnabled()) {
-                    log.debug(id + ": endpoint leased " + ConnPoolSupport.formatStats(route, state, pool));
+                    log.debug("{}: endpoint leased {}", id, ConnPoolSupport.formatStats(route, state, pool));
                 }
                 try {
                     if (TimeValue.isNonNegative(validateAfterInactivity)) {
@@ -299,7 +298,7 @@ public class PoolingHttpClientConnectionManager
                             }
                             if (stale) {
                                 if (log.isDebugEnabled()) {
-                                    log.debug(id + ": connection " + ConnPoolSupport.getId(conn) + " is stale");
+                                    log.debug("{}: connection {} is stale", id, ConnPoolSupport.getId(conn));
                                 }
                                 poolEntry.discardConnection(CloseMode.IMMEDIATE);
                             }
@@ -313,19 +312,19 @@ public class PoolingHttpClientConnectionManager
                     }
                     if (leaseFuture.isCancelled()) {
                         if (log.isDebugEnabled()) {
-                            log.debug(id + ": endpoint lease cancelled");
+                            log.debug("{}: endpoint lease cancelled", id);
                         }
                         pool.release(poolEntry, false);
                     } else {
                         this.endpoint = new InternalConnectionEndpoint(poolEntry);
                         if (log.isDebugEnabled()) {
-                            log.debug(id + ": acquired " + ConnPoolSupport.getId(endpoint));
+                            log.debug("{}: acquired {}", id, ConnPoolSupport.getId(endpoint));
                         }
                     }
                     return this.endpoint;
                 } catch (final Exception ex) {
                     if (log.isDebugEnabled()) {
-                        log.debug(id + ": endpoint lease failed");
+                        log.debug("{}: endpoint lease failed", id);
                     }
                     pool.release(poolEntry, false);
                     throw new ExecutionException(ex.getMessage(), ex);
@@ -349,7 +348,7 @@ public class PoolingHttpClientConnectionManager
             return;
         }
         if (log.isDebugEnabled()) {
-            log.debug(ConnPoolSupport.getId(endpoint) + ": releasing endpoint");
+            log.debug("{}: releasing endpoint", ConnPoolSupport.getId(endpoint));
         }
         final ManagedHttpClientConnection conn = entry.getConnection();
         if (conn != null && keepAlive == null) {
@@ -368,12 +367,11 @@ public class PoolingHttpClientConnectionManager
                     } else {
                         s = "indefinitely";
                     }
-                    log.debug(ConnPoolSupport.getId(endpoint) + ": connection " + ConnPoolSupport.getId(conn) +
-                            " can be kept alive " + s);
+                    log.debug("{}: connection {} can be kept alive {}", ConnPoolSupport.getId(endpoint), ConnPoolSupport.getId(conn), s);
                 }
             } else {
                 if (this.log.isDebugEnabled()) {
-                    this.log.debug(ConnPoolSupport.getId(endpoint) + ": connection is not kept alive");
+                    this.log.debug("{}: connection is not kept alive", ConnPoolSupport.getId(endpoint));
                 }
             }
         } catch (final RuntimeException ex) {
@@ -382,8 +380,7 @@ public class PoolingHttpClientConnectionManager
         } finally {
             this.pool.release(entry, reusable);
             if (this.log.isDebugEnabled()) {
-                log.debug(ConnPoolSupport.getId(endpoint) + ": connection released " +
-                        ConnPoolSupport.formatStats(entry.getRoute(), entry.getState(), pool));
+                log.debug("{}: connection released {}", ConnPoolSupport.getId(endpoint), ConnPoolSupport.formatStats(entry.getRoute(), entry.getState(), pool));
             }
         }
     }
@@ -407,7 +404,7 @@ public class PoolingHttpClientConnectionManager
             host = route.getTargetHost();
         }
         if (this.log.isDebugEnabled()) {
-            log.debug(ConnPoolSupport.getId(endpoint) + ": connecting endpoint to " + host + " (" + connectTimeout + ")");
+            log.debug("{}: connecting endpoint to {} ({})", ConnPoolSupport.getId(endpoint), host, connectTimeout);
         }
         final ManagedHttpClientConnection conn = poolEntry.getConnection();
         this.connectionOperator.connect(
@@ -418,7 +415,7 @@ public class PoolingHttpClientConnectionManager
                 defaultSocketConfig != null ? this.defaultSocketConfig : SocketConfig.DEFAULT,
                 context);
         if (log.isDebugEnabled()) {
-            log.debug(ConnPoolSupport.getId(endpoint) + ": connected " + ConnPoolSupport.getId(conn));
+            log.debug("{}: connected {}", ConnPoolSupport.getId(endpoint), ConnPoolSupport.getId(conn));
         }
     }
 
@@ -435,7 +432,7 @@ public class PoolingHttpClientConnectionManager
     public void closeIdle(final TimeValue idleTime) {
         Args.notNull(idleTime, "Idle time");
         if (this.log.isDebugEnabled()) {
-            this.log.debug("Closing connections idle longer than " + idleTime);
+            this.log.debug("Closing connections idle longer than {}", idleTime);
         }
         this.pool.closeIdle(idleTime);
     }
@@ -595,7 +592,7 @@ public class PoolingHttpClientConnectionManager
             Args.notNull(requestExecutor, "Request executor");
             final ManagedHttpClientConnection connection = getValidatedPoolEntry().getConnection();
             if (log.isDebugEnabled()) {
-                log.debug(id + ": executing exchange " + exchangeId + " over " + ConnPoolSupport.getId(connection));
+                log.debug("{}: executing exchange {} over {}", id, exchangeId, ConnPoolSupport.getId(connection));
             }
             return requestExecutor.execute(request, connection, context);
         }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/DefaultManagedAsyncClientConnection.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/DefaultManagedAsyncClientConnection.java
@@ -78,7 +78,7 @@ final class DefaultManagedAsyncClientConnection implements ManagedAsyncClientCon
     public void close(final CloseMode closeMode) {
         if (this.closed.compareAndSet(false, true)) {
             if (log.isDebugEnabled()) {
-                log.debug(getId() + ": Shutdown connection " + closeMode);
+                log.debug("{}: Shutdown connection {}", getId(), closeMode);
             }
             ioSession.close(closeMode);
         }
@@ -88,7 +88,7 @@ final class DefaultManagedAsyncClientConnection implements ManagedAsyncClientCon
     public void close() throws IOException {
         if (this.closed.compareAndSet(false, true)) {
             if (log.isDebugEnabled()) {
-                log.debug(getId() + ": Close connection");
+                log.debug("{}: Close connection", getId());
             }
             ioSession.enqueue(new ShutdownCommand(CloseMode.GRACEFUL), Command.Priority.IMMEDIATE);
         }
@@ -146,7 +146,7 @@ final class DefaultManagedAsyncClientConnection implements ManagedAsyncClientCon
             final SSLSessionVerifier verifier,
             final Timeout handshakeTimeout) throws UnsupportedOperationException {
         if (log.isDebugEnabled()) {
-            log.debug(getId() + ": start TLS");
+            log.debug("{}: start TLS", getId());
         }
         if (ioSession instanceof TransportSecurityLayer) {
             ((TransportSecurityLayer) ioSession).startTls(sslContext, endpoint, sslBufferMode, initializer, verifier,
@@ -170,7 +170,7 @@ final class DefaultManagedAsyncClientConnection implements ManagedAsyncClientCon
     @Override
     public void submitCommand(final Command command, final Command.Priority priority) {
         if (log.isDebugEnabled()) {
-            log.debug(getId() + ": " + command.getClass().getSimpleName() + " with " + priority + " priority");
+            log.debug("{}: {} with {} priority", getId(), command.getClass().getSimpleName(), priority);
         }
         ioSession.enqueue(command, Command.Priority.IMMEDIATE);
     }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/MultihomeIOSessionRequester.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/MultihomeIOSessionRequester.java
@@ -68,13 +68,13 @@ final class MultihomeIOSessionRequester {
 
         if (remoteAddress != null) {
             if (log.isDebugEnabled()) {
-                log.debug(remoteEndpoint + ": connecting " + localAddress + " to " + remoteAddress + " (" + connectTimeout + ")");
+                log.debug("{}: connecting {} to {} ({})", remoteEndpoint, localAddress, remoteAddress, connectTimeout);
             }
             return connectionInitiator.connect(remoteEndpoint, remoteAddress, localAddress, connectTimeout, attachment, callback);
         }
 
         if (log.isDebugEnabled()) {
-            log.debug(remoteEndpoint + ": resolving remote address");
+            log.debug("{}: resolving remote address", remoteEndpoint);
         }
 
         final ComplexFuture<IOSession> future = new ComplexFuture<>(callback);
@@ -87,7 +87,7 @@ final class MultihomeIOSessionRequester {
         }
 
         if (log.isDebugEnabled()) {
-            log.debug(remoteEndpoint + ": resolved to " + Arrays.asList(remoteAddresses));
+            log.debug("{}: resolved to {}", remoteEndpoint, Arrays.asList(remoteAddresses));
         }
 
         final Runnable runnable = new Runnable() {
@@ -99,7 +99,7 @@ final class MultihomeIOSessionRequester {
                 final InetSocketAddress remoteAddress = new InetSocketAddress(remoteAddresses[index], remoteEndpoint.getPort());
 
                 if (log.isDebugEnabled()) {
-                    log.debug(remoteEndpoint + ": connecting " + localAddress + " to " + remoteAddress + " (" + connectTimeout + ")");
+                    log.debug("{}: connecting {} to {} ({})", remoteEndpoint, localAddress, remoteAddress, connectTimeout);
                 }
 
                 final Future<IOSession> sessionFuture = connectionInitiator.connect(
@@ -114,8 +114,7 @@ final class MultihomeIOSessionRequester {
                             public void completed(final IOSession session) {
                                 if (log.isDebugEnabled()) {
                                     if (log.isDebugEnabled()) {
-                                        log.debug(remoteEndpoint + ": connected " + session.getId() + " " +
-                                                session.getLocalAddress() + "->" + session.getRemoteAddress());
+                                        log.debug("{}: connected {} {}->{}", remoteEndpoint, session.getId(), session.getLocalAddress(), session.getRemoteAddress());
                                     }
                                 }
                                 future.completed(session);
@@ -125,8 +124,7 @@ final class MultihomeIOSessionRequester {
                             public void failed(final Exception cause) {
                                 if (attempt.get() >= remoteAddresses.length) {
                                     if (log.isDebugEnabled()) {
-                                        log.debug(remoteEndpoint + ": connection to " + remoteAddress + " failed " +
-                                                "(" + cause.getClass() + "); terminating operation");
+                                        log.debug("{}: connection to {} failed ({}); terminating operation", remoteEndpoint, remoteAddress, cause.getClass());
                                     }
                                     if (cause instanceof IOException) {
                                         future.failed(ConnectExceptionSupport.enhance((IOException) cause, remoteEndpoint, remoteAddresses));
@@ -135,8 +133,7 @@ final class MultihomeIOSessionRequester {
                                     }
                                 } else {
                                     if (log.isDebugEnabled()) {
-                                        log.debug(remoteEndpoint + ": connection to " + remoteAddress + " failed " +
-                                                "(" + cause.getClass() + "); retrying connection to the next address");
+                                        log.debug("{}: connection to {} failed ({}); retrying connection to the next address", remoteEndpoint, remoteAddress, cause.getClass());
                                     }
                                     executeNext();
                                 }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java
@@ -197,7 +197,7 @@ public class PoolingAsyncClientConnectionManager implements AsyncClientConnectio
     public void close(final CloseMode closeMode) {
         if (this.closed.compareAndSet(false, true)) {
             if (this.log.isDebugEnabled()) {
-                this.log.debug("Shutdown connection pool " + closeMode);
+                this.log.debug("Shutdown connection pool {}", closeMode);
             }
             this.pool.close(closeMode);
             this.log.debug("Connection pool shut down");
@@ -219,8 +219,7 @@ public class PoolingAsyncClientConnectionManager implements AsyncClientConnectio
             final Timeout requestTimeout,
             final FutureCallback<AsyncConnectionEndpoint> callback) {
         if (log.isDebugEnabled()) {
-            log.debug(id + ": endpoint lease request (" + requestTimeout + ") " +
-                    ConnPoolSupport.formatStats(route, state, pool));
+            log.debug("{}: endpoint lease request ({}) {}", id, requestTimeout, ConnPoolSupport.formatStats(route, state, pool));
         }
         final ComplexFuture<AsyncConnectionEndpoint> resultFuture = new ComplexFuture<>(callback);
         final Future<PoolEntry<HttpRoute, ManagedAsyncClientConnection>> leaseFuture = pool.lease(
@@ -232,11 +231,11 @@ public class PoolingAsyncClientConnectionManager implements AsyncClientConnectio
                             connection.activate();
                         }
                         if (log.isDebugEnabled()) {
-                            log.debug(id + ": endpoint leased " + ConnPoolSupport.formatStats(route, state, pool));
+                            log.debug("{}: endpoint leased {}", id, ConnPoolSupport.formatStats(route, state, pool));
                         }
                         final AsyncConnectionEndpoint endpoint = new InternalConnectionEndpoint(poolEntry);
                         if (log.isDebugEnabled()) {
-                            log.debug(id + ": acquired " + ConnPoolSupport.getId(endpoint));
+                            log.debug("{}: acquired {}", id, ConnPoolSupport.getId(endpoint));
                         }
                         resultFuture.completed(endpoint);
                     }
@@ -255,7 +254,7 @@ public class PoolingAsyncClientConnectionManager implements AsyncClientConnectio
                                     public void execute(final Boolean result) {
                                         if (result == Boolean.FALSE) {
                                             if (log.isDebugEnabled()) {
-                                                log.debug(id + ": connection " + ConnPoolSupport.getId(connection) + " is stale");
+                                                log.debug("{}: connection {} is stale", id, ConnPoolSupport.getId(connection));
                                             }
                                             poolEntry.discardConnection(CloseMode.IMMEDIATE);
                                         }
@@ -266,7 +265,7 @@ public class PoolingAsyncClientConnectionManager implements AsyncClientConnectio
                             } else {
                                 if (!connection.isOpen()) {
                                     if (log.isDebugEnabled()) {
-                                        log.debug(id + ": connection " + ConnPoolSupport.getId(connection) + " is closed");
+                                        log.debug("{}: connection {} is closed", id, ConnPoolSupport.getId(connection));
                                     }
                                     poolEntry.discardConnection(CloseMode.IMMEDIATE);
                                 }
@@ -280,7 +279,7 @@ public class PoolingAsyncClientConnectionManager implements AsyncClientConnectio
                     @Override
                     public void failed(final Exception ex) {
                         if (log.isDebugEnabled()) {
-                            log.debug(id + ": endpoint lease failed");
+                            log.debug("{}: endpoint lease failed", id);
                         }
                         resultFuture.failed(ex);
                     }
@@ -288,7 +287,7 @@ public class PoolingAsyncClientConnectionManager implements AsyncClientConnectio
                     @Override
                     public void cancelled() {
                         if (log.isDebugEnabled()) {
-                            log.debug(id + ": endpoint lease cancelled");
+                            log.debug("{}: endpoint lease cancelled", id);
                         }
                         resultFuture.cancel();
                     }
@@ -308,7 +307,7 @@ public class PoolingAsyncClientConnectionManager implements AsyncClientConnectio
             return;
         }
         if (log.isDebugEnabled()) {
-            log.debug(ConnPoolSupport.getId(endpoint) + ": releasing endpoint");
+            log.debug("{}: releasing endpoint", ConnPoolSupport.getId(endpoint));
         }
         final ManagedAsyncClientConnection connection = entry.getConnection();
         boolean reusable = connection != null && connection.isOpen();
@@ -324,8 +323,7 @@ public class PoolingAsyncClientConnectionManager implements AsyncClientConnectio
                     } else {
                         s = "indefinitely";
                     }
-                    log.debug(ConnPoolSupport.getId(endpoint) + ": connection " + ConnPoolSupport.getId(connection) +
-                            " can be kept alive " + s);
+                    log.debug("{}: connection {} can be kept alive {}", ConnPoolSupport.getId(endpoint), ConnPoolSupport.getId(connection), s);
                 }
             }
         } catch (final RuntimeException ex) {
@@ -334,8 +332,7 @@ public class PoolingAsyncClientConnectionManager implements AsyncClientConnectio
         } finally {
             pool.release(entry, reusable);
             if (log.isDebugEnabled()) {
-                log.debug(ConnPoolSupport.getId(endpoint) + ": connection released " +
-                        ConnPoolSupport.formatStats(entry.getRoute(), entry.getState(), pool));
+                log.debug("{}: connection released {}", ConnPoolSupport.getId(endpoint), ConnPoolSupport.formatStats(entry.getRoute(), entry.getState(), pool));
             }
         }
     }
@@ -367,7 +364,7 @@ public class PoolingAsyncClientConnectionManager implements AsyncClientConnectio
         }
         final InetSocketAddress localAddress = route.getLocalSocketAddress();
         if (this.log.isDebugEnabled()) {
-            log.debug(ConnPoolSupport.getId(endpoint) + ": connecting endpoint to " + host + " (" + connectTimeout + ")");
+            log.debug("{}: connecting endpoint to {} ({})", ConnPoolSupport.getId(endpoint), host, connectTimeout);
         }
         final Future<ManagedAsyncClientConnection> connectFuture = connectionOperator.connect(
                 connectionInitiator, host, localAddress, connectTimeout, attachment, new FutureCallback<ManagedAsyncClientConnection>() {
@@ -376,7 +373,7 @@ public class PoolingAsyncClientConnectionManager implements AsyncClientConnectio
                     public void completed(final ManagedAsyncClientConnection connection) {
                         try {
                             if (log.isDebugEnabled()) {
-                                log.debug(ConnPoolSupport.getId(endpoint) + ": connected " + ConnPoolSupport.getId(connection));
+                                log.debug("{}: connected {}", ConnPoolSupport.getId(endpoint), ConnPoolSupport.getId(connection));
                             }
                             poolEntry.assignConnection(connection);
                             resultFuture.completed(internalEndpoint);
@@ -412,7 +409,7 @@ public class PoolingAsyncClientConnectionManager implements AsyncClientConnectio
         final ManagedAsyncClientConnection connection = poolEntry.getConnection();
         connectionOperator.upgrade(poolEntry.getConnection(), route.getTargetHost(), attachment);
         if (log.isDebugEnabled()) {
-            log.debug(ConnPoolSupport.getId(internalEndpoint) + ": upgraded " + ConnPoolSupport.getId(connection));
+            log.debug("{}: upgraded {}", ConnPoolSupport.getId(internalEndpoint), ConnPoolSupport.getId(connection));
         }
     }
 
@@ -527,7 +524,7 @@ public class PoolingAsyncClientConnectionManager implements AsyncClientConnectio
             final PoolEntry<HttpRoute, ManagedAsyncClientConnection> poolEntry = poolEntryRef.get();
             if (poolEntry != null) {
                 if (log.isDebugEnabled()) {
-                    log.debug(id + ": close " + closeMode);
+                    log.debug("{}: close {}", id, closeMode);
                 }
                 poolEntry.discardConnection(closeMode);
             }
@@ -563,7 +560,7 @@ public class PoolingAsyncClientConnectionManager implements AsyncClientConnectio
                 final HttpContext context) {
             final ManagedAsyncClientConnection connection = getValidatedPoolEntry().getConnection();
             if (log.isDebugEnabled()) {
-                log.debug(id + ": executing exchange " + exchangeId + " over " + ConnPoolSupport.getId(connection));
+                log.debug("{}: executing exchange {} over {}", id, exchangeId, ConnPoolSupport.getId(connection));
             }
             connection.submitCommand(
                     new RequestExecutionCommand(exchangeHandler, pushHandlerFactory, context),

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/protocol/RequestAddCookies.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/protocol/RequestAddCookies.java
@@ -111,7 +111,7 @@ public class RequestAddCookies implements HttpRequestInterceptor {
             cookieSpecName = StandardCookieSpec.STRICT;
         }
         if (this.log.isDebugEnabled()) {
-            this.log.debug("Cookie spec selected: " + cookieSpecName);
+            this.log.debug("Cookie spec selected: {}", cookieSpecName);
         }
 
         final URIAuthority authority = request.getAuthority();
@@ -133,7 +133,7 @@ public class RequestAddCookies implements HttpRequestInterceptor {
         final CookieSpecFactory factory = registry.lookup(cookieSpecName);
         if (factory == null) {
             if (this.log.isDebugEnabled()) {
-                this.log.debug("Unsupported cookie spec: " + cookieSpecName);
+                this.log.debug("Unsupported cookie spec: {}", cookieSpecName);
             }
 
             return;
@@ -149,13 +149,13 @@ public class RequestAddCookies implements HttpRequestInterceptor {
             if (!cookie.isExpired(now)) {
                 if (cookieSpec.match(cookie, cookieOrigin)) {
                     if (this.log.isDebugEnabled()) {
-                        this.log.debug("Cookie " + cookie + " match " + cookieOrigin);
+                        this.log.debug("Cookie {} match {}", cookie, cookieOrigin);
                     }
                     matchedCookies.add(cookie);
                 }
             } else {
                 if (this.log.isDebugEnabled()) {
-                    this.log.debug("Cookie " + cookie + " expired");
+                    this.log.debug("Cookie {} expired", cookie);
                 }
                 expired = true;
             }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/protocol/RequestAuthCache.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/protocol/RequestAuthCache.java
@@ -104,7 +104,7 @@ public class RequestAuthCache implements HttpRequestInterceptor {
             final AuthScheme authScheme = authCache.get(target);
             if (authScheme != null) {
                 if (this.log.isDebugEnabled()) {
-                    this.log.debug("Re-using cached '" + authScheme.getName() + "' auth scheme for " + target);
+                    this.log.debug("Re-using cached '{}' auth scheme for {}", authScheme.getName(), target);
                 }
                 targetAuthExchange.select(authScheme);
             }
@@ -117,7 +117,7 @@ public class RequestAuthCache implements HttpRequestInterceptor {
                 final AuthScheme authScheme = authCache.get(proxy);
                 if (authScheme != null) {
                     if (this.log.isDebugEnabled()) {
-                        this.log.debug("Re-using cached '" + authScheme.getName() + "' auth scheme for " + proxy);
+                        this.log.debug("Re-using cached '{}' auth scheme for {}", authScheme.getName(), proxy);
                     }
                     proxyAuthExchange.select(authScheme);
                 }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/protocol/ResponseProcessCookies.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/protocol/ResponseProcessCookies.java
@@ -108,19 +108,17 @@ public class ResponseProcessCookies implements HttpResponseInterceptor {
                         cookieStore.addCookie(cookie);
 
                         if (this.log.isDebugEnabled()) {
-                            this.log.debug("Cookie accepted [" + formatCooke(cookie) + "]");
+                            this.log.debug("Cookie accepted [{}]", formatCooke(cookie));
                         }
                     } catch (final MalformedCookieException ex) {
                         if (this.log.isWarnEnabled()) {
-                            this.log.warn("Cookie rejected [" + formatCooke(cookie) + "] "
-                                    + ex.getMessage());
+                            this.log.warn("Cookie rejected [{}] {}", formatCooke(cookie), ex.getMessage());
                         }
                     }
                 }
             } catch (final MalformedCookieException ex) {
                 if (this.log.isWarnEnabled()) {
-                    this.log.warn("Invalid cookie header: \""
-                            + header + "\". " + ex.getMessage());
+                    this.log.warn("Invalid cookie header: \"{}\". {}", header, ex.getMessage());
                 }
             }
         }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/AbstractClientTlsStrategy.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/AbstractClientTlsStrategy.java
@@ -122,8 +122,8 @@ abstract class AbstractClientTlsStrategy implements TlsStrategy {
                 initializeEngine(sslEngine);
 
                 if (log.isDebugEnabled()) {
-                    log.debug("Enabled protocols: " + Arrays.asList(sslEngine.getEnabledProtocols()));
-                    log.debug("Enabled cipher suites:" + Arrays.asList(sslEngine.getEnabledCipherSuites()));
+                    log.debug("Enabled protocols: {}", Arrays.asList(sslEngine.getEnabledProtocols()));
+                    log.debug("Enabled cipher suites:{}", Arrays.asList(sslEngine.getEnabledCipherSuites()));
                 }
             }
 

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/SSLConnectionSocketFactory.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/SSLConnectionSocketFactory.java
@@ -211,7 +211,7 @@ public class SSLConnectionSocketFactory implements LayeredConnectionSocketFactor
                 sock.setSoTimeout(connectTimeout.toMillisecondsIntBound());
             }
             if (this.log.isDebugEnabled()) {
-                this.log.debug("Connecting socket to " + remoteAddress + " with timeout " + connectTimeout);
+                this.log.debug("Connecting socket to {} with timeout {}", remoteAddress, connectTimeout);
             }
             // Run this under a doPrivileged to support lib users that run under a SecurityManager this allows granting connect permissions
             // only to this library
@@ -267,8 +267,8 @@ public class SSLConnectionSocketFactory implements LayeredConnectionSocketFactor
         }
 
         if (this.log.isDebugEnabled()) {
-            this.log.debug("Enabled protocols: " + Arrays.asList(sslsock.getEnabledProtocols()));
-            this.log.debug("Enabled cipher suites:" + Arrays.asList(sslsock.getEnabledCipherSuites()));
+            this.log.debug("Enabled protocols: {}", Arrays.asList(sslsock.getEnabledProtocols()));
+            this.log.debug("Enabled cipher suites:{}", Arrays.asList(sslsock.getEnabledCipherSuites()));
         }
 
         prepareSocket(sslsock);

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/TlsSessionValidator.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/TlsSessionValidator.java
@@ -67,7 +67,7 @@ final class TlsSessionValidator {
                     final X509Certificate x509 = (X509Certificate) cert;
                     final X500Principal peer = x509.getSubjectX500Principal();
 
-                    log.debug(" peer principal: {}", peer.toString());
+                    log.debug(" peer principal: {}", peer);
                     final Collection<List<?>> altNames1 = x509.getSubjectAlternativeNames();
                     if (altNames1 != null) {
                         final List<String> altNames = new ArrayList<>();
@@ -80,7 +80,7 @@ final class TlsSessionValidator {
                     }
 
                     final X500Principal issuer = x509.getIssuerX500Principal();
-                    log.debug(" issuer principal: {}", issuer.toString());
+                    log.debug(" issuer principal: {}", issuer);
                     final Collection<List<?>> altNames2 = x509.getIssuerAlternativeNames();
                     if (altNames2 != null) {
                         final List<String> altNames = new ArrayList<>();

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/TlsSessionValidator.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/TlsSessionValidator.java
@@ -56,8 +56,8 @@ final class TlsSessionValidator {
 
         if (log.isDebugEnabled()) {
             log.debug("Secure session established");
-            log.debug(" negotiated protocol: " + sslsession.getProtocol());
-            log.debug(" negotiated cipher suite: " + sslsession.getCipherSuite());
+            log.debug(" negotiated protocol: {}", sslsession.getProtocol());
+            log.debug(" negotiated cipher suite: {}", sslsession.getCipherSuite());
 
             try {
 
@@ -67,7 +67,7 @@ final class TlsSessionValidator {
                     final X509Certificate x509 = (X509Certificate) cert;
                     final X500Principal peer = x509.getSubjectX500Principal();
 
-                    log.debug(" peer principal: " + peer.toString());
+                    log.debug(" peer principal: {}", peer.toString());
                     final Collection<List<?>> altNames1 = x509.getSubjectAlternativeNames();
                     if (altNames1 != null) {
                         final List<String> altNames = new ArrayList<>();
@@ -76,11 +76,11 @@ final class TlsSessionValidator {
                                 altNames.add((String) aC.get(1));
                             }
                         }
-                        log.debug(" peer alternative names: " + altNames);
+                        log.debug(" peer alternative names: {}", altNames);
                     }
 
                     final X500Principal issuer = x509.getIssuerX500Principal();
-                    log.debug(" issuer principal: " + issuer.toString());
+                    log.debug(" issuer principal: {}", issuer.toString());
                     final Collection<List<?>> altNames2 = x509.getIssuerAlternativeNames();
                     if (altNames2 != null) {
                         final List<String> altNames = new ArrayList<>();
@@ -89,7 +89,7 @@ final class TlsSessionValidator {
                                 altNames.add((String) aC.get(1));
                             }
                         }
-                        log.debug(" issuer alternative names: " + altNames);
+                        log.debug(" issuer alternative names: {}", altNames);
                     }
                 }
             } catch (final Exception ignore) {

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClientFormLogin.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClientFormLogin.java
@@ -64,7 +64,7 @@ public class ClientFormLogin {
                     System.out.println("None");
                 } else {
                     for (int i = 0; i < cookies.size(); i++) {
-                        System.out.println("- " + cookies.get(i).toString());
+                        System.out.println("- " + cookies.get(i));
                     }
                 }
             }
@@ -86,7 +86,7 @@ public class ClientFormLogin {
                     System.out.println("None");
                 } else {
                     for (int i = 0; i < cookies.size(); i++) {
-                        System.out.println("- " + cookies.get(i).toString());
+                        System.out.println("- " + cookies.get(i));
                     }
                 }
             }

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/examples/ReactiveClientFullDuplexExchange.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/examples/ReactiveClientFullDuplexExchange.java
@@ -87,7 +87,7 @@ public class ReactiveClientFullDuplexExchange {
 
         System.out.println(streamingResponse.getHead());
         for (final Header header : streamingResponse.getHead().getHeaders()) {
-            System.out.println(header.toString());
+            System.out.println(header);
         }
         System.out.println();
 
@@ -104,7 +104,7 @@ public class ReactiveClientFullDuplexExchange {
             .forEach(new Consumer<Notification<String>>() {
                 @Override
                 public void accept(final Notification<String> byteBufferNotification) throws Exception {
-                    System.out.println(byteBufferNotification.toString());
+                    System.out.println(byteBufferNotification);
                 }
             });
 

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/routing/TestRouteTracker.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/routing/TestRouteTracker.java
@@ -592,7 +592,7 @@ public class TestRouteTracker {
     public final static boolean checkVia(final RouteTracker rt, final HttpRoute r,
                                          final HttpRouteDirector rd, final int steps) {
 
-        final String msg = r.toString() + " @ " + rt.toString();
+        final String msg = r + " @ " + rt;
 
         boolean complete = false;
         int n = steps;


### PR DESCRIPTION
Methodology:
I used the intellij idea ultimate edition inspection "non-constant
string concatenation as argument to logging call" to find and
auto-fix occurrences of this pattern.

The first commit is entirely built from automation.
The second commit, https://github.com/apache/httpcomponents-client/commit/47ac659b944796607a2b586d2148acc74c45e117, is a manual fix for an issue I noticed while reviewing the diff.