### PR TITLE
Don't retry a request for NoRouteToHostException

### DIFF
--- a/httpclient/src/main/java/org/apache/http/impl/client/DefaultHttpRequestRetryHandler.java
+++ b/httpclient/src/main/java/org/apache/http/impl/client/DefaultHttpRequestRetryHandler.java
@@ -30,6 +30,7 @@ package org.apache.http.impl.client;
 import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.net.ConnectException;
+import java.net.NoRouteToHostException;
 import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.Collection;
@@ -103,6 +104,7 @@ public class DefaultHttpRequestRetryHandler implements HttpRequestRetryHandler {
                 InterruptedIOException.class,
                 UnknownHostException.class,
                 ConnectException.class,
+                NoRouteToHostException.class,
                 SSLException.class));
     }
 

--- a/httpclient/src/test/java/org/apache/http/impl/client/TestDefaultHttpRequestRetryHandler.java
+++ b/httpclient/src/test/java/org/apache/http/impl/client/TestDefaultHttpRequestRetryHandler.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.net.NoRouteToHostException;
 import java.net.UnknownHostException;
 
 import org.apache.http.client.methods.HttpUriRequest;
@@ -111,4 +112,21 @@ public class TestDefaultHttpRequestRetryHandler {
         Assert.assertFalse(retryHandler.retryRequest(new ConnectTimeoutException(),3,context));
     }
 
+    /**
+     * Test that {@link DefaultHttpRequestRetryHandler} doesn't retry a request
+     * when {@link java.net.NoRouteToHostException} is thrown when establishing
+     * a connection
+     */
+    @Test
+    public void noRetryForNoRouteToHostException() {
+        final HttpContext context = mock(HttpContext.class);
+        final HttpUriRequest request = mock(HttpUriRequest.class);
+        when(request.isAborted()).thenReturn(false);
+        when(context.getAttribute(HttpCoreContext.HTTP_REQUEST)).thenReturn(request);
+
+        final DefaultHttpRequestRetryHandler retryHandler = new DefaultHttpRequestRetryHandler();
+        Assert.assertFalse("Request was unexpectedly retried for "
+                        + NoRouteToHostException.class.getName() + " exception",
+                retryHandler.retryRequest(new NoRouteToHostException(), 1, context));
+    }
 }


### PR DESCRIPTION
As discussed in the mailing list discussion here[1], the commit here includes `java.net.NoRouteToHostException` to the set of exception types, for which request retries are disabled by default. The commit also has a test case which reproduces the issue and verifies the fix.

I had a look at the `java.net.SocketException` hieararchy. It has `BindException`, `ConnectException`, `NoRouteToHostException` and `PortUnreachableException` as its subclasses. The `BindException` is not relevant while connecting as a client. The `ConnectException` is already included in the default set of non-retriable exception types in this `DefaultHttpRequestRetryHandler` class. The `PortUnreachableException` is for ICMP port unreachable cases, so it isn't relevant in this flow. So that leaves only `NoRouteToHostException` which was missing from this set of non-retriable exception type. Adding this should thus make it behave similar like the `ConnectException` and cover the possible exception types.

P.S: I haven't checked if a similar change is needed in 5.x versions of this library.

[1] https://mail-archives.apache.org/mod_mbox/hc-httpclient-users/202108.mbox/%3C3362ac32-1ced-9aad-36d6-2e0e000168ff%40apache.org%3E