### PR TITLE
Add maven-bundle-plugin to create OSGi-ready packages

### DIFF
--- a/httpclient5-cache/pom.xml
+++ b/httpclient5-cache/pom.xml
@@ -35,7 +35,7 @@
   <inceptionYear>2010</inceptionYear>
   <description>Apache HttpComponents HttpClient Cache</description>
   <url>https://hc.apache.org/httpcomponents-client-5.0.x/</url>
-  <packaging>bundle</packaging>
+  <packaging>jar</packaging>
 
   <properties>
     <Automatic-Module-Name>org.apache.httpcomponents.client5.httpclient5.cache</Automatic-Module-Name>
@@ -99,6 +99,15 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+            <manifestEntries>
+              <Automatic-Module-Name>${Automatic-Module-Name}</Automatic-Module-Name>
+              <Implementation-URL>${project.url}</Implementation-URL>
+            </manifestEntries>
+          </archive>
+        </configuration>
         <executions>
           <execution>
             <goals>
@@ -121,6 +130,15 @@
             </Export-Package>
           </instructions>
         </configuration>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/httpclient5-cache/pom.xml
+++ b/httpclient5-cache/pom.xml
@@ -35,7 +35,7 @@
   <inceptionYear>2010</inceptionYear>
   <description>Apache HttpComponents HttpClient Cache</description>
   <url>https://hc.apache.org/httpcomponents-client-5.0.x/</url>
-  <packaging>jar</packaging>
+  <packaging>bundle</packaging>
 
   <properties>
     <Automatic-Module-Name>org.apache.httpcomponents.client5.httpclient5.cache</Automatic-Module-Name>
@@ -106,6 +106,21 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Export-Package>
+              org.apache.hc.client5.http.cache,
+              org.apache.hc.client5.http.schedule,
+              org.apache.hc.client5.http.impl.cache.*,
+              org.apache.hc.client5.http.impl.schedule
+            </Export-Package>
+          </instructions>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/httpclient5-fluent/pom.xml
+++ b/httpclient5-fluent/pom.xml
@@ -35,7 +35,7 @@
   <inceptionYear>2011</inceptionYear>
   <description>Apache HttpComponents Client Fluent</description>
   <url>https://hc.apache.org/httpcomponents-client-5.0.x/</url>
-  <packaging>jar</packaging>
+  <packaging>bundle</packaging>
 
   <properties>
     <Automatic-Module-Name>org.apache.httpcomponents.client5.httpclient5.fluent</Automatic-Module-Name>
@@ -77,6 +77,16 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+      </plugin>
+    </plugins>
+  </build>
 
   <reporting>
     <plugins>

--- a/httpclient5-fluent/pom.xml
+++ b/httpclient5-fluent/pom.xml
@@ -35,7 +35,7 @@
   <inceptionYear>2011</inceptionYear>
   <description>Apache HttpComponents Client Fluent</description>
   <url>https://hc.apache.org/httpcomponents-client-5.0.x/</url>
-  <packaging>bundle</packaging>
+  <packaging>jar</packaging>
 
   <properties>
     <Automatic-Module-Name>org.apache.httpcomponents.client5.httpclient5.fluent</Automatic-Module-Name>
@@ -81,9 +81,30 @@
   <build>
     <plugins>
       <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+            <manifestEntries>
+              <Automatic-Module-Name>${Automatic-Module-Name}</Automatic-Module-Name>
+              <Implementation-URL>${project.url}</Implementation-URL>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
         <extensions>true</extensions>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/httpclient5-win/pom.xml
+++ b/httpclient5-win/pom.xml
@@ -34,7 +34,7 @@
   <name>Apache HttpClient Windows features</name>
   <description>Apache HttpClient Windows specific functionality</description>
   <url>https://hc.apache.org/httpcomponents-client-5.0.x/</url>
-  <packaging>bundle</packaging>
+  <packaging>jar</packaging>
 
   <properties>
     <Automatic-Module-Name>org.apache.httpcomponents.client5.httpclient5.win</Automatic-Module-Name>
@@ -84,6 +84,18 @@
   <build>
     <plugins>
       <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+            <manifestEntries>
+              <Automatic-Module-Name>${Automatic-Module-Name}</Automatic-Module-Name>
+              <Implementation-URL>${project.url}</Implementation-URL>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
         <extensions>true</extensions>
@@ -92,6 +104,15 @@
             <Export-Package>org.apache.hc.client5.http.impl.win</Export-Package>
           </instructions>
         </configuration>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/httpclient5-win/pom.xml
+++ b/httpclient5-win/pom.xml
@@ -34,7 +34,7 @@
   <name>Apache HttpClient Windows features</name>
   <description>Apache HttpClient Windows specific functionality</description>
   <url>https://hc.apache.org/httpcomponents-client-5.0.x/</url>
-  <packaging>jar</packaging>
+  <packaging>bundle</packaging>
 
   <properties>
     <Automatic-Module-Name>org.apache.httpcomponents.client5.httpclient5.win</Automatic-Module-Name>
@@ -80,6 +80,21 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Export-Package>org.apache.hc.client5.http.impl.win</Export-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 
   <reporting>
     <plugins>

--- a/httpclient5/pom.xml
+++ b/httpclient5/pom.xml
@@ -34,7 +34,7 @@
   <name>Apache HttpClient</name>
   <description>Apache HttpComponents Client</description>
   <url>https://hc.apache.org/httpcomponents-client-5.0.x/</url>
-  <packaging>bundle</packaging>
+  <packaging>jar</packaging>
 
   <properties>
     <Automatic-Module-Name>org.apache.httpcomponents.client5.httpclient5</Automatic-Module-Name>
@@ -127,6 +127,15 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+            <manifestEntries>
+              <Automatic-Module-Name>${Automatic-Module-Name}</Automatic-Module-Name>
+              <Implementation-URL>${project.url}</Implementation-URL>
+            </manifestEntries>
+          </archive>
+        </configuration>
         <executions>
           <execution>
             <goals>
@@ -144,7 +153,16 @@
             <Export-Package>org.apache.hc.client5.http.*</Export-Package>
           </instructions>
         </configuration>
-        </plugin>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/httpclient5/pom.xml
+++ b/httpclient5/pom.xml
@@ -34,7 +34,7 @@
   <name>Apache HttpClient</name>
   <description>Apache HttpComponents Client</description>
   <url>https://hc.apache.org/httpcomponents-client-5.0.x/</url>
-  <packaging>jar</packaging>
+  <packaging>bundle</packaging>
 
   <properties>
     <Automatic-Module-Name>org.apache.httpcomponents.client5.httpclient5</Automatic-Module-Name>
@@ -135,6 +135,16 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Export-Package>org.apache.hc.client5.http.*</Export-Package>
+          </instructions>
+        </configuration>
+        </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
The Felix maven-bundle-plugin adds a manifest file within the resulting jar that OSGi uses when wiring together dependencies. By default, the plugin ignores packages named impl, so explicit instructions have been added to the poms of httpclient5,  httpclient5-cache, and httpclient5-win to publish all packages in the manifest. The resulting package is still a jar file, so non-OSGi consumers need not do anything different.