### PR TITLE
Optimize MultipartEntityBuilder#generateBoundary

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/entity/mime/MultipartEntityBuilder.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/entity/mime/MultipartEntityBuilder.java
@@ -29,6 +29,7 @@ package org.apache.hc.client5.http.entity.mime;
 
 import java.io.File;
 import java.io.InputStream;
+import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -174,12 +175,13 @@ public class MultipartEntityBuilder {
     }
 
     private String generateBoundary() {
-        final StringBuilder buffer = new StringBuilder();
         final Random rand = ThreadLocalRandom.current();
         final int count = rand.nextInt(11) + 30; // a random size from 30 to 40
-        for (int i = 0; i < count; i++) {
+        final CharBuffer buffer = CharBuffer.allocate(count);
+        while (buffer.hasRemaining()) {
             buffer.append(MULTIPART_CHARS[rand.nextInt(MULTIPART_CHARS.length)]);
         }
+        buffer.flip();
         return buffer.toString();
     }
 

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/entity/mime/MultipartEntityBuilder.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/entity/mime/MultipartEntityBuilder.java
@@ -35,7 +35,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 
 import org.apache.hc.core5.http.ContentType;
@@ -175,8 +174,8 @@ public class MultipartEntityBuilder {
     }
 
     private String generateBoundary() {
-        final Random rand = ThreadLocalRandom.current();
-        final int count = rand.nextInt(11) + 30; // a random size from 30 to 40
+        final ThreadLocalRandom rand = ThreadLocalRandom.current();
+        final int count = rand.nextInt(30, 41); // a random size from 30 to 40
         final CharBuffer buffer = CharBuffer.allocate(count);
         while (buffer.hasRemaining()) {
             buffer.append(MULTIPART_CHARS[rand.nextInt(MULTIPART_CHARS.length)]);

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/entity/mime/MultipartEntityBuilder.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/entity/mime/MultipartEntityBuilder.java
@@ -178,7 +178,7 @@ public class MultipartEntityBuilder {
         final int count = rand.nextInt(30, 41); // a random size from 30 to 40
         final CharBuffer buffer = CharBuffer.allocate(count);
         while (buffer.hasRemaining()) {
-            buffer.append(MULTIPART_CHARS[rand.nextInt(MULTIPART_CHARS.length)]);
+            buffer.put(MULTIPART_CHARS[rand.nextInt(MULTIPART_CHARS.length)]);
         }
         buffer.flip();
         return buffer.toString();

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/entity/mime/MultipartEntityBuilder.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/entity/mime/MultipartEntityBuilder.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpEntity;
@@ -174,7 +175,7 @@ public class MultipartEntityBuilder {
 
     private String generateBoundary() {
         final StringBuilder buffer = new StringBuilder();
-        final Random rand = new Random();
+        final Random rand = ThreadLocalRandom.current();
         final int count = rand.nextInt(11) + 30; // a random size from 30 to 40
         for (int i = 0; i < count; i++) {
             buffer.append(MULTIPART_CHARS[rand.nextInt(MULTIPART_CHARS.length)]);


### PR DESCRIPTION
I've changed generateBoundary to use `ThreadLocalRandom` instead of creating a new `Random` every time, and I've replaced the `StringBuilder` with the faster `CharBuffer`.