### PR TITLE
4.5.x use array fill and more

### DIFF
--- a/httpclient-cache/src/main/java/org/apache/http/impl/client/cache/memcached/KeyHashingScheme.java
+++ b/httpclient-cache/src/main/java/org/apache/http/impl/client/cache/memcached/KeyHashingScheme.java
@@ -68,5 +68,5 @@ public interface KeyHashingScheme {
      *   as its key for looking up cache entries
      * @return a cache key suitable for use with memcached
      */
-    public String hash(String storageKey);
+    String hash(String storageKey);
 }

--- a/httpclient-cache/src/test/java/org/apache/http/impl/client/cache/TestProtocolRequirements.java
+++ b/httpclient-cache/src/test/java/org/apache/http/impl/client/cache/TestProtocolRequirements.java
@@ -29,6 +29,7 @@ package org.apache.http.impl.client.cache;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.SocketTimeoutException;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.Random;
 import java.util.regex.Matcher;
@@ -1584,9 +1585,7 @@ public class TestProtocolRequirements extends AbstractProtocolTest {
         resp1.setHeader("Cache-Control", "max-age=3600");
         resp1.setHeader("ETag", "\"etag1\"");
         final byte[] bytes1 = new byte[128];
-        for (int i = 0; i < bytes1.length; i++) {
-            bytes1[i] = (byte) 1;
-        }
+        Arrays.fill(bytes1, (byte) 1);
         resp1.setEntity(new ByteArrayEntity(bytes1));
 
         final HttpRequestWrapper req2 = HttpRequestWrapper.wrap(
@@ -1602,9 +1601,7 @@ public class TestProtocolRequirements extends AbstractProtocolTest {
         resp2.setHeader("ETag", "\"etag2\"");
         resp2.setHeader("Content-Range", "bytes 0-50/128");
         final byte[] bytes2 = new byte[51];
-        for (int i = 0; i < bytes2.length; i++) {
-            bytes2[i] = (byte) 2;
-        }
+        Arrays.fill(bytes2, (byte) 2);
         resp2.setEntity(new ByteArrayEntity(bytes2));
 
         final Date inTwoSeconds = new Date(now.getTime() + 2000L);
@@ -1615,9 +1612,7 @@ public class TestProtocolRequirements extends AbstractProtocolTest {
         resp3.setHeader("Cache-Control", "max-age=3600");
         resp3.setHeader("ETag", "\"etag2\"");
         final byte[] bytes3 = new byte[128];
-        for (int i = 0; i < bytes3.length; i++) {
-            bytes3[i] = (byte) 2;
-        }
+        Arrays.fill(bytes3, (byte) 2);
         resp3.setEntity(new ByteArrayEntity(bytes3));
 
         EasyMock.expect(
@@ -1678,9 +1673,7 @@ public class TestProtocolRequirements extends AbstractProtocolTest {
         resp1.setHeader("Cache-Control", "max-age=3600");
         resp1.setHeader("Last-Modified", DateUtils.formatDate(oneHourAgo));
         final byte[] bytes1 = new byte[128];
-        for (int i = 0; i < bytes1.length; i++) {
-            bytes1[i] = (byte) 1;
-        }
+        Arrays.fill(bytes1, (byte) 1);
         resp1.setEntity(new ByteArrayEntity(bytes1));
 
         final HttpRequestWrapper req2 = HttpRequestWrapper.wrap(
@@ -1696,9 +1689,7 @@ public class TestProtocolRequirements extends AbstractProtocolTest {
         resp2.setHeader("Last-Modified", DateUtils.formatDate(now));
         resp2.setHeader("Content-Range", "bytes 0-50/128");
         final byte[] bytes2 = new byte[51];
-        for (int i = 0; i < bytes2.length; i++) {
-            bytes2[i] = (byte) 2;
-        }
+        Arrays.fill(bytes2, (byte) 2);
         resp2.setEntity(new ByteArrayEntity(bytes2));
 
         final Date inTwoSeconds = new Date(now.getTime() + 2000L);
@@ -1709,9 +1700,7 @@ public class TestProtocolRequirements extends AbstractProtocolTest {
         resp3.setHeader("Cache-Control", "max-age=3600");
         resp3.setHeader("ETag", "\"etag2\"");
         final byte[] bytes3 = new byte[128];
-        for (int i = 0; i < bytes3.length; i++) {
-            bytes3[i] = (byte) 2;
-        }
+        Arrays.fill(bytes3, (byte) 2);
         resp3.setEntity(new ByteArrayEntity(bytes3));
 
         EasyMock.expect(

--- a/httpclient-osgi/src/main/java/org/apache/http/osgi/impl/OSGiHttpRoutePlanner.java
+++ b/httpclient-osgi/src/main/java/org/apache/http/osgi/impl/OSGiHttpRoutePlanner.java
@@ -95,7 +95,7 @@ final class OSGiHttpRoutePlanner extends DefaultRoutePlanner {
         return new HostNameMatcher(name);
     }
 
-    private static interface HostMatcher {
+    private interface HostMatcher {
 
         boolean matches(String host);
 

--- a/httpclient-osgi/src/main/java/org/apache/http/osgi/impl/PropertiesUtils.java
+++ b/httpclient-osgi/src/main/java/org/apache/http/osgi/impl/PropertiesUtils.java
@@ -111,7 +111,7 @@ final class PropertiesUtils {
         // do nothing
     }
 
-    private static interface PropertyConverter<T> {
+    private interface PropertyConverter<T> {
 
         T to(Object propValue);
 

--- a/httpclient-osgi/src/test/java/org/apache/http/osgi/impl/TestPropertiesUtils.java
+++ b/httpclient-osgi/src/test/java/org/apache/http/osgi/impl/TestPropertiesUtils.java
@@ -99,12 +99,12 @@ public final class TestPropertiesUtils {
 
     @Test
     public void toLong() {
-        assertConverted(123l, null, long.class, 123l);
-        assertConverted(123l, null, Long.class, 123l);
-        assertConverted(456l, "456", long.class, null);
-        assertConverted(456l, "456", Long.class, null);
-        assertConverted(789l, "not a long", long.class, 789l);
-        assertConverted(789l, "not a long", Long.class, 789l);
+        assertConverted(123L, null, long.class, 123L);
+        assertConverted(123L, null, Long.class, 123L);
+        assertConverted(456L, "456", long.class, null);
+        assertConverted(456L, "456", Long.class, null);
+        assertConverted(789L, "not a long", long.class, 789L);
+        assertConverted(789L, "not a long", Long.class, 789L);
     }
 
     @Test

--- a/httpclient-win/src/main/java/org/apache/http/impl/client/WinHttpClients.java
+++ b/httpclient-win/src/main/java/org/apache/http/impl/client/WinHttpClients.java
@@ -59,8 +59,8 @@ public class WinHttpClients {
         if (os != null && os.contains("windows")) {
             try {
                 return Sspi.MAX_TOKEN_SIZE > 0;
-            } catch (final Exception ignore) { // Likely ClassNotFound
-                return false;
+            } catch (final Exception ignore) {
+                // Likely ClassNotFound
             }
         }
         return false;

--- a/httpclient/src/main/java-deprecated/org/apache/http/client/protocol/ClientContext.java
+++ b/httpclient/src/main/java-deprecated/org/apache/http/client/protocol/ClientContext.java
@@ -44,77 +44,77 @@ public interface ClientContext {
      *
      * @since 4.3
      */
-    public static final String ROUTE   = "http.route";
+    String ROUTE   = "http.route";
 
     /**
      * Attribute name of a {@link org.apache.http.conn.scheme.Scheme}
      * object that represents the actual protocol scheme registry.
      */
-    public static final String SCHEME_REGISTRY   = "http.scheme-registry";
+    String SCHEME_REGISTRY   = "http.scheme-registry";
 
     /**
      * Attribute name of a {@link org.apache.http.config.Lookup} object that represents
      * the actual {@link org.apache.http.cookie.CookieSpecRegistry} registry.
      */
-    public static final String COOKIESPEC_REGISTRY   = "http.cookiespec-registry";
+    String COOKIESPEC_REGISTRY   = "http.cookiespec-registry";
 
     /**
      * Attribute name of a {@link org.apache.http.cookie.CookieSpec}
      * object that represents the actual cookie specification.
      */
-    public static final String COOKIE_SPEC           = "http.cookie-spec";
+    String COOKIE_SPEC           = "http.cookie-spec";
 
     /**
      * Attribute name of a {@link org.apache.http.cookie.CookieOrigin}
      * object that represents the actual details of the origin server.
      */
-    public static final String COOKIE_ORIGIN         = "http.cookie-origin";
+    String COOKIE_ORIGIN         = "http.cookie-origin";
 
     /**
      * Attribute name of a {@link org.apache.http.client.CookieStore}
      * object that represents the actual cookie store.
      */
-    public static final String COOKIE_STORE          = "http.cookie-store";
+    String COOKIE_STORE          = "http.cookie-store";
 
     /**
      * Attribute name of a {@link org.apache.http.client.CredentialsProvider}
      * object that represents the actual credentials provider.
      */
-    public static final String CREDS_PROVIDER        = "http.auth.credentials-provider";
+    String CREDS_PROVIDER        = "http.auth.credentials-provider";
 
     /**
      * Attribute name of a {@link org.apache.http.client.AuthCache} object
      * that represents the auth scheme cache.
      */
-    public static final String AUTH_CACHE            = "http.auth.auth-cache";
+    String AUTH_CACHE            = "http.auth.auth-cache";
 
     /**
      * Attribute name of a {@link org.apache.http.auth.AuthState}
      * object that represents the actual target authentication state.
      */
-    public static final String TARGET_AUTH_STATE     = "http.auth.target-scope";
+    String TARGET_AUTH_STATE     = "http.auth.target-scope";
 
     /**
      * Attribute name of a {@link org.apache.http.auth.AuthState}
      * object that represents the actual proxy authentication state.
      */
-    public static final String PROXY_AUTH_STATE      = "http.auth.proxy-scope";
+    String PROXY_AUTH_STATE      = "http.auth.proxy-scope";
 
-    public static final String AUTH_SCHEME_PREF      = "http.auth.scheme-pref";
+    String AUTH_SCHEME_PREF      = "http.auth.scheme-pref";
 
     /**
      * Attribute name of a {@link java.lang.Object} object that represents
      * the actual user identity such as user {@link java.security.Principal}.
      */
-    public static final String USER_TOKEN            = "http.user-token";
+    String USER_TOKEN            = "http.user-token";
 
     /**
      * Attribute name of a {@link org.apache.http.config.Lookup} object that represents
      * the actual {@link org.apache.http.auth.AuthSchemeRegistry} registry.
      */
-    public static final String AUTHSCHEME_REGISTRY   = "http.authscheme-registry";
+    String AUTHSCHEME_REGISTRY   = "http.authscheme-registry";
 
-    public static final String SOCKET_FACTORY_REGISTRY = "http.socket-factory-registry";
+    String SOCKET_FACTORY_REGISTRY = "http.socket-factory-registry";
 
     /**
      * Attribute name of a {@link org.apache.http.client.config.RequestConfig} object that
@@ -122,6 +122,6 @@ public interface ClientContext {
      *
      * @since 4.3
      */
-    public static final String REQUEST_CONFIG = "http.request-config";
+    String REQUEST_CONFIG = "http.request-config";
 
 }

--- a/httpclient/src/main/java-deprecated/org/apache/http/conn/MultihomePlainSocketFactory.java
+++ b/httpclient/src/main/java-deprecated/org/apache/http/conn/MultihomePlainSocketFactory.java
@@ -163,7 +163,7 @@ public final class MultihomePlainSocketFactory implements SocketFactory {
      * @throws IllegalArgumentException if the argument is invalid
      */
     @Override
-    public final boolean isSecure(final Socket sock)
+    public boolean isSecure(final Socket sock)
         throws IllegalArgumentException {
 
         Args.notNull(sock, "Socket");

--- a/httpclient/src/main/java-deprecated/org/apache/http/conn/ssl/SSLContextBuilder.java
+++ b/httpclient/src/main/java-deprecated/org/apache/http/conn/ssl/SSLContextBuilder.java
@@ -38,6 +38,7 @@ import java.security.SecureRandom;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -112,9 +113,7 @@ public class SSLContextBuilder {
                     }
                 }
             }
-            for (final TrustManager tm : tms) {
-                this.trustmanagers.add(tm);
-            }
+            Collections.addAll(this.trustmanagers, tms);
         }
         return this;
     }
@@ -151,9 +150,7 @@ public class SSLContextBuilder {
                     }
                 }
             }
-            for (final KeyManager km : kms) {
-                keymanagers.add(km);
-            }
+            Collections.addAll(keymanagers, kms);
         }
         return this;
     }

--- a/httpclient/src/main/java-deprecated/org/apache/http/impl/client/AbstractAuthenticationHandler.java
+++ b/httpclient/src/main/java-deprecated/org/apache/http/impl/client/AbstractAuthenticationHandler.java
@@ -68,12 +68,11 @@ public abstract class AbstractAuthenticationHandler implements AuthenticationHan
     private final Log log = LogFactory.getLog(getClass());
 
     private static final List<String> DEFAULT_SCHEME_PRIORITY =
-        Collections.unmodifiableList(Arrays.asList(new String[] {
+        Collections.unmodifiableList(Arrays.asList(
                 AuthPolicy.SPNEGO,
                 AuthPolicy.NTLM,
                 AuthPolicy.DIGEST,
-                AuthPolicy.BASIC
-    }));
+                AuthPolicy.BASIC));
 
     public AbstractAuthenticationHandler() {
         super();

--- a/httpclient/src/main/java-deprecated/org/apache/http/impl/client/CloseableHttpResponseProxy.java
+++ b/httpclient/src/main/java-deprecated/org/apache/http/impl/client/CloseableHttpResponseProxy.java
@@ -50,7 +50,7 @@ class CloseableHttpResponseProxy implements InvocationHandler {
     static {
         try {
             CONSTRUCTOR = Proxy.getProxyClass(CloseableHttpResponseProxy.class.getClassLoader(),
-                    new Class<?>[] { CloseableHttpResponse.class }).getConstructor(new Class[] { InvocationHandler.class });
+                    CloseableHttpResponse.class).getConstructor(InvocationHandler.class);
         } catch (final NoSuchMethodException ex) {
             throw new IllegalStateException(ex);
         }

--- a/httpclient/src/main/java/org/apache/http/auth/params/AuthPNames.java
+++ b/httpclient/src/main/java/org/apache/http/auth/params/AuthPNames.java
@@ -45,7 +45,7 @@ public interface AuthPNames {
      * <p>
      * This parameter expects a value of type {@link String}.
      */
-    public static final String CREDENTIAL_CHARSET = "http.auth.credential-charset";
+    String CREDENTIAL_CHARSET = "http.auth.credential-charset";
 
     /**
      * Defines the order of preference for supported
@@ -57,7 +57,7 @@ public interface AuthPNames {
      * a name of an authentication scheme as returned by
      * {@link org.apache.http.auth.AuthScheme#getSchemeName()}.
      */
-    public static final String TARGET_AUTH_PREF = "http.auth.target-scheme-pref";
+    String TARGET_AUTH_PREF = "http.auth.target-scheme-pref";
 
     /**
      * Defines the order of preference for supported
@@ -69,6 +69,6 @@ public interface AuthPNames {
      * a name of an authentication scheme as returned by
      * {@link org.apache.http.auth.AuthScheme#getSchemeName()}.
      */
-    public static final String PROXY_AUTH_PREF = "http.auth.proxy-scheme-pref";
+    String PROXY_AUTH_PREF = "http.auth.proxy-scheme-pref";
 
 }

--- a/httpclient/src/main/java/org/apache/http/client/BackoffManager.java
+++ b/httpclient/src/main/java/org/apache/http/client/BackoffManager.java
@@ -43,12 +43,12 @@ public interface BackoffManager {
      * using a connection should be interpreted as a
      * backoff signal.
      */
-    public void backOff(HttpRoute route);
+    void backOff(HttpRoute route);
 
     /**
      * Called when we have determined that the result of
      * using a connection has succeeded and that we may
      * probe for more connections.
      */
-    public void probe(HttpRoute route);
+    void probe(HttpRoute route);
 }

--- a/httpclient/src/main/java/org/apache/http/client/params/ClientPNames.java
+++ b/httpclient/src/main/java/org/apache/http/client/params/ClientPNames.java
@@ -36,7 +36,7 @@ package org.apache.http.client.params;
 @Deprecated
 public interface ClientPNames {
 
-    public static final String CONNECTION_MANAGER_FACTORY_CLASS_NAME = "http.connection-manager.factory-class-name";
+    String CONNECTION_MANAGER_FACTORY_CLASS_NAME = "http.connection-manager.factory-class-name";
 
     /**
      * Defines whether redirects should be handled automatically
@@ -44,7 +44,7 @@ public interface ClientPNames {
      * This parameter expects a value of type {@link Boolean}.
      * </p>
      */
-    public static final String HANDLE_REDIRECTS = "http.protocol.handle-redirects";
+    String HANDLE_REDIRECTS = "http.protocol.handle-redirects";
 
     /**
      * Defines whether relative redirects should be rejected. HTTP specification
@@ -53,7 +53,7 @@ public interface ClientPNames {
      * This parameter expects a value of type {@link Boolean}.
      * </p>
      */
-    public static final String REJECT_RELATIVE_REDIRECT = "http.protocol.reject-relative-redirect";
+    String REJECT_RELATIVE_REDIRECT = "http.protocol.reject-relative-redirect";
 
     /**
      * Defines the maximum number of redirects to be followed.
@@ -62,7 +62,7 @@ public interface ClientPNames {
      * This parameter expects a value of type {@link Integer}.
      * </p>
      */
-    public static final String MAX_REDIRECTS = "http.protocol.max-redirects";
+    String MAX_REDIRECTS = "http.protocol.max-redirects";
 
     /**
      * Defines whether circular redirects (redirects to the same location) should be allowed.
@@ -72,7 +72,7 @@ public interface ClientPNames {
      * This parameter expects a value of type {@link Boolean}.
      * </p>
      */
-    public static final String ALLOW_CIRCULAR_REDIRECTS = "http.protocol.allow-circular-redirects";
+    String ALLOW_CIRCULAR_REDIRECTS = "http.protocol.allow-circular-redirects";
 
     /**
      * Defines whether authentication should be handled automatically.
@@ -80,7 +80,7 @@ public interface ClientPNames {
      * This parameter expects a value of type {@link Boolean}.
      * </p>
      */
-    public static final String HANDLE_AUTHENTICATION = "http.protocol.handle-authentication";
+    String HANDLE_AUTHENTICATION = "http.protocol.handle-authentication";
 
     /**
      * Defines the name of the cookie specification to be used for HTTP state management.
@@ -88,7 +88,7 @@ public interface ClientPNames {
      * This parameter expects a value of type {@link String}.
      * </p>
      */
-    public static final String COOKIE_POLICY = "http.protocol.cookie-policy";
+    String COOKIE_POLICY = "http.protocol.cookie-policy";
 
     /**
      * Defines the virtual host to be used in the {@code Host}
@@ -98,7 +98,7 @@ public interface ClientPNames {
      * </p>
      * If a port is not provided, it will be derived from the request URL.
      */
-    public static final String VIRTUAL_HOST = "http.virtual-host";
+    String VIRTUAL_HOST = "http.virtual-host";
 
     /**
      * Defines the request headers to be sent per default with each request.
@@ -107,7 +107,7 @@ public interface ClientPNames {
      * collection is expected to contain {@link org.apache.http.Header}s.
      * </p>
      */
-    public static final String DEFAULT_HEADERS = "http.default-headers";
+    String DEFAULT_HEADERS = "http.default-headers";
 
     /**
      * Defines the default host. The default value will be used if the target host is
@@ -116,7 +116,7 @@ public interface ClientPNames {
      * This parameter expects a value of type {@link org.apache.http.HttpHost}.
      * </p>
      */
-    public static final String DEFAULT_HOST = "http.default-host";
+    String DEFAULT_HOST = "http.default-host";
 
     /**
      * Defines the timeout in milliseconds used when retrieving an instance of
@@ -127,7 +127,7 @@ public interface ClientPNames {
      * <p>
      * @since 4.2
      */
-    public static final String CONN_MANAGER_TIMEOUT = "http.conn-manager.timeout";
+    String CONN_MANAGER_TIMEOUT = "http.conn-manager.timeout";
 
 }
 

--- a/httpclient/src/main/java/org/apache/http/client/utils/URIBuilder.java
+++ b/httpclient/src/main/java/org/apache/http/client/utils/URIBuilder.java
@@ -410,9 +410,7 @@ public class URIBuilder {
         } else {
             this.queryParams.clear();
         }
-        for (final NameValuePair nvp: nvps) {
-            this.queryParams.add(nvp);
-        }
+        Collections.addAll(this.queryParams, nvps);
         this.encodedQuery = null;
         this.encodedSchemeSpecificPart = null;
         this.query = null;

--- a/httpclient/src/main/java/org/apache/http/client/utils/URIUtils.java
+++ b/httpclient/src/main/java/org/apache/http/client/utils/URIUtils.java
@@ -448,7 +448,7 @@ public class URIUtils {
                     try {
                         return new HttpHost(hostname, port, scheme);
                     } catch (final IllegalArgumentException ex) {
-                        return null;
+                        // ignore
                     }
                 }
             } else {

--- a/httpclient/src/main/java/org/apache/http/conn/params/ConnConnectionPNames.java
+++ b/httpclient/src/main/java/org/apache/http/conn/params/ConnConnectionPNames.java
@@ -57,8 +57,7 @@ public interface ConnConnectionPNames {
      * @deprecated (4.1) Use custom {@link
      *   org.apache.http.impl.conn.DefaultHttpResponseParser} implementation
      */
-    @Deprecated
-    public static final String MAX_STATUS_LINE_GARBAGE = "http.connection.max-status-line-garbage";
+    @Deprecated String MAX_STATUS_LINE_GARBAGE = "http.connection.max-status-line-garbage";
 
 
 }

--- a/httpclient/src/main/java/org/apache/http/conn/params/ConnManagerPNames.java
+++ b/httpclient/src/main/java/org/apache/http/conn/params/ConnManagerPNames.java
@@ -43,7 +43,7 @@ public interface ConnManagerPNames {
      * <p>
      * This parameter expects a value of type {@link Long}.
      */
-    public static final String TIMEOUT = "http.conn-manager.timeout";
+    String TIMEOUT = "http.conn-manager.timeout";
 
     /**
      * Defines the maximum number of connections per route.
@@ -53,7 +53,7 @@ public interface ConnManagerPNames {
      * This parameter expects a value of type {@link ConnPerRoute}.
      * <p>
      */
-    public static final String MAX_CONNECTIONS_PER_ROUTE = "http.conn-manager.max-per-route";
+    String MAX_CONNECTIONS_PER_ROUTE = "http.conn-manager.max-per-route";
 
     /**
      * Defines the maximum number of connections in total.
@@ -62,6 +62,6 @@ public interface ConnManagerPNames {
      * <p>
      * This parameter expects a value of type {@link Integer}.
      */
-    public static final String MAX_TOTAL_CONNECTIONS = "http.conn-manager.max-total";
+    String MAX_TOTAL_CONNECTIONS = "http.conn-manager.max-total";
 
 }

--- a/httpclient/src/main/java/org/apache/http/conn/params/ConnRoutePNames.java
+++ b/httpclient/src/main/java/org/apache/http/conn/params/ConnRoutePNames.java
@@ -45,7 +45,7 @@ public interface ConnRoutePNames {
      * This parameter expects a value of type {@link org.apache.http.HttpHost}.
      * </p>
      */
-    public static final String DEFAULT_PROXY = "http.route.default-proxy";
+    String DEFAULT_PROXY = "http.route.default-proxy";
 
     /**
      * Parameter for the local address.
@@ -59,7 +59,7 @@ public interface ConnRoutePNames {
      * This parameter expects a value of type {@link java.net.InetAddress}.
      * </p>
      */
-    public static final String LOCAL_ADDRESS = "http.route.local-address";
+    String LOCAL_ADDRESS = "http.route.local-address";
 
     /**
      * Parameter for an forced route.
@@ -73,7 +73,7 @@ public interface ConnRoutePNames {
      * {@link org.apache.http.conn.routing.HttpRoute HttpRoute}.
      * </p>
      */
-    public static final String FORCED_ROUTE = "http.route.forced-route";
+    String FORCED_ROUTE = "http.route.forced-route";
 
 }
 

--- a/httpclient/src/main/java/org/apache/http/conn/routing/HttpRoute.java
+++ b/httpclient/src/main/java/org/apache/http/conn/routing/HttpRoute.java
@@ -212,26 +212,26 @@ public final class HttpRoute implements RouteInfo, Cloneable {
     }
 
     @Override
-    public final HttpHost getTargetHost() {
+    public HttpHost getTargetHost() {
         return this.targetHost;
     }
 
     @Override
-    public final InetAddress getLocalAddress() {
+    public InetAddress getLocalAddress() {
         return this.localAddress;
     }
 
-    public final InetSocketAddress getLocalSocketAddress() {
+    public InetSocketAddress getLocalSocketAddress() {
         return this.localAddress != null ? new InetSocketAddress(this.localAddress, 0) : null;
     }
 
     @Override
-    public final int getHopCount() {
+    public int getHopCount() {
         return proxyChain != null ? proxyChain.size() + 1 : 1;
     }
 
     @Override
-    public final HttpHost getHopTarget(final int hop) {
+    public HttpHost getHopTarget(final int hop) {
         Args.notNegative(hop, "Hop index");
         final int hopcount = getHopCount();
         Args.check(hop < hopcount, "Hop index exceeds tracked route length");
@@ -239,32 +239,32 @@ public final class HttpRoute implements RouteInfo, Cloneable {
     }
 
     @Override
-    public final HttpHost getProxyHost() {
+    public HttpHost getProxyHost() {
         return proxyChain != null && !this.proxyChain.isEmpty() ? this.proxyChain.get(0) : null;
     }
 
     @Override
-    public final TunnelType getTunnelType() {
+    public TunnelType getTunnelType() {
         return this.tunnelled;
     }
 
     @Override
-    public final boolean isTunnelled() {
+    public boolean isTunnelled() {
         return (this.tunnelled == TunnelType.TUNNELLED);
     }
 
     @Override
-    public final LayerType getLayerType() {
+    public LayerType getLayerType() {
         return this.layered;
     }
 
     @Override
-    public final boolean isLayered() {
+    public boolean isLayered() {
         return (this.layered == LayerType.LAYERED);
     }
 
     @Override
-    public final boolean isSecure() {
+    public boolean isSecure() {
         return this.secure;
     }
 
@@ -277,7 +277,7 @@ public final class HttpRoute implements RouteInfo, Cloneable {
      *          {@code false}
      */
     @Override
-    public final boolean equals(final Object obj) {
+    public boolean equals(final Object obj) {
         if (this == obj) {
             return true;
         }
@@ -302,7 +302,7 @@ public final class HttpRoute implements RouteInfo, Cloneable {
      * @return  the hash code
      */
     @Override
-    public final int hashCode() {
+    public int hashCode() {
         int hash = LangUtils.HASH_SEED;
         hash = LangUtils.hashCode(hash, this.targetHost);
         hash = LangUtils.hashCode(hash, this.localAddress);
@@ -323,7 +323,7 @@ public final class HttpRoute implements RouteInfo, Cloneable {
      * @return  a human-readable representation of this route
      */
     @Override
-    public final String toString() {
+    public String toString() {
         final StringBuilder cab = new StringBuilder(50 + getHopCount()*30);
         if (this.localAddress != null) {
             cab.append(this.localAddress);

--- a/httpclient/src/main/java/org/apache/http/conn/routing/HttpRouteDirector.java
+++ b/httpclient/src/main/java/org/apache/http/conn/routing/HttpRouteDirector.java
@@ -37,25 +37,25 @@ package org.apache.http.conn.routing;
 public interface HttpRouteDirector {
 
     /** Indicates that the route can not be established at all. */
-    public final static int UNREACHABLE = -1;
+    int UNREACHABLE = -1;
 
     /** Indicates that the route is complete. */
-    public final static int COMPLETE = 0;
+    int COMPLETE = 0;
 
     /** Step: open connection to target. */
-    public final static int CONNECT_TARGET = 1;
+    int CONNECT_TARGET = 1;
 
     /** Step: open connection to proxy. */
-    public final static int CONNECT_PROXY = 2;
+    int CONNECT_PROXY = 2;
 
     /** Step: tunnel through proxy to target. */
-    public final static int TUNNEL_TARGET = 3;
+    int TUNNEL_TARGET = 3;
 
     /** Step: tunnel through proxy to other proxy. */
-    public final static int TUNNEL_PROXY = 4;
+    int TUNNEL_PROXY = 4;
 
     /** Step: layer protocol (over tunnel). */
-    public final static int LAYER_PROTOCOL = 5;
+    int LAYER_PROTOCOL = 5;
 
 
     /**
@@ -69,6 +69,6 @@ public interface HttpRouteDirector {
      *          either the next step to perform, or success, or failure.
      *          0 is for success, a negative value for failure.
      */
-    public int nextStep(RouteInfo plan, RouteInfo fact);
+    int nextStep(RouteInfo plan, RouteInfo fact);
 
 }

--- a/httpclient/src/main/java/org/apache/http/conn/routing/HttpRoutePlanner.java
+++ b/httpclient/src/main/java/org/apache/http/conn/routing/HttpRoutePlanner.java
@@ -61,7 +61,7 @@ public interface HttpRoutePlanner {
      *
      * @throws HttpException    in case of a problem
      */
-    public HttpRoute determineRoute(HttpHost target,
+    HttpRoute determineRoute(HttpHost target,
                                     HttpRequest request,
                                     HttpContext context) throws HttpException;
 

--- a/httpclient/src/main/java/org/apache/http/conn/routing/RouteTracker.java
+++ b/httpclient/src/main/java/org/apache/http/conn/routing/RouteTracker.java
@@ -112,7 +112,7 @@ public final class RouteTracker implements RouteInfo, Cloneable {
      * @param secure    {@code true} if the route is secure,
      *                  {@code false} otherwise
      */
-    public final void connectTarget(final boolean secure) {
+    public void connectTarget(final boolean secure) {
         Asserts.check(!this.connected, "Already connected");
         this.connected = true;
         this.secure = secure;
@@ -125,7 +125,7 @@ public final class RouteTracker implements RouteInfo, Cloneable {
      * @param secure    {@code true} if the route is secure,
      *                  {@code false} otherwise
      */
-    public final void connectProxy(final HttpHost proxy, final boolean secure) {
+    public void connectProxy(final HttpHost proxy, final boolean secure) {
         Args.notNull(proxy, "Proxy host");
         Asserts.check(!this.connected, "Already connected");
         this.connected  = true;
@@ -139,7 +139,7 @@ public final class RouteTracker implements RouteInfo, Cloneable {
      * @param secure    {@code true} if the route is secure,
      *                  {@code false} otherwise
      */
-    public final void tunnelTarget(final boolean secure) {
+    public void tunnelTarget(final boolean secure) {
         Asserts.check(this.connected, "No tunnel unless connected");
         Asserts.notNull(this.proxyChain, "No tunnel without proxy");
         this.tunnelled = TunnelType.TUNNELLED;
@@ -155,7 +155,7 @@ public final class RouteTracker implements RouteInfo, Cloneable {
      * @param secure    {@code true} if the route is secure,
      *                  {@code false} otherwise
      */
-    public final void tunnelProxy(final HttpHost proxy, final boolean secure) {
+    public void tunnelProxy(final HttpHost proxy, final boolean secure) {
         Args.notNull(proxy, "Proxy host");
         Asserts.check(this.connected, "No tunnel unless connected");
         Asserts.notNull(this.proxyChain, "No tunnel without proxy");
@@ -175,7 +175,7 @@ public final class RouteTracker implements RouteInfo, Cloneable {
      * @param secure    {@code true} if the route is secure,
      *                  {@code false} otherwise
      */
-    public final void layerProtocol(final boolean secure) {
+    public void layerProtocol(final boolean secure) {
         // it is possible to layer a protocol over a direct connection,
         // although this case is probably not considered elsewhere
         Asserts.check(this.connected, "No layered protocol unless connected");
@@ -184,17 +184,17 @@ public final class RouteTracker implements RouteInfo, Cloneable {
     }
 
     @Override
-    public final HttpHost getTargetHost() {
+    public HttpHost getTargetHost() {
         return this.targetHost;
     }
 
     @Override
-    public final InetAddress getLocalAddress() {
+    public InetAddress getLocalAddress() {
         return this.localAddress;
     }
 
     @Override
-    public final int getHopCount() {
+    public int getHopCount() {
         int hops = 0;
         if (this.connected) {
             if (proxyChain == null) {
@@ -207,7 +207,7 @@ public final class RouteTracker implements RouteInfo, Cloneable {
     }
 
     @Override
-    public final HttpHost getHopTarget(final int hop) {
+    public HttpHost getHopTarget(final int hop) {
         Args.notNegative(hop, "Hop index");
         final int hopcount = getHopCount();
         Args.check(hop < hopcount, "Hop index exceeds tracked route length");
@@ -222,36 +222,36 @@ public final class RouteTracker implements RouteInfo, Cloneable {
     }
 
     @Override
-    public final HttpHost getProxyHost() {
+    public HttpHost getProxyHost() {
         return (this.proxyChain == null) ? null : this.proxyChain[0];
     }
 
-    public final boolean isConnected() {
+    public boolean isConnected() {
         return this.connected;
     }
 
     @Override
-    public final TunnelType getTunnelType() {
+    public TunnelType getTunnelType() {
         return this.tunnelled;
     }
 
     @Override
-    public final boolean isTunnelled() {
+    public boolean isTunnelled() {
         return (this.tunnelled == TunnelType.TUNNELLED);
     }
 
     @Override
-    public final LayerType getLayerType() {
+    public LayerType getLayerType() {
         return this.layered;
     }
 
     @Override
-    public final boolean isLayered() {
+    public boolean isLayered() {
         return (this.layered == LayerType.LAYERED);
     }
 
     @Override
-    public final boolean isSecure() {
+    public boolean isSecure() {
         return this.secure;
     }
 
@@ -263,7 +263,7 @@ public final class RouteTracker implements RouteInfo, Cloneable {
      * @return  the tracked route, or
      *          {@code null} if nothing has been tracked so far
      */
-    public final HttpRoute toRoute() {
+    public HttpRoute toRoute() {
         return !this.connected ?
             null : new HttpRoute(this.targetHost, this.localAddress,
                                  this.proxyChain, this.secure,
@@ -279,7 +279,7 @@ public final class RouteTracker implements RouteInfo, Cloneable {
      *          {@code false}
      */
     @Override
-    public final boolean equals(final Object o) {
+    public boolean equals(final Object o) {
         if (o == this) {
             return true;
         }
@@ -308,7 +308,7 @@ public final class RouteTracker implements RouteInfo, Cloneable {
      * @return  the hash code
      */
     @Override
-    public final int hashCode() {
+    public int hashCode() {
         int hash = LangUtils.HASH_SEED;
         hash = LangUtils.hashCode(hash, this.targetHost);
         hash = LangUtils.hashCode(hash, this.localAddress);
@@ -330,7 +330,7 @@ public final class RouteTracker implements RouteInfo, Cloneable {
      * @return  a human-readable representation of the tracked route
      */
     @Override
-    public final String toString() {
+    public String toString() {
         final StringBuilder cab = new StringBuilder(50 + getHopCount()*30);
 
         cab.append("RouteTracker[");

--- a/httpclient/src/main/java/org/apache/http/conn/scheme/Scheme.java
+++ b/httpclient/src/main/java/org/apache/http/conn/scheme/Scheme.java
@@ -145,7 +145,7 @@ public final class Scheme {
      *
      * @return  the default port for this scheme
      */
-    public final int getDefaultPort() {
+    public int getDefaultPort() {
         return defaultPort;
     }
 
@@ -160,7 +160,7 @@ public final class Scheme {
      * @deprecated (4.1)  Use {@link #getSchemeSocketFactory()}
      */
     @Deprecated
-    public final SocketFactory getSocketFactory() {
+    public SocketFactory getSocketFactory() {
         if (this.socketFactory instanceof SchemeSocketFactoryAdaptor) {
             return ((SchemeSocketFactoryAdaptor) this.socketFactory).getFactory();
         }
@@ -179,7 +179,7 @@ public final class Scheme {
      *
      * @since 4.1
      */
-    public final SchemeSocketFactory getSchemeSocketFactory() {
+    public SchemeSocketFactory getSchemeSocketFactory() {
         return this.socketFactory;
     }
 
@@ -188,7 +188,7 @@ public final class Scheme {
      *
      * @return  the name of this scheme, in lowercase
      */
-    public final String getName() {
+    public String getName() {
         return name;
     }
 
@@ -198,7 +198,7 @@ public final class Scheme {
      * @return {@code true} if layered connections are possible,
      *         {@code false} otherwise
      */
-    public final boolean isLayered() {
+    public boolean isLayered() {
         return layered;
     }
 
@@ -211,7 +211,7 @@ public final class Scheme {
      *
      * @return the given port or the defaultPort
      */
-    public final int resolvePort(final int port) {
+    public int resolvePort(final int port) {
         return port <= 0 ? defaultPort : port;
     }
 
@@ -221,7 +221,7 @@ public final class Scheme {
      * @return  a human-readable string description of this scheme
      */
     @Override
-    public final String toString() {
+    public String toString() {
         if (stringRep == null) {
             final StringBuilder buffer = new StringBuilder();
             buffer.append(this.name);
@@ -233,7 +233,7 @@ public final class Scheme {
     }
 
     @Override
-    public final boolean equals(final Object obj) {
+    public boolean equals(final Object obj) {
         if (this == obj) {
             return true;
         }

--- a/httpclient/src/main/java/org/apache/http/conn/scheme/SchemeRegistry.java
+++ b/httpclient/src/main/java/org/apache/http/conn/scheme/SchemeRegistry.java
@@ -69,7 +69,7 @@ public final class SchemeRegistry {
      * @throws IllegalStateException
      *          if the scheme with the given name is not registered
      */
-    public final Scheme getScheme(final String name) {
+    public Scheme getScheme(final String name) {
         final Scheme found = get(name);
         if (found == null) {
             throw new IllegalStateException
@@ -89,7 +89,7 @@ public final class SchemeRegistry {
      * @throws IllegalStateException
      *          if a scheme with the respective name is not registered
      */
-    public final Scheme getScheme(final HttpHost host) {
+    public Scheme getScheme(final HttpHost host) {
         Args.notNull(host, "Host");
         return getScheme(host.getSchemeName());
     }
@@ -102,7 +102,7 @@ public final class SchemeRegistry {
      * @return  the scheme, or
      *          {@code null} if there is none by this name
      */
-    public final Scheme get(final String name) {
+    public Scheme get(final String name) {
         Args.notNull(name, "Scheme name");
         // leave it to the caller to use the correct name - all lowercase
         //name = name.toLowerCase(Locale.ENGLISH);
@@ -120,7 +120,7 @@ public final class SchemeRegistry {
      * @return  the scheme previously registered with that name, or
      *          {@code null} if none was registered
      */
-    public final Scheme register(final Scheme sch) {
+    public Scheme register(final Scheme sch) {
         Args.notNull(sch, "Scheme");
         final Scheme old = registeredSchemes.put(sch.getName(), sch);
         return old;
@@ -134,7 +134,7 @@ public final class SchemeRegistry {
      * @return  the unregistered scheme, or
      *          {@code null} if there was none
      */
-    public final Scheme unregister(final String name) {
+    public Scheme unregister(final String name) {
         Args.notNull(name, "Scheme name");
         // leave it to the caller to use the correct name - all lowercase
         //name = name.toLowerCase(Locale.ENGLISH);
@@ -147,7 +147,7 @@ public final class SchemeRegistry {
      *
      * @return  List containing registered scheme names.
      */
-    public final List<String> getSchemeNames() {
+    public List<String> getSchemeNames() {
         return new ArrayList<String>(registeredSchemes.keySet());
     }
 

--- a/httpclient/src/main/java/org/apache/http/cookie/ClientCookie.java
+++ b/httpclient/src/main/java/org/apache/http/cookie/ClientCookie.java
@@ -45,22 +45,17 @@ import org.apache.http.annotation.Obsolete;
  */
 public interface ClientCookie extends Cookie {
 
-    @Obsolete
-    public static final String VERSION_ATTR    = "version";
-    public static final String PATH_ATTR       = "path";
-    public static final String DOMAIN_ATTR     = "domain";
-    public static final String MAX_AGE_ATTR    = "max-age";
-    public static final String SECURE_ATTR     = "secure";
-    @Obsolete
-    public static final String COMMENT_ATTR    = "comment";
-    public static final String EXPIRES_ATTR    = "expires";
+    @Obsolete String VERSION_ATTR    = "version";
+    String PATH_ATTR       = "path";
+    String DOMAIN_ATTR     = "domain";
+    String MAX_AGE_ATTR    = "max-age";
+    String SECURE_ATTR     = "secure";
+    @Obsolete String COMMENT_ATTR    = "comment";
+    String EXPIRES_ATTR    = "expires";
 
-    @Obsolete
-    public static final String PORT_ATTR       = "port";
-    @Obsolete
-    public static final String COMMENTURL_ATTR = "commenturl";
-    @Obsolete
-    public static final String DISCARD_ATTR    = "discard";
+    @Obsolete String PORT_ATTR       = "port";
+    @Obsolete String COMMENTURL_ATTR = "commenturl";
+    @Obsolete String DISCARD_ATTR    = "discard";
 
     String getAttribute(String name);
 

--- a/httpclient/src/main/java/org/apache/http/cookie/SM.java
+++ b/httpclient/src/main/java/org/apache/http/cookie/SM.java
@@ -35,9 +35,9 @@ package org.apache.http.cookie;
  */
 public interface SM {
 
-    public static final String COOKIE            = "Cookie";
-    public static final String COOKIE2           = "Cookie2";
-    public static final String SET_COOKIE        = "Set-Cookie";
-    public static final String SET_COOKIE2       = "Set-Cookie2";
+    String COOKIE            = "Cookie";
+    String COOKIE2           = "Cookie2";
+    String SET_COOKIE        = "Set-Cookie";
+    String SET_COOKIE2       = "Set-Cookie2";
 
 }

--- a/httpclient/src/main/java/org/apache/http/cookie/params/CookieSpecPNames.java
+++ b/httpclient/src/main/java/org/apache/http/cookie/params/CookieSpecPNames.java
@@ -50,7 +50,7 @@ public interface CookieSpecPNames {
      * with the syntax of {@link java.text.SimpleDateFormat}.
      * </p>
      */
-    public static final String DATE_PATTERNS = "http.protocol.cookie-datepatterns";
+    String DATE_PATTERNS = "http.protocol.cookie-datepatterns";
 
     /**
      * Defines whether cookies should be forced into a single
@@ -60,6 +60,6 @@ public interface CookieSpecPNames {
      * This parameter expects a value of type {@link Boolean}.
      * </p>
      */
-    public static final String SINGLE_COOKIE_HEADER = "http.protocol.single-cookie-header";
+    String SINGLE_COOKIE_HEADER = "http.protocol.single-cookie-header";
 
 }

--- a/httpclient/src/main/java/org/apache/http/impl/auth/NTLMEngineImpl.java
+++ b/httpclient/src/main/java/org/apache/http/impl/auth/NTLMEngineImpl.java
@@ -766,7 +766,7 @@ final class NTLMEngineImpl implements NTLMEngine {
         return lmv2Response;
     }
 
-    static enum Mode
+    enum Mode
     {
         CLIENT, SERVER;
     }

--- a/httpclient/src/main/java/org/apache/http/impl/auth/NTLMEngineImpl.java
+++ b/httpclient/src/main/java/org/apache/http/impl/auth/NTLMEngineImpl.java
@@ -433,7 +433,7 @@ final class NTLMEngineImpl implements NTLMEngine {
         public byte[] getTimestamp() {
             if (timestamp == null) {
                 long time = this.currentTime;
-                time += 11644473600000l; // milliseconds from January 1, 1601 -> epoch.
+                time += 11644473600000L; // milliseconds from January 1, 1601 -> epoch.
                 time *= 10000; // tenths of a microsecond.
                 // convert to little-endian byte array.
                 timestamp = new byte[8];

--- a/httpclient/src/main/java/org/apache/http/impl/client/BasicAuthCache.java
+++ b/httpclient/src/main/java/org/apache/http/impl/client/BasicAuthCache.java
@@ -134,12 +134,10 @@ public class BasicAuthCache implements AuthCache {
                 if (log.isWarnEnabled()) {
                     log.warn("Unexpected I/O error while de-serializing auth scheme", ex);
                 }
-                return null;
             } catch (final ClassNotFoundException ex) {
                 if (log.isWarnEnabled()) {
                     log.warn("Unexpected error while de-serializing auth scheme", ex);
                 }
-                return null;
             }
         }
         return null;

--- a/httpclient/src/main/java/org/apache/http/impl/client/DefaultHttpRequestRetryHandler.java
+++ b/httpclient/src/main/java/org/apache/http/impl/client/DefaultHttpRequestRetryHandler.java
@@ -82,9 +82,7 @@ public class DefaultHttpRequestRetryHandler implements HttpRequestRetryHandler {
         this.retryCount = retryCount;
         this.requestSentRetryEnabled = requestSentRetryEnabled;
         this.nonRetriableClasses = new HashSet<Class<? extends IOException>>();
-        for (final Class<? extends IOException> clazz: clazzes) {
-            this.nonRetriableClasses.add(clazz);
-        }
+        this.nonRetriableClasses.addAll(clazzes);
     }
 
     /**

--- a/httpclient/src/main/java/org/apache/http/impl/client/IdleConnectionEvictor.java
+++ b/httpclient/src/main/java/org/apache/http/impl/client/IdleConnectionEvictor.java
@@ -117,7 +117,7 @@ public final class IdleConnectionEvictor {
             return t;
         }
 
-    };
+    }
 
 
 }

--- a/httpclient/src/test/java/org/apache/http/impl/client/integration/TestConnectionManagement.java
+++ b/httpclient/src/test/java/org/apache/http/impl/client/integration/TestConnectionManagement.java
@@ -40,7 +40,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.apache.http.HttpClientConnection;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
-import org.apache.http.HttpRequestInterceptor;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.HttpVersion;
@@ -114,7 +113,7 @@ public class TestConnectionManagement extends LocalServerTestBase {
         context.setAttribute(HttpCoreContext.HTTP_TARGET_HOST, target);
 
         final HttpProcessor httpProcessor = new ImmutableHttpProcessor(
-                new HttpRequestInterceptor[] { new RequestContent(), new RequestConnControl() });
+                new RequestContent(), new RequestConnControl());
 
         final HttpRequestExecutor exec = new HttpRequestExecutor();
         exec.preProcess(request, httpProcessor, context);
@@ -203,7 +202,7 @@ public class TestConnectionManagement extends LocalServerTestBase {
         context.setAttribute(HttpCoreContext.HTTP_TARGET_HOST, target);
 
         final HttpProcessor httpProcessor = new ImmutableHttpProcessor(
-                new HttpRequestInterceptor[] { new RequestContent(), new RequestConnControl() });
+                new RequestContent(), new RequestConnControl());
 
         final HttpRequestExecutor exec = new HttpRequestExecutor();
         exec.preProcess(request, httpProcessor, context);
@@ -401,7 +400,7 @@ public class TestConnectionManagement extends LocalServerTestBase {
         context.setAttribute(HttpCoreContext.HTTP_TARGET_HOST, target);
 
         final HttpProcessor httpProcessor = new ImmutableHttpProcessor(
-                new HttpRequestInterceptor[] { new RequestContent(), new RequestConnControl() });
+                new RequestContent(), new RequestConnControl());
 
         final HttpRequestExecutor exec = new HttpRequestExecutor();
         exec.preProcess(request, httpProcessor, context);

--- a/httpclient/src/test/java/org/apache/http/localserver/LocalServerTestBase.java
+++ b/httpclient/src/test/java/org/apache/http/localserver/LocalServerTestBase.java
@@ -45,7 +45,7 @@ import org.junit.Before;
  */
 public abstract class LocalServerTestBase {
 
-    public enum ProtocolScheme { http, https };
+    public enum ProtocolScheme { http, https }
 
     public static final String ORIGIN = "TEST/1.1";
 


### PR DESCRIPTION
Each commit in this PR comprise one kind of cleanup/change:
- Use Arrays.fill().
- Remove redundant modifiers. …
- Use Collections.addAll() and Collection.addAll() APIs instead of loops.
- Remove redundant returns.
- No need to explicitly declare an array when calling a vararg method.
- Remote extra semicolons (;).
- Use a 'L' instead of 'l' to make long literals more readable.