### PR TITLE
Use decimal numbers for endpoint/execution IDs

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/ExecSupport.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/ExecSupport.java
@@ -45,7 +45,7 @@ public final class ExecSupport {
     }
 
     public static String getNextExchangeId() {
-        return String.format("ex-%08X", COUNT.incrementAndGet());
+        return String.format("ex-%010d", COUNT.incrementAndGet());
     }
 
 }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java
@@ -527,7 +527,7 @@ public class PoolingHttpClientConnectionManager
         InternalConnectionEndpoint(
                 final PoolEntry<HttpRoute, ManagedHttpClientConnection> poolEntry) {
             this.poolEntryRef = new AtomicReference<>(poolEntry);
-            this.id = String.format("ep-%08X", COUNT.getAndIncrement());
+            this.id = String.format("ep-%010d", COUNT.getAndIncrement());
         }
 
         @Override

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java
@@ -492,7 +492,7 @@ public class PoolingAsyncClientConnectionManager implements AsyncClientConnectio
 
         InternalConnectionEndpoint(final PoolEntry<HttpRoute, ManagedAsyncClientConnection> poolEntry) {
             this.poolEntryRef = new AtomicReference<>(poolEntry);
-            this.id = String.format("ep-%08X", COUNT.getAndIncrement());
+            this.id = String.format("ep-%010d", COUNT.getAndIncrement());
         }
 
         @Override


### PR DESCRIPTION
As discussed some time ago on the dev mailing list.