### PR TITLE
PoolingAsyncClientConnectionManager handles null ping callback values

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java
@@ -252,7 +252,7 @@ public class PoolingAsyncClientConnectionManager implements AsyncClientConnectio
 
                                     @Override
                                     public void execute(final Boolean result) {
-                                        if (result == Boolean.FALSE) {
+                                        if (!result) {
                                             if (log.isDebugEnabled()) {
                                                 log.debug("{}: connection {} is stale", id, ConnPoolSupport.getId(connection));
                                             }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java
@@ -252,7 +252,7 @@ public class PoolingAsyncClientConnectionManager implements AsyncClientConnectio
 
                                     @Override
                                     public void execute(final Boolean result) {
-                                        if (!result) {
+                                        if (result == null || !result) {
                                             if (log.isDebugEnabled()) {
                                                 log.debug("{}: connection {} is stale", id, ConnPoolSupport.getId(connection));
                                             }


### PR DESCRIPTION
This change brings back handling for null values that was lost
in the fix for HTTPCLIENT-2097.
Note that unlike the previous implementation, a null value
results in the connection being discarded and closed as opposed to
being added to the pool in an unknown state.