### PR TITLE
Add Automatic-Module-Name in manifest so Java9 modular applications c…

### DIFF
--- a/httpclient5-cache/pom.xml
+++ b/httpclient5-cache/pom.xml
@@ -37,6 +37,10 @@
   <url>http://hc.apache.org/httpcomponents-client</url>
   <packaging>jar</packaging>
 
+  <properties>
+    <Automatic-Module-Name>org.apache.httpcomponents.client5.httpclient5.cache</Automatic-Module-Name>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.httpcomponents.client5</groupId>

--- a/httpclient5-fluent/pom.xml
+++ b/httpclient5-fluent/pom.xml
@@ -37,6 +37,10 @@
   <url>http://hc.apache.org/httpcomponents-client</url>
   <packaging>jar</packaging>
 
+  <properties>
+    <Automatic-Module-Name>org.apache.httpcomponents.client5.httpclient5.fluent</Automatic-Module-Name>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.httpcomponents.client5</groupId>

--- a/httpclient5-testing/pom.xml
+++ b/httpclient5-testing/pom.xml
@@ -36,6 +36,10 @@
   <url>http://hc.apache.org/httpcomponents-client</url>
   <packaging>jar</packaging>
 
+  <properties>
+    <Automatic-Module-Name>org.apache.httpcomponents.client5.httpclient5.testing</Automatic-Module-Name>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.httpcomponents.core5</groupId>

--- a/httpclient5-win/pom.xml
+++ b/httpclient5-win/pom.xml
@@ -36,6 +36,10 @@
   <url>http://hc.apache.org/httpcomponents-client</url>
   <packaging>jar</packaging>
 
+  <properties>
+    <Automatic-Module-Name>org.apache.httpcomponents.client5.httpclient5.win</Automatic-Module-Name>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.httpcomponents.client5</groupId>

--- a/httpclient5/pom.xml
+++ b/httpclient5/pom.xml
@@ -36,6 +36,10 @@
   <url>http://hc.apache.org/httpcomponents-client</url>
   <packaging>jar</packaging>
 
+  <properties>
+    <Automatic-Module-Name>org.apache.httpcomponents.client5.httpclient5</Automatic-Module-Name>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.httpcomponents.core5</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,7 @@
               <Implementation-Version>${project.version}</Implementation-Version>
               <Implementation-Vendor>The Apache Software Foundation</Implementation-Vendor>
               <Implementation-Vendor-Id>org.apache</Implementation-Vendor-Id>
+              <Automatic-Module-Name>${Automatic-Module-Name}</Automatic-Module-Name>
               <url>${project.url}</url>
             </manifestEntries>
           </archive>


### PR DESCRIPTION
…an depend on this library.

This is essentially a duplication of https://github.com/apache/httpcomponents-client/pull/104 but now for the 5.x versions.
As indicated here https://github.com/apache/httpcomponents-client/pull/104#issuecomment-403436258 I have made sure the module names to not contain a hyphen ('-').

Looking at what was done for the 4.x version I have chosen to stick as close as possible to essentially `groupdId.artifactId` as possible. 
Please indicate if this is the right choice or if you want something different. 
I see this as a very important choice to get right at this point as it is something I expect will be hard to change in the future.

I added this to ALL maven artifacts (also the -testing), please asses if this is correct.

Please commit this into both master and the 5.1.x branch if you agree with these changes.