### PR TITLE
Blocking connection managers to validate connections by default

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java
@@ -95,9 +95,6 @@ import org.slf4j.LoggerFactory;
  * Total time to live (TTL) set at construction time defines maximum life span
  * of persistent connections regardless of their expiration setting. No persistent
  * connection will be re-used past its TTL value.
- * <p>
- * Please note in contrast to 4.x no stale check is employed by default.
- * @see #setValidateAfterInactivity(TimeValue)
  *
  * @since 4.3
  */
@@ -206,6 +203,7 @@ public class PoolingHttpClientConnectionManager
         }
         this.connFactory = connFactory != null ? connFactory : ManagedHttpClientConnectionFactory.INSTANCE;
         this.closed = new AtomicBoolean(false);
+        this.validateAfterInactivity = TimeValue.ofSeconds(2L);
     }
 
     @Internal

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManagerBuilder.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManagerBuilder.java
@@ -212,7 +212,9 @@ public class PoolingHttpClientConnectionManagerBuilder {
                 schemePortResolver,
                 dnsResolver,
                 connectionFactory);
-        poolingmgr.setValidateAfterInactivity(this.validateAfterInactivity);
+        if (validateAfterInactivity != null) {
+            poolingmgr.setValidateAfterInactivity(validateAfterInactivity);
+        }
         if (defaultSocketConfig != null) {
             poolingmgr.setDefaultSocketConfig(defaultSocketConfig);
         }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManagerBuilder.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManagerBuilder.java
@@ -201,7 +201,9 @@ public class PoolingAsyncClientConnectionManagerBuilder {
                 timeToLive,
                 schemePortResolver,
                 dnsResolver);
-        poolingmgr.setValidateAfterInactivity(this.validateAfterInactivity);
+        if (validateAfterInactivity != null) {
+            poolingmgr.setValidateAfterInactivity(validateAfterInactivity);
+        }
         if (maxConnTotal > 0) {
             poolingmgr.setMaxTotal(maxConnTotal);
         }


### PR DESCRIPTION
@carterkozak @rschmitt Blocking connection managers now validate connections after inactivity of more than 2s by default. The behavior of async connection managers remains unchanged. 

Please review.