### PR TITLE
Remove clone() method that only calls super in Object.

### DIFF
--- a/httpclient-cache/src/main/java/org/apache/http/impl/client/cache/CacheEntity.java
+++ b/httpclient-cache/src/main/java/org/apache/http/impl/client/cache/CacheEntity.java
@@ -99,11 +99,7 @@ class CacheEntity implements HttpEntity, Serializable {
 
     @Override
     public void consumeContent() throws IOException {
-    }
-
-    @Override
-    public Object clone() throws CloneNotSupportedException {
-        return super.clone();
+        // consume nothing
     }
 
 }


### PR DESCRIPTION
Remove `clone()` method that only calls `super` in `Object`.
