### PR TITLE
Use 'arm64' instead of 'arm64-graviton2'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ language: java
 dist: trusty
 sudo: false
 
+arch:
+  - amd64
+  - arm64-graviton2
+
 jdk:
   - oraclejdk8
   - openjdk12

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,13 @@ sudo: false
 
 arch:
   - amd64
-  - arm64-graviton2
+  - arm64
 
+addons:
+  apt:
+    packages:
+      - maven
+      
 jdk:
   - oraclejdk8
   - openjdk12


### PR DESCRIPTION
The Graviton2 builder is available only on travis-ci.com. Apache uses travis-ci.org

Install Maven explicitly because it is not pre-installed on the ARM64 image for Trusty

Related-to: https://github.com/apache/httpcomponents-client/pull/265