### PR TITLE
handle the request's path error when using system proxy

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/entity/mime/AbstractMultipartFormat.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/entity/mime/AbstractMultipartFormat.java
@@ -50,7 +50,7 @@ abstract class AbstractMultipartFormat {
             final Charset charset, final String string) {
         final ByteBuffer encoded = charset.encode(CharBuffer.wrap(string));
         final ByteArrayBuffer bab = new ByteArrayBuffer(encoded.remaining());
-        bab.append(encoded.array(), encoded.position(), encoded.remaining());
+        bab.append(encoded.array(), encoded.arrayOffset() + encoded.position(), encoded.remaining());
         return bab;
     }
 


### PR DESCRIPTION
system: macOS 10.15.6

problem: I take cookieStore to manage my cookies, if I config the system's network, set a proxy, the cookies in the cookieStore won't sent to the website

the reason is the code I changed, before my change, the request's path will change to the all url, actually, the path should be the url's last part expect the host, like 'https://google.com/', the path should be '/', but if there have system proxy, the path will changed to 'http://google.com/', this will make cookie match mistake, so, it won't sent the cookie to the website