### PR TITLE
HTTPCLIENT-2099: SSLConnectionSocketFactory timeout fix

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/SSLConnectionSocketFactory.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/SSLConnectionSocketFactory.java
@@ -207,9 +207,6 @@ public class SSLConnectionSocketFactory implements LayeredConnectionSocketFactor
             sock.bind(localAddress);
         }
         try {
-            if (TimeValue.isPositive(connectTimeout) && sock.getSoTimeout() == 0) {
-                sock.setSoTimeout(connectTimeout.toMillisecondsIntBound());
-            }
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Connecting socket to {} with timeout {}", remoteAddress, connectTimeout);
             }


### PR DESCRIPTION
SSLConnectionSocketFactory no longer overrides the socket timeout
with the connect timeout when an unlimited socket timeout is
configured. This matches behavior of HTTPCLIENT-2091.

Note that in scenarios where SocketConfig sets an infinite timeout
and the RequestConfig sets a bounded timeout, this change results
in the connect-timeout no longer applying to the TLS handshake.
This behavior can be retained by setting the expected timeout in
the SocketConfig.