### PR TITLE
Added a security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+# Reporting a vulnerability
+
+If you believe you found a vulnerability in Apache HttpClient,
+please contact [the Apache Security Team](https://www.apache.org/security/).


### PR DESCRIPTION
The process of reporting security issues should be documented and easy to find.

I'd like to propose adding a security policy to the project that would be integrated with other GitHub features

https://docs.github.com/en/free-pro-team@latest/github/managing-security-vulnerabilities/adding-a-security-policy-to-your-repository

Although the project's page has the "Security" tab, I think `SECURITY.md` would make it a bit easier to find the docs that describe how security issues should be reported. Also, when someone creates an issue in the repository, they will see a link to the security policy.

The proposed `SECURITY.md` file just contains a link to https://www.apache.org/security/ but we can put more info if necessary.

I had a look at several Apache projects and looks like there is a common template for `SECURITY.md`. For example:

- https://github.com/apache/nifi/blob/main/SECURITY.md
- https://github.com/apache/logging-log4j2/blob/master/SECURITY.md
- https://github.com/apache/commons-text/blob/master/SECURITY.md