### PR TITLE
Prevent sending Authorization header to other than the original host

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/RedirectExec.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/RedirectExec.java
@@ -187,6 +187,10 @@ public final class RedirectExec implements ExecChainHandler {
                                     proxyAuthExchange.reset();
                                 }
                             }
+                            if (LOG.isDebugEnabled()) {
+                                LOG.debug("{}: removing Authorization header", exchangeId);
+                            }
+                            redirect.removeHeaders("Authorization");
                             currentScope = new ExecChain.Scope(
                                     currentScope.exchangeId,
                                     newRoute,


### PR DESCRIPTION
It's an easy fix and really important (from my perspective) - mainly for security reasons.