### PR TITLE
Fix the issues causing Kerberos/SPNego to fail

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/GGSSchemeBase.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/GGSSchemeBase.java
@@ -28,7 +28,6 @@ package org.apache.hc.client5.http.impl.auth;
 
 import java.net.UnknownHostException;
 import java.security.Principal;
-import java.util.Locale;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.hc.client5.http.DnsResolver;
@@ -73,7 +72,7 @@ public abstract class GGSSchemeBase implements AuthScheme {
     }
 
     private static final Logger LOG = LoggerFactory.getLogger(GGSSchemeBase.class);
-
+    private static final String NO_TOKEN = "";
     private final KerberosConfig config;
     private final DnsResolver dnsResolver;
 
@@ -108,10 +107,9 @@ public abstract class GGSSchemeBase implements AuthScheme {
             final AuthChallenge authChallenge,
             final HttpContext context) throws MalformedChallengeException {
         Args.notNull(authChallenge, "AuthChallenge");
-        if (authChallenge.getValue() == null) {
-            throw new MalformedChallengeException("Missing auth challenge");
-        }
-        this.challenge = authChallenge.getValue();
+
+        this.challenge = authChallenge.getValue() != null ? authChallenge.getValue() : NO_TOKEN;
+
         if (state == State.UNINITIATED) {
             token = Base64.decodeBase64(challenge.getBytes());
             state = State.CHALLENGE_RECEIVED;
@@ -133,9 +131,9 @@ public abstract class GGSSchemeBase implements AuthScheme {
      * @since 4.4
      */
     protected byte[] generateGSSToken(
-            final byte[] input, final Oid oid, final String serviceName, final String authServer) throws GSSException {
+            final byte[] input, final Oid oid, final String authServer) throws GSSException {
         final GSSManager manager = getManager();
-        final GSSName serverName = manager.createName(serviceName + "@" + authServer, GSSName.NT_HOSTBASED_SERVICE);
+        final GSSName serverName = manager.createName("HTTP@" + authServer, GSSName.NT_HOSTBASED_SERVICE);
 
         final GSSContext gssContext = createGSSContext(manager, oid, serverName, gssCredential);
         if (input != null) {
@@ -164,7 +162,7 @@ public abstract class GGSSchemeBase implements AuthScheme {
     /**
      * @since 4.4
      */
-    protected abstract byte[] generateToken(byte[] input, String serviceName, String authServer) throws GSSException;
+    protected abstract byte[] generateToken(byte[] input, String authServer) throws GSSException;
 
     @Override
     public boolean isChallengeComplete() {
@@ -222,14 +220,13 @@ public abstract class GGSSchemeBase implements AuthScheme {
                 } else {
                     authServer = hostname + ":" + host.getPort();
                 }
-                final String serviceName = host.getSchemeName().toUpperCase(Locale.ROOT);
 
                 if (LOG.isDebugEnabled()) {
                     final HttpClientContext clientContext = HttpClientContext.adapt(context);
                     final String exchangeId = clientContext.getExchangeId();
                     LOG.debug("{} init {}", exchangeId, authServer);
                 }
-                token = generateToken(token, serviceName, authServer);
+                token = generateToken(token, authServer);
                 state = State.TOKEN_GENERATED;
             } catch (final GSSException gsse) {
                 state = State.FAILED;

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/KerberosScheme.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/KerberosScheme.java
@@ -64,8 +64,8 @@ public class KerberosScheme extends GGSSchemeBase {
     }
 
     @Override
-    protected byte[] generateToken(final byte[] input, final String serviceName, final String authServer) throws GSSException {
-        return generateGSSToken(input, new Oid(KERBEROS_OID), serviceName, authServer);
+    protected byte[] generateToken(final byte[] input, final String authServer) throws GSSException {
+        return generateGSSToken(input, new Oid(KERBEROS_OID), authServer);
     }
 
     @Override

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/SPNegoScheme.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/SPNegoScheme.java
@@ -65,8 +65,8 @@ public class SPNegoScheme extends GGSSchemeBase {
     }
 
     @Override
-    protected byte[] generateToken(final byte[] input, final String serviceName, final String authServer) throws GSSException {
-        return generateGSSToken(input, new Oid(SPNEGO_OID), serviceName, authServer);
+    protected byte[] generateToken(final byte[] input, final String authServer) throws GSSException {
+        return generateGSSToken(input, new Oid(SPNEGO_OID), authServer);
     }
 
     @Override


### PR DESCRIPTION
1. At the beginning of the negotiate, no token is defined in "WWW-Authenticate: Negotiate".
2. Kerberos expects HTTP.