### PR TITLE
Connection lease request cancellation bug

### DIFF
--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestClientRequestExecution.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestClientRequestExecution.java
@@ -29,6 +29,10 @@ package org.apache.hc.client5.testing.sync;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URI;
+import java.util.Random;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hc.client5.http.HttpRequestRetryStrategy;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
@@ -289,6 +293,64 @@ public class TestClientRequestExecution extends LocalServerTestBase {
         final RedirectLocations redirectLocations = context.getRedirectLocations();
         final URI location = URIUtils.resolve(uri, target, redirectLocations.getAll());
         Assert.assertEquals(uri, location);
+    }
+
+    @Test
+    public void testRequestCancellation() throws Exception {
+        this.connManager.setDefaultMaxPerRoute(1);
+        this.connManager.setMaxTotal(1);
+
+        final HttpHost target = start();
+
+        final ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
+        try {
+
+            for (int i = 0; i < 20; i++) {
+                final HttpGet httpget = new HttpGet("/random/1000");
+
+                executorService.schedule(new Runnable() {
+
+                    @Override
+                    public void run() {
+                        httpget.cancel();
+                    }
+                }, 1, TimeUnit.MILLISECONDS);
+
+                try (final ClassicHttpResponse response = this.httpclient.execute(target, httpget)) {
+                    EntityUtils.consume(response.getEntity());
+                } catch (final Exception ignore) {
+                }
+            }
+
+            final Random rnd = new Random();
+            for (int i = 0; i < 20; i++) {
+                final HttpGet httpget = new HttpGet("/random/1000");
+
+                executorService.schedule(new Runnable() {
+
+                    @Override
+                    public void run() {
+                        httpget.cancel();
+                    }
+                }, rnd.nextInt(200), TimeUnit.MILLISECONDS);
+
+                try (final ClassicHttpResponse response = this.httpclient.execute(target, httpget)) {
+                    EntityUtils.consume(response.getEntity());
+                } catch (final Exception ignore) {
+                }
+
+            }
+
+            for (int i = 0; i < 5; i++) {
+                final HttpGet httpget = new HttpGet("/random/1000");
+                try (final ClassicHttpResponse response = this.httpclient.execute(target, httpget)) {
+                    EntityUtils.consume(response.getEntity());
+                }
+            }
+
+        } finally {
+            executorService.shutdownNow();
+        }
     }
 
 }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java
@@ -28,7 +28,6 @@ package org.apache.hc.client5.http.impl.io;
 
 import java.io.IOException;
 import java.util.Set;
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeoutException;
@@ -270,9 +269,6 @@ public class PoolingHttpClientConnectionManager
                 final PoolEntry<HttpRoute, ManagedHttpClientConnection> poolEntry;
                 try {
                     poolEntry = leaseFuture.get(timeout.getDuration(), timeout.getTimeUnit());
-                    if (poolEntry == null || leaseFuture.isCancelled()) {
-                        throw new ExecutionException(new CancellationException("Operation cancelled"));
-                    }
                 } catch (final TimeoutException ex) {
                     leaseFuture.cancel(true);
                     throw ex;
@@ -306,16 +302,9 @@ public class PoolingHttpClientConnectionManager
                     } else {
                         poolEntry.assignConnection(connFactory.createConnection(null));
                     }
-                    if (leaseFuture.isCancelled()) {
-                        if (LOG.isDebugEnabled()) {
-                            LOG.debug("{} endpoint lease cancelled", id);
-                        }
-                        pool.release(poolEntry, false);
-                    } else {
-                        this.endpoint = new InternalConnectionEndpoint(poolEntry);
-                        if (LOG.isDebugEnabled()) {
-                            LOG.debug("{} acquired {}", id, ConnPoolSupport.getId(endpoint));
-                        }
+                    this.endpoint = new InternalConnectionEndpoint(poolEntry);
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("{} acquired {}", id, ConnPoolSupport.getId(endpoint));
                     }
                     return this.endpoint;
                 } catch (final Exception ex) {

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java
@@ -29,7 +29,10 @@ package org.apache.hc.client5.http.impl.nio;
 
 import java.net.InetSocketAddress;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -47,6 +50,7 @@ import org.apache.hc.client5.http.ssl.DefaultClientTlsStrategy;
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.Internal;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
+import org.apache.hc.core5.concurrent.BasicFuture;
 import org.apache.hc.core5.concurrent.ComplexFuture;
 import org.apache.hc.core5.concurrent.FutureCallback;
 import org.apache.hc.core5.function.Callback;
@@ -221,82 +225,112 @@ public class PoolingAsyncClientConnectionManager implements AsyncClientConnectio
         if (LOG.isDebugEnabled()) {
             LOG.debug("{} endpoint lease request ({}) {}", id, requestTimeout, ConnPoolSupport.formatStats(route, state, pool));
         }
-        final ComplexFuture<AsyncConnectionEndpoint> resultFuture = new ComplexFuture<>(callback);
-        final Future<PoolEntry<HttpRoute, ManagedAsyncClientConnection>> leaseFuture = pool.lease(
-                route, state, requestTimeout, new FutureCallback<PoolEntry<HttpRoute, ManagedAsyncClientConnection>>() {
+        return new Future<AsyncConnectionEndpoint>() {
 
-                    void leaseCompleted(final PoolEntry<HttpRoute, ManagedAsyncClientConnection> poolEntry) {
-                        final ManagedAsyncClientConnection connection = poolEntry.getConnection();
-                        if (connection != null) {
-                            connection.activate();
-                        }
-                        if (LOG.isDebugEnabled()) {
-                            LOG.debug("{} endpoint leased {}", id, ConnPoolSupport.formatStats(route, state, pool));
-                        }
-                        final AsyncConnectionEndpoint endpoint = new InternalConnectionEndpoint(poolEntry);
-                        if (LOG.isDebugEnabled()) {
-                            LOG.debug("{} acquired {}", id, ConnPoolSupport.getId(endpoint));
-                        }
-                        resultFuture.completed(endpoint);
-                    }
+            final BasicFuture<AsyncConnectionEndpoint> resultFuture = new BasicFuture<>(callback);
 
-                    @Override
-                    public void completed(final PoolEntry<HttpRoute, ManagedAsyncClientConnection> poolEntry) {
-                        final ManagedAsyncClientConnection connection = poolEntry.getConnection();
-                        if (connection != null) {
-                            if (connection.isOpen()) {
-                                final ProtocolVersion protocolVersion = connection.getProtocolVersion();
-                                if (protocolVersion != null && protocolVersion.greaterEquals(HttpVersion.HTTP_2_0)) {
-                                    final TimeValue timeValue = PoolingAsyncClientConnectionManager.this.validateAfterInactivity;
-                                    if (TimeValue.isNonNegative(timeValue) &&
-                                            poolEntry.getUpdated() + timeValue.toMilliseconds() <= System.currentTimeMillis()) {
-                                        connection.submitCommand(new PingCommand(new BasicPingHandler(new Callback<Boolean>() {
+            final Future<PoolEntry<HttpRoute, ManagedAsyncClientConnection>> leaseFuture = pool.lease(
+                    route,
+                    state,
+                    requestTimeout, new FutureCallback<PoolEntry<HttpRoute, ManagedAsyncClientConnection>>() {
 
-                                            @Override
-                                            public void execute(final Boolean result) {
-                                                if (result == null || !result) {
-                                                    if (LOG.isDebugEnabled()) {
-                                                        LOG.debug("{} connection {} is stale", id, ConnPoolSupport.getId(connection));
+                        @Override
+                        public void completed(final PoolEntry<HttpRoute, ManagedAsyncClientConnection> poolEntry) {
+                            final ManagedAsyncClientConnection connection = poolEntry.getConnection();
+                            if (connection != null) {
+                                if (connection.isOpen()) {
+                                    final ProtocolVersion protocolVersion = connection.getProtocolVersion();
+                                    if (protocolVersion != null && protocolVersion.greaterEquals(HttpVersion.HTTP_2_0)) {
+                                        final TimeValue timeValue = PoolingAsyncClientConnectionManager.this.validateAfterInactivity;
+                                        if (TimeValue.isNonNegative(timeValue) &&
+                                                poolEntry.getUpdated() + timeValue.toMilliseconds() <= System.currentTimeMillis()) {
+                                            connection.submitCommand(new PingCommand(new BasicPingHandler(new Callback<Boolean>() {
+
+                                                @Override
+                                                public void execute(final Boolean result) {
+                                                    if (result == null || !result) {
+                                                        if (LOG.isDebugEnabled()) {
+                                                            LOG.debug("{} connection {} is stale", id, ConnPoolSupport.getId(connection));
+                                                        }
+                                                        poolEntry.discardConnection(CloseMode.IMMEDIATE);
                                                     }
-                                                    poolEntry.discardConnection(CloseMode.IMMEDIATE);
+                                                    leaseCompleted(poolEntry);
                                                 }
-                                                leaseCompleted(poolEntry);
-                                            }
 
-                                        })), Command.Priority.IMMEDIATE);
-                                        return;
+                                            })), Command.Priority.IMMEDIATE);
+                                            return;
+                                        }
                                     }
+                                } else {
+                                    if (LOG.isDebugEnabled()) {
+                                        LOG.debug("{} connection {} is closed", id, ConnPoolSupport.getId(connection));
+                                    }
+                                    poolEntry.discardConnection(CloseMode.IMMEDIATE);
                                 }
-                            } else {
-                                if (LOG.isDebugEnabled()) {
-                                    LOG.debug("{} connection {} is closed", id, ConnPoolSupport.getId(connection));
-                                }
-                                poolEntry.discardConnection(CloseMode.IMMEDIATE);
                             }
+                            leaseCompleted(poolEntry);
                         }
-                        leaseCompleted(poolEntry);
-                    }
 
-                    @Override
-                    public void failed(final Exception ex) {
-                        if (LOG.isDebugEnabled()) {
-                            LOG.debug("{} endpoint lease failed", id);
+                        void leaseCompleted(final PoolEntry<HttpRoute, ManagedAsyncClientConnection> poolEntry) {
+                            final ManagedAsyncClientConnection connection = poolEntry.getConnection();
+                            if (connection != null) {
+                                connection.activate();
+                            }
+                            if (LOG.isDebugEnabled()) {
+                                LOG.debug("{} endpoint leased {}", id, ConnPoolSupport.formatStats(route, state, pool));
+                            }
+                            final AsyncConnectionEndpoint endpoint = new InternalConnectionEndpoint(poolEntry);
+                            if (LOG.isDebugEnabled()) {
+                                LOG.debug("{} acquired {}", id, ConnPoolSupport.getId(endpoint));
+                            }
+                            resultFuture.completed(endpoint);
                         }
-                        resultFuture.failed(ex);
-                    }
 
-                    @Override
-                    public void cancelled() {
-                        if (LOG.isDebugEnabled()) {
-                            LOG.debug("{} endpoint lease cancelled", id);
+                        @Override
+                        public void failed(final Exception ex) {
+                            if (LOG.isDebugEnabled()) {
+                                LOG.debug("{} endpoint lease failed", id);
+                            }
+                            resultFuture.failed(ex);
                         }
-                        resultFuture.cancel();
-                    }
 
-                });
+                        @Override
+                        public void cancelled() {
+                            if (LOG.isDebugEnabled()) {
+                                LOG.debug("{} endpoint lease cancelled", id);
+                            }
+                            resultFuture.cancel();
+                        }
 
-        resultFuture.setDependency(leaseFuture);
-        return resultFuture;
+                    });
+
+            @Override
+            public AsyncConnectionEndpoint get() throws InterruptedException, ExecutionException {
+                return resultFuture.get();
+            }
+
+            @Override
+            public AsyncConnectionEndpoint get(
+                    final long timeout, final TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+                return resultFuture.get(timeout, unit);
+            }
+
+            @Override
+            public boolean cancel(final boolean mayInterruptIfRunning) {
+                return leaseFuture.cancel(mayInterruptIfRunning);
+            }
+
+            @Override
+            public boolean isDone() {
+                return resultFuture.isDone();
+            }
+
+            @Override
+            public boolean isCancelled() {
+                return resultFuture.isCancelled();
+            }
+
+        };
     }
 
     @Override

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/io/TestPoolingHttpClientConnectionManager.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/io/TestPoolingHttpClientConnectionManager.java
@@ -30,7 +30,6 @@ package org.apache.hc.client5.http.impl.io;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -157,27 +156,6 @@ public class TestPoolingHttpClientConnectionManager {
         mgr.release(endpoint1, null, TimeValue.NEG_ONE_MILLISECOND);
 
         Mockito.verify(pool).release(entry, false);
-    }
-
-    @Test(expected= ExecutionException.class)
-    public void testLeaseFutureCancelled() throws Exception {
-        final HttpHost target = new HttpHost("localhost", 80);
-        final HttpRoute route = new HttpRoute(target);
-
-        final PoolEntry<HttpRoute, ManagedHttpClientConnection> entry = new PoolEntry<>(route, TimeValue.NEG_ONE_MILLISECOND);
-        entry.assignConnection(conn);
-
-        Mockito.when(future.isCancelled()).thenReturn(Boolean.TRUE);
-        Mockito.when(future.get(1, TimeUnit.SECONDS)).thenReturn(entry);
-        Mockito.when(pool.lease(
-                Mockito.eq(route),
-                Mockito.eq(null),
-                Mockito.<Timeout>any(),
-                Mockito.<FutureCallback<PoolEntry<HttpRoute, ManagedHttpClientConnection>>>eq(null)))
-                .thenReturn(future);
-
-        final LeaseRequest connRequest1 = mgr.lease("some-id", route, null);
-        connRequest1.get(Timeout.ofSeconds(1));
     }
 
     @Test(expected=TimeoutException.class)


### PR DESCRIPTION
@rschmitt Fundamentally, the core problem here is whose responsibility it is to release a pool entry back to the pool if the lease request simultaneously succeeds and gets cancelled. 

This is not a _final_ fix but merely a concept. I still need to figure the back way of dealing with the problem. I also need to fix the same defect in the async connection manager implementation.

What truly baffles me is how come this issue has never been reported with HttpClient 4.5 given it appears to be equally affected.