### PR TITLE
Fixed and suppressed several findings from LGTM.com

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/entity/mime/HttpRFC7578Multipart.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/entity/mime/HttpRFC7578Multipart.java
@@ -137,13 +137,12 @@ class HttpRFC7578Multipart extends AbstractMultipartFormat {
             for (int i = 0; i < bytes.length; i++) {
                 final int b = bytes[i];
                 if (b == ESCAPE_CHAR) {
-                    try {
-                        final int u = digit16(bytes[++i]);
-                        final int l = digit16(bytes[++i]);
-                        buffer.append((char) ((u << 4) + l));
-                    } catch (final ArrayIndexOutOfBoundsException e) {
-                        throw new DecoderException("Invalid URL encoding: ", e);
+                    if (i >= bytes.length - 2) {
+                        throw new DecoderException("Invalid URL encoding: too short");
                     }
+                    final int u = digit16(bytes[++i]);
+                    final int l = digit16(bytes[++i]);
+                    buffer.append((char) ((u << 4) + l));
                 } else {
                     buffer.append(b);
                 }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/BasicHttpClientConnectionManager.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/BasicHttpClientConnectionManager.java
@@ -275,7 +275,9 @@ public class BasicHttpClientConnectionManager implements HttpClientConnectionMan
                 }
             } else {
                 this.state = state;
-                conn.passivate();
+                if (conn != null) {
+                    conn.passivate();
+                }
                 if (TimeValue.isPositive(keepAlive)) {
                     if (LOG.isDebugEnabled()) {
                         LOG.debug("Connection can be kept alive for {}", keepAlive);

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/entity/mime/HttpRFC7578MultipartTest.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/entity/mime/HttpRFC7578MultipartTest.java
@@ -1,0 +1,60 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.hc.client5.http.entity.mime;
+
+import org.apache.commons.codec.DecoderException;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class HttpRFC7578MultipartTest {
+
+    @Test(expected = DecoderException.class)
+    public void testPercentDecodingWithTooShortMessage() throws DecoderException {
+        new HttpRFC7578Multipart.PercentCodec().decode("%".getBytes());
+    }
+
+    @Test
+    public void testPercentDecodingWithValidMessages() throws DecoderException {
+        final HttpRFC7578Multipart.PercentCodec codec = new HttpRFC7578Multipart.PercentCodec();
+        final String[][] tests = new String[][] {
+                {"test", "test"},
+                {"%20", " "},
+                {"a%20b", "a b"},
+                {"https%3A%2F%2Fhc.apache.org%2Fhttpcomponents-client-5.0.x%2Findex.html",
+                        "https://hc.apache.org/httpcomponents-client-5.0.x/index.html"},
+                {"%00", "\00"},
+                {"%0A", "\n"},
+
+        };
+        for (final String[] test : tests) {
+            assertEquals(test[1], new String(codec.decode(test[0].getBytes())));
+        }
+    }
+
+}


### PR DESCRIPTION
LGTM.com offers static analysis for open-source projects. It's based on CodeQL engine. The current report for Apache HttpClient is pretty good. There are only 19 findings. I had a look at them, and didn't find anything severe. Nevertheless, I'd like to propose fixing some minor findings and suppressing the rest. Suppressing the warnings would make it simpler to triage new issues in the future.

Here is a list of updates:

- Fixed a few possible null dereferences
- Fixed a few possible out-of-bound array ops
- Suppressed warnings for weak cryptographic algorithms for NTLM and Digest authentication schemes
- Suppressed a few false-positives for null dereference
- Suppressed a few warnings for overriding a synchronized method without synchronization
- Added a couple of test cases