### PR TITLE
Enable nohttp check during the build

### DIFF
--- a/nohttp-checkstyle.xml
+++ b/nohttp-checkstyle.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   ====================================================================
+   Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+   ====================================================================
+
+   This software consists of voluntary contributions made by many
+   individuals on behalf of the Apache Software Foundation.  For more
+   information on the Apache Software Foundation, please see
+   <http://www.apache.org />.
+ -->
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN" "https://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+<module name="Checker">
+  <property name="charset" value="UTF-8"/>
+  <property name="fileExtensions" value=""/>
+  <module name="io.spring.nohttp.checkstyle.check.NoHttpCheck"/>
+</module>

--- a/nohttp-suppressions.xml
+++ b/nohttp-suppressions.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   ====================================================================
+   Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+   ====================================================================
+
+   This software consists of voluntary contributions made by many
+   individuals on behalf of the Apache Software Foundation.  For more
+   information on the Apache Software Foundation, please see
+   <http://www.apache.org />.
+ -->
+<!DOCTYPE suppressions PUBLIC "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN" "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+<suppressions>
+  <suppress message="http://app.mydomain.fr" checks="NoHttp"/>
+  <suppress message="http://bugs.sun.com" checks="NoHttp"/>
+  <suppress message="http://code.google.com/p/memcached/wiki/NewStart" checks="NoHttp"/>
+  <suppress message="http://code.google.com/p/spymemcached/" checks="NoHttp"/>
+  <suppress message="http://davenport.sourceforge.net/ntlm.html" checks="NoHttp"/>
+  <suppress message="http://docs.oracle.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html" checks="NoHttp"/>
+  <suppress message="http://dustin.github.com/java-memcached-client/apidocs/net/spy/memcached/KetamaConnectionFactory.html" checks="NoHttp"/>
+  <suppress message="http://ehcache.org" checks="NoHttp"/>
+  <suppress message="http://ehcache.org/documentation/index.html" checks="NoHttp"/>
+  <suppress message="http://en.wikipedia.org/wiki/SHA-2" checks="NoHttp"/>
+  <suppress message="http://example.com/" checks="NoHttp"/>
+  <suppress message="http://hc.apache.org/" checks="NoHttp"/>
+  <suppress message="http://hc.apache.org/httpcomponents-client/" checks="NoHttp"/>
+  <suppress message="http://hc.apache.org/httpcomponents-client-ga/" checks="NoHttp"/>
+  <suppress message="http://hc.apache.org/httpcomponents-core-ga/" checks="NoHttp"/>
+  <suppress message="http://hc.apache.org/status.html" checks="NoHttp"/>
+  <suppress message="http://httpbin.org/basic-auth/user/passwd" checks="NoHttp"/>
+  <suppress message="http://httpbin.org/cookies" checks="NoHttp"/>
+  <suppress message="http://httpbin.org/digest-auth/auth/user/passwd" checks="NoHttp"/>
+  <suppress message="http://httpbin.org/get" checks="NoHttp"/>
+  <suppress message="http://httpbin.org/hidden-basic-auth/user/passwd" checks="NoHttp"/>
+  <suppress message="http://httpbin.org/post" checks="NoHttp"/>
+  <suppress message="http://httpcomponents.apache.org" checks="NoHttp"/>
+  <suppress message="http://httpcomponents.apache.org/downloads.cgi" checks="NoHttp"/>
+  <suppress message="http://httpcomponents.apache.org/mail-lists.html" checks="NoHttp"/>
+  <suppress message="http://httpd.apache.org/docs/2.4/" checks="NoHttp"/>
+  <suppress message="http://httpd.apache.org/docs/2.4/mod/core.html" checks="NoHttp"/>
+  <suppress message="http://httpd.apache.org/docs/2.4/mod/directives.html" checks="NoHttp"/>
+  <suppress message="http://httpd.apache.org/docs/2.4/mod/mod_ssl.html" checks="NoHttp"/>
+  <suppress message="http://issues.apache.org/jira/browse/HTTPCLIENT" checks="NoHttp"/>
+  <suppress message="http://jcifs.samba.org" checks="NoHttp"/>
+  <suppress message="http://maven.apache.org/maven-v4_0_0.xsd" checks="NoHttp"/>
+  <suppress message="http://maven.apache.org/run-maven/index.html" checks="NoHttp"/>
+  <suppress message="http://memcached.org/" checks="NoHttp"/>
+  <suppress message="http://mozilla.org/MPL/2.0/" checks="NoHttp"/>
+  <suppress message="http://msdn.microsoft.com/en-us/library/cc236650%28v=prot.20%29.aspx" checks="NoHttp"/>
+  <suppress message="http://msdn.microsoft.com/en-us/library/windows/desktop/aa375506" checks="NoHttp"/>
+  <suppress message="http://nghttp2.org/httpbin/post" checks="NoHttp"/>
+  <suppress message="http://projects.apache.org/category/http" checks="NoHttp"/>
+  <suppress message="http://projects.apache.org/category/library" checks="NoHttp"/>
+  <suppress message="http://projects.apache.org/category/network-client" checks="NoHttp"/>
+  <suppress message="http://projects.apache.org/ns/asfext" checks="NoHttp"/>
+  <suppress message="http://publicsuffix.org/" checks="NoHttp"/>
+  <suppress message="http://svn.apache.org/repos/asf/httpcomponents/site" checks="NoHttp"/>
+  <suppress message="http://tools.ietf.org/html/rfc1945" checks="NoHttp"/>
+  <suppress message="http://tools.ietf.org/html/rfc2817" checks="NoHttp"/>
+  <suppress message="http://tools.ietf.org/html/rfc2818" checks="NoHttp"/>
+  <suppress message="http://tools.ietf.org/html/rfc5861" checks="NoHttp"/>
+  <suppress message="http://tools.ietf.org/html/rfc6265" checks="NoHttp"/>
+  <suppress message="http://tools.ietf.org/html/rfc7230" checks="NoHttp"/>
+  <suppress message="http://tools.ietf.org/html/rfc7231" checks="NoHttp"/>
+  <suppress message="http://tools.ietf.org/html/rfc7235" checks="NoHttp"/>
+  <suppress message="http://tools.ietf.org/html/rfc7540" checks="NoHttp"/>
+  <suppress message="http://tools.ietf.org/html/rfc7541" checks="NoHttp"/>
+  <suppress message="http://usefulinc.com/doap/licenses/asl20" checks="NoHttp"/>
+  <suppress message="http://usefulinc.com/ns/doap" checks="NoHttp"/>
+  <suppress message="http://www.apache.org" checks="NoHttp"/>
+  <suppress message="http://www.apache.org/licenses/" checks="NoHttp"/>
+  <suppress message="http://www.apache.org/licenses/LICENSE-2.0" checks="NoHttp"/>
+  <suppress message="http://www.apple.com/" checks="NoHttp"/>
+  <suppress message="http://www.chromium.org/developers/design-documents/http-authentication" checks="NoHttp"/>
+  <suppress message="http://www.comcast.net:80/" checks="NoHttp"/>
+  <suppress message="http://www.comcast.net:8080/" checks="NoHttp"/>
+  <suppress message="http://www.comcast.net:80/?foo=bar" checks="NoHttp"/>
+  <suppress message="http://www.cs.umd.edu/~harry/jotp/src/md.java" checks="NoHttp"/>
+  <suppress message="http://www.domain.dom/ca-crl.pem" checks="NoHttp"/>
+  <suppress message="http://www.fancast.com:80/full_episodes" checks="NoHttp"/>
+  <suppress message="http://www.fancast.com:80/full_episodes?foo=bar" checks="NoHttp"/>
+  <suppress message="http://www.fancast.com:9999/full_episodes" checks="NoHttp"/>
+  <suppress message="http://www.google.com/" checks="NoHttp"/>
+  <suppress message="http://www.ietf.org/rfc/rfc2145.txt" checks="NoHttp"/>
+  <suppress message="http://www.ietf.org/rfc/rfc4492.txt" checks="NoHttp"/>
+  <suppress message="http://www.reactive-streams.org/" checks="NoHttp"/>
+  <suppress message="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html" checks="NoHttp"/>
+  <suppress message="http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html" checks="NoHttp"/>
+  <suppress message="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html" checks="NoHttp"/>
+  <suppress message="http://www.w3.org/Protocols/rfc2616/rfc2616-sec1.html" checks="NoHttp"/>
+  <suppress message="http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html" checks="NoHttp"/>
+  <suppress message="http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html" checks="NoHttp"/>
+  <suppress message="http://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html" checks="NoHttp"/>
+  <suppress message="http://www.w3.org/Protocols/rfc2616/rfc2616-sec7.html" checks="NoHttp"/>
+  <suppress message="http://www.w3.org/Protocols/rfc2616/rfc2616-sec8.html" checks="NoHttp"/>
+  <suppress message="http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html" checks="NoHttp"/>
+  <suppress message="http://www.wassenaar.org/" checks="NoHttp"/>
+  <suppress message="http://www.yahoo.com/" checks="NoHttp"/>
+  <suppress message="http://xmlns.com/foaf/0.1/" checks="NoHttp"/>
+</suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,9 @@
     <hc.stylecheck.version>1</hc.stylecheck.version>
     <rxjava.version>2.2.7</rxjava.version>
     <api.comparison.version>5.0</api.comparison.version>
+    <checkstyle.plugin.version>3.1.1</checkstyle.plugin.version>
+    <checkstyle.version>8.33</checkstyle.version>
+    <nohttp.version>0.0.5.RELEASE</nohttp.version>
   </properties>
 
   <dependencyManagement>
@@ -224,6 +227,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>${checkstyle.plugin.version}</version>
         <executions>
           <execution>
             <id>validate-main</id>
@@ -259,7 +263,35 @@
               <goal>checkstyle</goal>
             </goals>
           </execution>
+          <execution>
+            <id>validate-nohttp</id>
+            <phase>validate</phase>
+            <configuration>
+              <configLocation>nohttp-checkstyle.xml</configLocation>
+              <suppressionsLocation>nohttp-suppressions.xml</suppressionsLocation>
+              <encoding>UTF-8</encoding>
+              <sourceDirectories>${basedir}</sourceDirectories>
+              <includes>**/*</includes>
+              <excludes>nohttp-suppressions.xml,**/.git/**/*,**/.idea/**/*,**/target/**/,**/.flattened-pom.xml,**/*.class</excludes>
+            </configuration>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <inherited>false</inherited>
+          </execution>
         </executions>
+        <dependencies>
+          <dependency>
+            <groupId>com.puppycrawl.tools</groupId>
+            <artifactId>checkstyle</artifactId>
+            <version>${checkstyle.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>io.spring.nohttp</groupId>
+            <artifactId>nohttp-checkstyle</artifactId>
+            <version>${nohttp.version}</version>
+          </dependency>
+        </dependencies>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
HTTP is a plaintext protocol which means that someone may be able to eavesdrop the data. To prevent this, HTTPS should be used whenever possible. 

An HTTP link in a README or a comment in code may not be harmful. Sometimes it may lead to a bit more serious issues. See for example https://medium.com/bugbountywriteup/want-to-take-over-the-java-ecosystem-all-you-need-is-a-mitm-1fc329d898fb . Although Apache HttpClient doesn't seem to use HTTP URLs to repositories in its pom.xml files, `org.apache:apache:13` parent pom.xml file has at lease one

https://svn.apache.org/viewvc/maven/pom/tags/apache-13/pom.xml?view=markup#l56

Maintaining `https://` in all URLs may be difficult. The `nohttp` tool can help here. The tool scans all the files in a repository and reports where `http://` is used. This pull requests proposes the following:

- Added `nohttp` (via `checkstyle` plugin) into the build process.
- Suppressed findings as a baseline.

Without the suppression list, the tool reports ~1600 issues. Most of them are `http://www.apache.org/licenses/LICENSE-2.0` in the licence headers.

If you think it makes sense to use `nohttp` in the project, and if you think that some suppressed finding may be fixed, I can update the changeset accordingly (fixing all of them would result to a patch that touches ~1600 files).

Here are some info about the tool:
- https://github.com/spring-io/nohttp
- https://spring.io/blog/2019/06/10/announcing-nohttp

~~P.S. Who do you think I can contact about replacing `http://` link in https://svn.apache.org/viewvc/maven/pom/tags/apache-13/pom.xml?view=markup#l56 ?~~