### PR TITLE
Update versions to `5.1-alpha1-SNAPSHOT` matching httpcore 5.1.x

### DIFF
--- a/httpclient5-cache/pom.xml
+++ b/httpclient5-cache/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache.httpcomponents.client5</groupId>
     <artifactId>httpclient5-parent</artifactId>
-    <version>5.0.2-SNAPSHOT</version>
+    <version>5.1-alpha1-SNAPSHOT</version>
   </parent>
   <artifactId>httpclient5-cache</artifactId>
   <name>Apache HttpClient Cache</name>

--- a/httpclient5-fluent/pom.xml
+++ b/httpclient5-fluent/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache.httpcomponents.client5</groupId>
     <artifactId>httpclient5-parent</artifactId>
-    <version>5.0.2-SNAPSHOT</version>
+    <version>5.1-alpha1-SNAPSHOT</version>
   </parent>
   <artifactId>httpclient5-fluent</artifactId>
   <name>Apache HttpClient Fluent</name>

--- a/httpclient5-testing/pom.xml
+++ b/httpclient5-testing/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache.httpcomponents.client5</groupId>
     <artifactId>httpclient5-parent</artifactId>
-    <version>5.0.2-SNAPSHOT</version>
+    <version>5.1-alpha1-SNAPSHOT</version>
   </parent>
   <artifactId>httpclient5-testing</artifactId>
   <name>Apache HttpClient Integration Tests</name>

--- a/httpclient5-win/pom.xml
+++ b/httpclient5-win/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache.httpcomponents.client5</groupId>
     <artifactId>httpclient5-parent</artifactId>
-    <version>5.0.2-SNAPSHOT</version>
+    <version>5.1-alpha1-SNAPSHOT</version>
   </parent>
   <artifactId>httpclient5-win</artifactId>
   <name>Apache HttpClient Windows features</name>

--- a/httpclient5/pom.xml
+++ b/httpclient5/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache.httpcomponents.client5</groupId>
     <artifactId>httpclient5-parent</artifactId>
-    <version>5.0.2-SNAPSHOT</version>
+    <version>5.1-alpha1-SNAPSHOT</version>
   </parent>
   <artifactId>httpclient5</artifactId>
   <name>Apache HttpClient</name>

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/ProxyClient.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/ProxyClient.java
@@ -104,7 +104,12 @@ public class ProxyClient {
             final CharCodingConfig charCodingConfig,
             final RequestConfig requestConfig) {
         super();
-        this.connFactory = connFactory != null ? connFactory : new ManagedHttpClientConnectionFactory(h1Config, charCodingConfig, null, null);
+        this.connFactory = connFactory != null
+                ? connFactory
+                : ManagedHttpClientConnectionFactory.builder()
+                .http1Config(h1Config)
+                .charCodingConfig(charCodingConfig)
+                .build();
         this.requestConfig = requestConfig != null ? requestConfig : RequestConfig.DEFAULT;
         this.httpProcessor = new DefaultHttpProcessor(
                 new RequestTargetHost(), new RequestClientConnControl(), new RequestUserAgent());

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/ManagedHttpClientConnectionFactory.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/ManagedHttpClientConnectionFactory.java
@@ -139,4 +139,71 @@ public class ManagedHttpClientConnectionFactory implements HttpConnectionFactory
         return conn;
     }
 
+    /**
+     * Create a new {@link Builder}.
+     *
+     * @since 5.1
+     */
+    public static Builder builder()  {
+        return new Builder();
+    }
+
+    /**
+     * Builder for {@link ManagedHttpClientConnectionFactory}.
+     *
+     * @since 5.1
+     */
+    public static final class Builder {
+
+        private Http1Config http1Config;
+        private CharCodingConfig charCodingConfig;
+        private ContentLengthStrategy incomingContentLengthStrategy;
+        private ContentLengthStrategy outgoingContentLengthStrategy;
+        private HttpMessageWriterFactory<ClassicHttpRequest> requestWriterFactory;
+        private HttpMessageParserFactory<ClassicHttpResponse> responseParserFactory;
+
+        private Builder() {}
+
+        public Builder http1Config(final Http1Config http1Config) {
+            this.http1Config = http1Config;
+            return this;
+        }
+
+        public Builder charCodingConfig(final CharCodingConfig charCodingConfig) {
+            this.charCodingConfig = charCodingConfig;
+            return this;
+        }
+
+        public Builder incomingContentLengthStrategy(final ContentLengthStrategy incomingContentLengthStrategy) {
+            this.incomingContentLengthStrategy = incomingContentLengthStrategy;
+            return this;
+        }
+
+        public Builder outgoingContentLengthStrategy(final ContentLengthStrategy outgoingContentLengthStrategy) {
+            this.outgoingContentLengthStrategy = outgoingContentLengthStrategy;
+            return this;
+        }
+
+        public Builder requestWriterFactory(
+                final HttpMessageWriterFactory<ClassicHttpRequest> requestWriterFactory) {
+            this.requestWriterFactory = requestWriterFactory;
+            return this;
+        }
+
+        public Builder responseParserFactory(
+                final HttpMessageParserFactory<ClassicHttpResponse> responseParserFactory) {
+            this.responseParserFactory = responseParserFactory;
+            return this;
+        }
+
+        public ManagedHttpClientConnectionFactory build() {
+            return new ManagedHttpClientConnectionFactory(
+                    http1Config,
+                    charCodingConfig,
+                    requestWriterFactory,
+                    responseParserFactory,
+                    incomingContentLengthStrategy,
+                    outgoingContentLengthStrategy);
+        }
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   <groupId>org.apache.httpcomponents.client5</groupId>
   <artifactId>httpclient5-parent</artifactId>
   <name>Apache HttpComponents Client Parent</name>
-  <version>5.0.2-SNAPSHOT</version>
+  <version>5.1-alpha1-SNAPSHOT</version>
   <description>Apache HttpComponents Client is a library of components for building client side HTTP services</description>
   <url>http://hc.apache.org/httpcomponents-client-5.0.x/</url>
   <inceptionYear>1999</inceptionYear>
@@ -61,7 +61,7 @@
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/httpcomponents-client.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/httpcomponents-client.git</developerConnection>
     <url>https://github.com/apache/httpcomponents-client/tree/${project.scm.tag}</url>
-    <tag>5.0.2-SNAPSHOT</tag>
+    <tag>5.1.0-SNAPSHOT</tag>
   </scm>
 
   <properties>


### PR DESCRIPTION
This is a prerequisite to passing through the ResponseOutOfOrderStrategy for HTTPCLIENT-2104.

It looks like the update exposes some regressions in httpcore-5.1.x.