### PR TITLE
[4.5.x] Upgrade commons-codec to 1.15 due to vulnerability to Information Exposure

### DIFF
--- a/httpclient-osgi/pom.xml
+++ b/httpclient-osgi/pom.xml
@@ -59,7 +59,6 @@
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-      <version>${commons-codec.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <maven.compiler.target>1.6</maven.compiler.target>
     <httpcore.version>4.4.13</httpcore.version>
     <commons-logging.version>1.2</commons-logging.version>
-    <commons-codec.version>1.11</commons-codec.version>
+    <commons-codec.version>1.15</commons-codec.version>
     <ehcache.version>2.6.11</ehcache.version>
     <memcached.version>2.12.3</memcached.version>
     <slf4j.version>1.7.25</slf4j.version>


### PR DESCRIPTION
Fixed information exposure "Base32 would decode some invalid Base32 encoded string into arbitrary value" https://issues.apache.org/jira/browse/CODEC-134

This issue has been fixed in commons-codec 1.13, upgrading to the newest 1.15.
Version 5.0.x already have commons-codec 1.15

commons-codec versions [,1.13) are vulnerable to Information Exposure. When there is no byte array value that can be encoded into a string the Base32 implementation does not reject it, and instead decodes it into an arbitrary value which can be re-encoded again using the same implementation. This allows for information exposure exploits such as tunneling additional information via seemingly valid base 32 strings.