### PR TITLE
4.5.x - Prevent sending Authorization header to other than the original host

### DIFF
--- a/httpclient/src/main/java-deprecated/org/apache/http/impl/client/DefaultRequestDirector.java
+++ b/httpclient/src/main/java-deprecated/org/apache/http/impl/client/DefaultRequestDirector.java
@@ -1094,6 +1094,9 @@ public class DefaultRequestDirector implements RequestDirector {
                     this.log.debug("Resetting proxy auth state");
                     proxyAuthState.reset();
                 }
+
+                // Prevent sending Authorization header to other than the original host
+                redirect.removeHeaders("Authorization");
             }
 
             final RequestWrapper wrapper = wrapRequest(redirect);


### PR DESCRIPTION
It's an easy fix and really important (from my perspective) - mainly for security reasons.