### PR TITLE
Updating project URL to include '-ga' suffix

### DIFF
--- a/doap_HttpComponents_Client.rdf
+++ b/doap_HttpComponents_Client.rdf
@@ -31,11 +31,11 @@
    <http://www.apache.org />.
 -->
 
-  <Project rdf:about="http://hc.apache.org/httpcomponents-client/">
+  <Project rdf:about="http://hc.apache.org/httpcomponents-client-ga/">
     <created>2007-11-15</created>
     <license rdf:resource="http://usefulinc.com/doap/licenses/asl20" />
     <name>Apache HttpComponents Client</name>
-    <homepage rdf:resource="http://hc.apache.org/httpcomponents-client/" />
+    <homepage rdf:resource="http://hc.apache.org/httpcomponents-client-ga/" />
     <asfext:pmc rdf:resource="http://httpcomponents.apache.org" />
     <shortdesc>
 Java library implementing an HTTP client based on HttpCore components.

--- a/fluent-hc/pom.xml
+++ b/fluent-hc/pom.xml
@@ -36,7 +36,7 @@
   <description>
    Apache HttpComponents Client fluent API
   </description>
-  <url>http://hc.apache.org/httpcomponents-client</url>
+  <url>http://hc.apache.org/httpcomponents-client-ga</url>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/httpclient-cache/pom.xml
+++ b/httpclient-cache/pom.xml
@@ -36,7 +36,7 @@
   <description>
    Apache HttpComponents HttpClient - Cache
   </description>
-  <url>http://hc.apache.org/httpcomponents-client</url>
+  <url>http://hc.apache.org/httpcomponents-client-ga</url>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/httpclient-osgi/pom.xml
+++ b/httpclient-osgi/pom.xml
@@ -36,7 +36,7 @@
   <description>
    Apache HttpComponents Client (OSGi bundle)
   </description>
-  <url>http://hc.apache.org/httpcomponents-client</url>
+  <url>http://hc.apache.org/httpcomponents-client-ga</url>
   <packaging>bundle</packaging>
 
   <properties>

--- a/httpclient-win/pom.xml
+++ b/httpclient-win/pom.xml
@@ -35,7 +35,7 @@
   <description>
    Apache HttpClient Windows specific functionality
   </description>
-  <url>http://hc.apache.org/httpcomponents-client</url>
+  <url>http://hc.apache.org/httpcomponents-client-ga</url>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/httpclient/pom.xml
+++ b/httpclient/pom.xml
@@ -35,7 +35,7 @@
   <description>
    Apache HttpComponents Client
   </description>
-  <url>http://hc.apache.org/httpcomponents-client</url>
+  <url>http://hc.apache.org/httpcomponents-client-ga</url>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/httpmime/pom.xml
+++ b/httpmime/pom.xml
@@ -35,7 +35,7 @@
   <description>
    Apache HttpComponents HttpClient - MIME coded entities
   </description>
-  <url>http://hc.apache.org/httpcomponents-client</url>
+  <url>http://hc.apache.org/httpcomponents-client-ga</url>
   <packaging>jar</packaging>
 
   <dependencies>


### PR DESCRIPTION
Maven Central (https://search.maven.org/artifact/org.apache.httpcomponents/httpclient/4.5.13/jar
) tells wrong URL for the project.


<img width="1027" alt="Screen Shot 2021-04-02 at 15 27 28" src="https://user-images.githubusercontent.com/28604/113447472-f13cca00-93c7-11eb-9028-ebe23cb63d31.png">

