### PR TITLE
Build and test on both AMD64 and ARM64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ language: java
 dist: trusty
 sudo: false
 
+arch:
+  - amd64
+  - arm64-graviton2
+
 jdk:
   - oraclejdk8
   - openjdk12


### PR DESCRIPTION
More and more software development is being done on ARM64 CPU architecture.
It would be good if HttpComponents Client is being regularly tested on ARM64.

Similar PR for HttpComponents Core: https://github.com/apache/httpcomponents-core/pull/228