### PR TITLE
PoolingAsyncClientConnectionManager incorrectly emits Ping commands to HTTP/1.1 endpoints 

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java
@@ -247,7 +247,7 @@ public class PoolingAsyncClientConnectionManager implements AsyncClientConnectio
                         if (TimeValue.isNonNegative(timeValue) && connection != null &&
                                 poolEntry.getUpdated() + timeValue.toMilliseconds() <= System.currentTimeMillis()) {
                             final ProtocolVersion protocolVersion = connection.getProtocolVersion();
-                            if (HttpVersion.HTTP_2_0.greaterEquals(protocolVersion)) {
+                            if (protocolVersion != null && protocolVersion.greaterEquals(HttpVersion.HTTP_2_0)) {
                                 connection.submitCommand(new PingCommand(new BasicPingHandler(new Callback<Boolean>() {
 
                                     @Override


### PR DESCRIPTION
i have a problem here.

it doesn't support PingCommand When I use HTTP 1.1 protocol.  because AbstractHttp1StreamDuplexer.class doesn't support PingCommand.
