### PR TITLE
HTTPCLIENT-2189 - Cookie and Cache APIs to use Java time primitives.

### DIFF
--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/BasicHttpAsyncCache.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/BasicHttpAsyncCache.java
@@ -26,7 +26,7 @@
  */
 package org.apache.hc.client5.http.impl.cache;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -309,8 +309,8 @@ class BasicHttpAsyncCache implements HttpAsyncCache {
             final HttpRequest request,
             final HttpCacheEntry stale,
             final HttpResponse originResponse,
-            final Date requestSent,
-            final Date responseReceived,
+            final Instant requestSent,
+            final Instant responseReceived,
             final FutureCallback<HttpCacheEntry> callback) {
         if (LOG.isDebugEnabled()) {
             LOG.debug("Update cache entry: {}; {}", host, new RequestLine(request));
@@ -356,8 +356,8 @@ class BasicHttpAsyncCache implements HttpAsyncCache {
             final HttpRequest request,
             final HttpResponse originResponse,
             final Variant variant,
-            final Date requestSent,
-            final Date responseReceived,
+            final Instant requestSent,
+            final Instant responseReceived,
             final FutureCallback<HttpCacheEntry> callback) {
         if (LOG.isDebugEnabled()) {
             LOG.debug("Update variant cache entry: {}; {} / {}", host, new RequestLine(request), variant);
@@ -404,8 +404,8 @@ class BasicHttpAsyncCache implements HttpAsyncCache {
             final HttpRequest request,
             final HttpResponse originResponse,
             final ByteArrayBuffer content,
-            final Date requestSent,
-            final Date responseReceived,
+            final Instant requestSent,
+            final Instant responseReceived,
             final FutureCallback<HttpCacheEntry> callback) {
         if (LOG.isDebugEnabled()) {
             LOG.debug("Create cache entry: {}; {}", host, new RequestLine(request));

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/BasicHttpCache.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/BasicHttpCache.java
@@ -26,7 +26,7 @@
  */
 package org.apache.hc.client5.http.impl.cache;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -204,8 +204,8 @@ class BasicHttpCache implements HttpCache {
             final HttpRequest request,
             final HttpCacheEntry stale,
             final HttpResponse originResponse,
-            final Date requestSent,
-            final Date responseReceived) {
+            final Instant requestSent,
+            final Instant responseReceived) {
         if (LOG.isDebugEnabled()) {
             LOG.debug("Update cache entry: {}; {}", host, new RequestLine(request));
         }
@@ -233,8 +233,8 @@ class BasicHttpCache implements HttpCache {
             final HttpRequest request,
             final HttpResponse originResponse,
             final Variant variant,
-            final Date requestSent,
-            final Date responseReceived) {
+            final Instant requestSent,
+            final Instant responseReceived) {
         if (LOG.isDebugEnabled()) {
             LOG.debug("Update variant cache entry: {}; {} / {}", host, new RequestLine(request), variant);
         }
@@ -263,8 +263,8 @@ class BasicHttpCache implements HttpCache {
             final HttpRequest request,
             final HttpResponse originResponse,
             final ByteArrayBuffer content,
-            final Date requestSent,
-            final Date responseReceived) {
+            final Instant requestSent,
+            final Instant responseReceived) {
         if (LOG.isDebugEnabled()) {
             LOG.debug("Create cache entry: {}; {}", host, new RequestLine(request));
         }

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/ByteArrayCacheEntrySerializer.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/ByteArrayCacheEntrySerializer.java
@@ -90,6 +90,7 @@ public final class ByteArrayCacheEntrySerializer implements HttpCacheEntrySerial
                 Pattern.compile("^(\\[L)?org\\.apache\\.hc\\.(.*)"),
                 Pattern.compile("^(?:\\[+L)?java\\.util\\..*$"),
                 Pattern.compile("^(?:\\[+L)?java\\.lang\\..*$"),
+                Pattern.compile("^(?:\\[+L)?java\\.time\\..*$"), // java 8 time
                 Pattern.compile("^\\[+Z$"), // boolean
                 Pattern.compile("^\\[+B$"), // byte
                 Pattern.compile("^\\[+C$"), // char

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CacheUpdateHandler.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CacheUpdateHandler.java
@@ -26,7 +26,7 @@
  */
 package org.apache.hc.client5.http.impl.cache;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -69,8 +69,8 @@ class CacheUpdateHandler {
             final HttpRequest request,
             final HttpResponse originResponse,
             final ByteArrayBuffer content,
-            final Date requestSent,
-            final Date responseReceived) throws ResourceIOException {
+            final Instant requestSent,
+            final Instant responseReceived) throws ResourceIOException {
         return new HttpCacheEntry(
                 requestSent,
                 responseReceived,
@@ -86,8 +86,8 @@ class CacheUpdateHandler {
     public HttpCacheEntry updateCacheEntry(
             final String requestId,
             final HttpCacheEntry entry,
-            final Date requestDate,
-            final Date responseDate,
+            final Instant requestDate,
+            final Instant responseDate,
             final HttpResponse response) throws ResourceIOException {
         Args.check(response.getCode() == HttpStatus.SC_NOT_MODIFIED,
                 "Response must have 304 status code");
@@ -103,7 +103,7 @@ class CacheUpdateHandler {
                 mergedHeaders,
                 resource);
     }
-
+    @SuppressWarnings("deprecation")
     public HttpCacheEntry updateParentCacheEntry(
             final String requestId,
             final HttpCacheEntry existing,
@@ -122,8 +122,8 @@ class CacheUpdateHandler {
         final Map<String,String> variantMap = new HashMap<>(src.getVariantMap());
         variantMap.put(variantKey, variantCacheKey);
         return new HttpCacheEntry(
-                src.getRequestDate(),
-                src.getResponseDate(),
+                src.getRequestInstant(),
+                src.getResponseInstant(),
                 src.getStatus(),
                 src.getHeaders(),
                 resource,

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachedHttpResponseGenerator.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachedHttpResponseGenerator.java
@@ -27,7 +27,6 @@
 package org.apache.hc.client5.http.impl.cache;
 
 import java.time.Instant;
-import java.util.Date;
 
 import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
 import org.apache.hc.client5.http.cache.HeaderConstants;
@@ -65,7 +64,7 @@ class CachedHttpResponseGenerator {
      * @return {@link SimpleHttpResponse} constructed response
      */
     SimpleHttpResponse generateResponse(final HttpRequest request, final HttpCacheEntry entry) throws ResourceIOException {
-        final Date now = new Date();
+        final Instant now =Instant.now();
         final SimpleHttpResponse response = new SimpleHttpResponse(entry.getStatus());
         response.setVersion(HttpVersion.DEFAULT);
 

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachedResponseSuitabilityChecker.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachedResponseSuitabilityChecker.java
@@ -27,7 +27,6 @@
 package org.apache.hc.client5.http.impl.cache;
 
 import java.time.Instant;
-import java.util.Date;
 import java.util.Iterator;
 
 import org.apache.hc.client5.http.cache.HeaderConstants;
@@ -71,7 +70,7 @@ class CachedResponseSuitabilityChecker {
         this(new CacheValidityPolicy(), config);
     }
 
-    private boolean isFreshEnough(final HttpCacheEntry entry, final HttpRequest request, final Date now) {
+    private boolean isFreshEnough(final HttpCacheEntry entry, final HttpRequest request, final Instant now) {
         if (validityStrategy.isResponseFresh(entry, now)) {
             return true;
         }
@@ -142,7 +141,7 @@ class CachedResponseSuitabilityChecker {
      *            Right now in time
      * @return boolean yes/no answer
      */
-    public boolean canCachedResponseBeUsed(final HttpHost host, final HttpRequest request, final HttpCacheEntry entry, final Date now) {
+    public boolean canCachedResponseBeUsed(final HttpHost host, final HttpRequest request, final HttpCacheEntry entry, final Instant now) {
         if (!isFreshEnough(entry, request, now)) {
             LOG.debug("Cache entry is not fresh enough");
             return false;
@@ -274,13 +273,12 @@ class CachedResponseSuitabilityChecker {
      * @param now right NOW in time
      * @return {@code true} if the request matches all conditionals
      */
-    public boolean allConditionalsMatch(final HttpRequest request, final HttpCacheEntry entry, final Date now) {
+    public boolean allConditionalsMatch(final HttpRequest request, final HttpCacheEntry entry, final Instant now) {
         final boolean hasEtagValidator = hasSupportedEtagValidator(request);
         final boolean hasLastModifiedValidator = hasSupportedLastModifiedValidator(request);
 
         final boolean etagValidatorMatches = (hasEtagValidator) && etagValidatorMatches(request, entry);
-        final boolean lastModifiedValidatorMatches = (hasLastModifiedValidator) && lastModifiedValidatorMatches(request, entry,
-                DateUtils.toInstant(now));
+        final boolean lastModifiedValidatorMatches = (hasLastModifiedValidator) && lastModifiedValidatorMatches(request, entry, now);
 
         if ((hasEtagValidator && hasLastModifiedValidator)
             && !(etagValidatorMatches && lastModifiedValidatorMatches)) {

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingExecBase.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingExecBase.java
@@ -27,7 +27,7 @@
 package org.apache.hc.client5.http.impl.cache;
 
 import java.io.IOException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -183,7 +183,7 @@ public class CachingExecBase {
             final HttpRequest request,
             final HttpContext context,
             final HttpCacheEntry entry,
-            final Date now) throws ResourceIOException {
+            final Instant now) throws ResourceIOException {
         final SimpleHttpResponse cachedResponse;
         if (request.containsHeader(HeaderConstants.IF_NONE_MATCH)
                 || request.containsHeader(HeaderConstants.IF_MODIFIED_SINCE)) {
@@ -202,7 +202,7 @@ public class CachingExecBase {
             final HttpRequest request,
             final HttpContext context,
             final HttpCacheEntry entry,
-            final Date now) throws IOException {
+            final Instant now) throws IOException {
         if (staleResponseNotAllowed(request, entry, now)) {
             return generateGatewayTimeout(context);
         } else {
@@ -226,7 +226,7 @@ public class CachingExecBase {
         return cachedResponse;
     }
 
-    boolean staleResponseNotAllowed(final HttpRequest request, final HttpCacheEntry entry, final Date now) {
+    boolean staleResponseNotAllowed(final HttpRequest request, final HttpCacheEntry entry, final Instant now) {
         return validityPolicy.mustRevalidate(entry)
             || (cacheConfig.isSharedCache() && validityPolicy.proxyRevalidate(entry))
             || explicitFreshnessRequest(request, entry, now);
@@ -244,7 +244,7 @@ public class CachingExecBase {
         return true;
     }
 
-    boolean explicitFreshnessRequest(final HttpRequest request, final HttpCacheEntry entry, final Date now) {
+    boolean explicitFreshnessRequest(final HttpRequest request, final HttpCacheEntry entry, final Instant now) {
         final Iterator<HeaderElement> it = MessageSupport.iterate(request, HeaderConstants.CACHE_CONTROL);
         while (it.hasNext()) {
             final HeaderElement elt = it.next();
@@ -313,8 +313,8 @@ public class CachingExecBase {
         return SUPPORTS_RANGE_AND_CONTENT_RANGE_HEADERS;
     }
 
-    Date getCurrentDate() {
-        return new Date();
+    Instant getCurrentDate() {
+        return Instant.now();
     }
 
     boolean clientRequestsOurOptions(final HttpRequest request) {
@@ -340,7 +340,7 @@ public class CachingExecBase {
 
     boolean shouldSendNotModifiedResponse(final HttpRequest request, final HttpCacheEntry responseEntry) {
         return (suitabilityChecker.isConditional(request)
-                && suitabilityChecker.allConditionalsMatch(request, responseEntry, new Date()));
+                && suitabilityChecker.allConditionalsMatch(request, responseEntry, Instant.now()));
     }
 
     boolean staleIfErrorAppliesTo(final int statusCode) {

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/HttpAsyncCache.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/HttpAsyncCache.java
@@ -26,7 +26,7 @@
  */
 package org.apache.hc.client5.http.impl.cache;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.Map;
 
 import org.apache.hc.client5.http.cache.HttpCacheEntry;
@@ -79,8 +79,8 @@ interface HttpAsyncCache {
             HttpRequest request,
             HttpResponse originResponse,
             ByteArrayBuffer content,
-            Date requestSent,
-            Date responseReceived,
+            Instant requestSent,
+            Instant responseReceived,
             FutureCallback<HttpCacheEntry> callback);
 
     /**
@@ -91,8 +91,8 @@ interface HttpAsyncCache {
             HttpRequest request,
             HttpCacheEntry stale,
             HttpResponse originResponse,
-            Date requestSent,
-            Date responseReceived,
+            Instant requestSent,
+            Instant responseReceived,
             FutureCallback<HttpCacheEntry> callback);
 
     /**
@@ -104,8 +104,8 @@ interface HttpAsyncCache {
             HttpRequest request,
             HttpResponse originResponse,
             Variant variant,
-            Date requestSent,
-            Date responseReceived,
+            Instant requestSent,
+            Instant responseReceived,
             FutureCallback<HttpCacheEntry> callback);
 
     /**

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/HttpCache.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/HttpCache.java
@@ -26,7 +26,7 @@
  */
 package org.apache.hc.client5.http.impl.cache;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.Map;
 
 import org.apache.hc.client5.http.cache.HttpCacheEntry;
@@ -73,8 +73,8 @@ interface HttpCache {
             HttpRequest request,
             HttpResponse originResponse,
             ByteArrayBuffer content,
-            Date requestSent,
-            Date responseReceived);
+            Instant requestSent,
+            Instant responseReceived);
 
     /**
      * Update a {@link HttpCacheEntry} using a 304 {@link HttpResponse}.
@@ -84,8 +84,8 @@ interface HttpCache {
             HttpRequest request,
             HttpCacheEntry stale,
             HttpResponse originResponse,
-            Date requestSent,
-            Date responseReceived);
+            Instant requestSent,
+            Instant responseReceived);
 
     /**
      * Update a specific {@link HttpCacheEntry} representing a cached variant
@@ -96,8 +96,8 @@ interface HttpCache {
             HttpRequest request,
             HttpResponse originResponse,
             Variant variant,
-            Date requestSent,
-            Date responseReceived);
+            Instant requestSent,
+            Instant responseReceived);
 
     /**
      * Specifies cache should reuse the given cached variant to satisfy

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/ResponseProtocolCompliance.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/ResponseProtocolCompliance.java
@@ -29,7 +29,6 @@ package org.apache.hc.client5.http.impl.cache;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 import org.apache.hc.client5.http.ClientProtocolException;
@@ -101,8 +100,8 @@ class ResponseProtocolCompliance {
         boolean modified = false;
         for(final Header h : warningHeaders) {
             for(final WarningValue wv : WarningValue.getWarningValues(h)) {
-                final Date warnDate = wv.getWarnDate();
-                if (warnDate == null || warnDate.equals(responseDate)) {
+                final Instant warnInstant = wv.getWarnDate();
+                if (warnInstant == null || warnInstant.equals(responseDate)) {
                     newWarningHeaders.add(new BasicHeader(HeaderConstants.WARNING,wv.toString()));
                 } else {
                     modified = true;

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/WarningValue.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/WarningValue.java
@@ -26,8 +26,8 @@
  */
 package org.apache.hc.client5.http.impl.cache;
 
+import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -48,7 +48,7 @@ class WarningValue {
     private int warnCode;
     private String warnAgent;
     private String warnText;
-    private Date warnDate;
+    private Instant warnDate;
 
     WarningValue(final String s) {
         this(s, 0);
@@ -265,7 +265,7 @@ class WarningValue {
             parseError();
         }
         offs += m.end();
-        warnDate = DateUtils.toDate(DateUtils.parseStandardDate(src.substring(curr+1,offs-1)));
+        warnDate = DateUtils.parseStandardDate(src.substring(curr+1,offs-1));
     }
 
     /*
@@ -342,9 +342,9 @@ class WarningValue {
     /** Returns the date and time when this warning was added, or
      * {@code null} if a warning date was not supplied in the
      * header.
-     * @return {@link Date}
+     * @return {@link Instant}
      */
-    public Date getWarnDate() { return warnDate; }
+    public Instant getWarnDate() { return warnDate; }
 
     /** Formats a {@code WarningValue} as a {@link String}
      * suitable for including in a header. For example, you can:
@@ -359,7 +359,7 @@ class WarningValue {
     public String toString() {
         if (warnDate != null) {
             return String.format("%d %s %s \"%s\"", warnCode,
-                    warnAgent, warnText, DateUtils.formatStandardDate(DateUtils.toInstant(warnDate)));
+                    warnAgent, warnText, DateUtils.formatStandardDate(warnDate));
         } else {
             return String.format("%d %s %s", warnCode, warnAgent, warnText);
         }

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/HttpByteArrayCacheEntrySerializerTestUtils.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/HttpByteArrayCacheEntrySerializerTestUtils.java
@@ -34,8 +34,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.Collections;
-import java.util.Date;
 import java.util.Map;
 
 import org.apache.hc.client5.http.cache.HttpCacheEntry;
@@ -59,8 +59,8 @@ class HttpByteArrayCacheEntrySerializerTestUtils {
      */
     static class HttpCacheStorageEntryTestTemplate {
         Resource resource;
-        Date requestDate;
-        Date responseDate;
+        Instant requestDate;
+        Instant responseDate;
         int responseCode;
         Header[] responseHeaders;
         Map<String, String> variantMap;
@@ -120,8 +120,8 @@ class HttpByteArrayCacheEntrySerializerTestUtils {
     private static final HttpCacheStorageEntryTestTemplate DEFAULT_HTTP_CACHE_STORAGE_ENTRY_TEST_TEMPLATE = new HttpCacheStorageEntryTestTemplate();
     static {
         DEFAULT_HTTP_CACHE_STORAGE_ENTRY_TEST_TEMPLATE.resource = new HeapResource("Hello World".getBytes(StandardCharsets.UTF_8));
-        DEFAULT_HTTP_CACHE_STORAGE_ENTRY_TEST_TEMPLATE.requestDate = new Date(165214800000L);
-        DEFAULT_HTTP_CACHE_STORAGE_ENTRY_TEST_TEMPLATE.responseDate = new Date(2611108800000L);
+        DEFAULT_HTTP_CACHE_STORAGE_ENTRY_TEST_TEMPLATE.requestDate = Instant.ofEpochMilli(165214800000L);
+        DEFAULT_HTTP_CACHE_STORAGE_ENTRY_TEST_TEMPLATE.responseDate = Instant.ofEpochMilli(2611108800000L);
         DEFAULT_HTTP_CACHE_STORAGE_ENTRY_TEST_TEMPLATE.responseCode = 200;
         DEFAULT_HTTP_CACHE_STORAGE_ENTRY_TEST_TEMPLATE.responseHeaders = new Header[]{
                 new BasicHeader("Content-type", "text/html"),
@@ -220,8 +220,9 @@ class HttpByteArrayCacheEntrySerializerTestUtils {
         final HttpCacheEntry expectedContent = expected.getContent();
         final HttpCacheEntry actualContent = actual.getContent();
 
-        assertEquals(expectedContent.getRequestDate(), actualContent.getRequestDate());
-        assertEquals(expectedContent.getResponseDate(), actualContent.getResponseDate());
+        assertEquals(expectedContent.getRequestInstant(), actualContent.getRequestInstant());
+        assertEquals(expectedContent.getResponseInstant(), actualContent.getResponseInstant());
+
         assertEquals(expectedContent.getStatus(), actualContent.getStatus());
 
         assertArrayEquals(expectedContent.getVariantMap().keySet().toArray(), actualContent.getVariantMap().keySet().toArray());

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/HttpCacheEntryMatcher.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/HttpCacheEntryMatcher.java
@@ -26,8 +26,8 @@
  */
 package org.apache.hc.client5.http.impl.cache;
 
+import java.time.Instant;
 import java.util.Arrays;
-import java.util.Date;
 
 import org.apache.hc.client5.http.cache.HttpCacheEntry;
 import org.apache.hc.client5.http.cache.Resource;
@@ -57,16 +57,17 @@ public class HttpCacheEntryMatcher extends BaseMatcher<HttpCacheEntry> {
                 if (expectedStatus != otherStatus) {
                     return false;
                 }
-                final Date expectedRequestDate = expectedValue.getRequestDate();
-                final Date otherRequestDate = otherValue.getRequestDate();
-                if (!LangUtils.equals(expectedRequestDate, otherRequestDate)) {
+                final Instant expectedRequestInstant = expectedValue.getRequestInstant();
+                final Instant otherRequestInstant = otherValue.getRequestInstant();
+                if (!LangUtils.equals(expectedRequestInstant, otherRequestInstant)) {
                     return false;
                 }
-                final Date expectedResponseDate = expectedValue.getResponseDate();
-                final Date otherResponseDate = otherValue.getResponseDate();
-                if (!LangUtils.equals(expectedResponseDate, otherResponseDate)) {
+                final Instant expectedResponseInstant = expectedValue.getResponseInstant();
+                final Instant otherResponseInstant = otherValue.getResponseInstant();
+                if (!LangUtils.equals(expectedResponseInstant, otherResponseInstant)) {
                     return false;
                 }
+
                 final Header[] expectedHeaders = expectedValue.getHeaders();
                 final Header[] otherHeaders = otherValue.getHeaders();
                 if (expectedHeaders.length != otherHeaders.length) {

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/HttpTestUtils.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/HttpTestUtils.java
@@ -29,7 +29,6 @@ package org.apache.hc.client5.http.impl.cache;
 import java.io.InputStream;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -268,7 +267,7 @@ public class HttpTestUtils {
         return makeCacheEntry(now, now, getStockHeaders(now),
                 getRandomBytes(128), variantMap);
     }
-
+    @SuppressWarnings("deprecation")
     public static HttpCacheEntry makeCacheEntry(final Instant requestDate,
             final Instant responseDate, final Header[] headers, final byte[] bytes,
             final Map<String,String> variantMap) {
@@ -293,31 +292,6 @@ public class HttpTestUtils {
     public static HttpCacheEntry makeCacheEntry() {
         final Instant now = Instant.now();
         return makeCacheEntry(now, now);
-    }
-
-    public static HttpCacheEntry makeCacheEntryWithNoRequestMethodOrEntity(final Header... headers) {
-        final Date now = new Date();
-        return new HttpCacheEntry(now, now, HttpStatus.SC_OK, headers, null, null);
-    }
-
-    public static HttpCacheEntry makeCacheEntryWithNoRequestMethod(final Header... headers) {
-        final Date now = new Date();
-        return new HttpCacheEntry(now, now, HttpStatus.SC_OK, headers, new HeapResource(getRandomBytes(128)), null);
-    }
-
-    public static HttpCacheEntry make204CacheEntryWithNoRequestMethod(final Header... headers) {
-        final Date now = new Date();
-        return new HttpCacheEntry(now, now, HttpStatus.SC_NO_CONTENT, headers, null, null);
-    }
-
-    public static HttpCacheEntry makeHeadCacheEntry(final Header... headers) {
-        final Date now = new Date();
-        return new HttpCacheEntry(now, now, HttpStatus.SC_OK, headers, null, null);
-    }
-
-    public static HttpCacheEntry makeHeadCacheEntryWithNoRequestMethod(final Header... headers) {
-        final Date now = new Date();
-        return new HttpCacheEntry(now, now, HttpStatus.SC_OK, headers, null, null);
     }
 
     public static ClassicHttpResponse make200Response() {
@@ -372,5 +346,31 @@ public class HttpTestUtils {
         variants.put(key, value);
 
         return variants;
+    }
+
+
+    public static HttpCacheEntry makeCacheEntryWithNoRequestMethodOrEntity(final Header... headers) {
+        final Instant now = Instant.now();
+        return new HttpCacheEntry(now, now, HttpStatus.SC_OK, headers, null, null);
+    }
+
+    public static HttpCacheEntry makeCacheEntryWithNoRequestMethod(final Header... headers) {
+        final Instant now = Instant.now();
+        return new HttpCacheEntry(now, now, HttpStatus.SC_OK, headers, new HeapResource(getRandomBytes(128)), null);
+    }
+
+    public static HttpCacheEntry make204CacheEntryWithNoRequestMethod(final Header... headers) {
+        final Instant now = Instant.now();
+        return new HttpCacheEntry(now, now, HttpStatus.SC_NO_CONTENT, headers, null, null);
+    }
+
+    public static HttpCacheEntry makeHeadCacheEntry(final Header... headers) {
+        final Instant now = Instant.now();
+        return new HttpCacheEntry(now, now, HttpStatus.SC_OK, headers, null, null);
+    }
+
+    public static HttpCacheEntry makeHeadCacheEntryWithNoRequestMethod(final Header... headers) {
+        final Instant now = Instant.now();
+        return new HttpCacheEntry(now, now, HttpStatus.SC_OK, headers, null, null);
     }
 }

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestBasicHttpCache.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestBasicHttpCache.java
@@ -34,7 +34,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.time.Instant;
-import java.util.Date;
 import java.util.Map;
 
 import org.apache.hc.client5.http.cache.HeaderConstants;
@@ -231,7 +230,7 @@ public class TestBasicHttpCache {
         origResponse.setHeader("Vary", "Accept-Encoding");
         origResponse.setHeader("Content-Encoding","gzip");
 
-        impl.createCacheEntry(host, origRequest, origResponse, buf, new Date(), new Date());
+        impl.createCacheEntry(host, origRequest, origResponse, buf, Instant.now(), Instant.now());
 
         final HttpRequest request = new HttpGet("http://foo.example.com/bar");
         final HttpCacheEntry result = impl.getCacheEntry(host, request);
@@ -253,7 +252,7 @@ public class TestBasicHttpCache {
         origResponse.setHeader("Vary", "Accept-Encoding");
         origResponse.setHeader("Content-Encoding","gzip");
 
-        impl.createCacheEntry(host, origRequest, origResponse, buf, new Date(), new Date());
+        impl.createCacheEntry(host, origRequest, origResponse, buf, Instant.now(), Instant.now());
 
         final HttpRequest request = new HttpGet("http://foo.example.com/bar");
         request.setHeader("Accept-Encoding","gzip");
@@ -297,8 +296,8 @@ public class TestBasicHttpCache {
         resp2.setHeader("Content-Encoding","gzip");
         resp2.setHeader("Vary", "Accept-Encoding");
 
-        impl.createCacheEntry(host, req1, resp1, null, new Date(), new Date());
-        impl.createCacheEntry(host, req2, resp2, null, new Date(), new Date());
+        impl.createCacheEntry(host, req1, resp1, null, Instant.now(), Instant.now());
+        impl.createCacheEntry(host, req2, resp2, null, Instant.now(), Instant.now());
 
         final Map<String,Variant> variants = impl.getVariantCacheEntriesWithEtags(host, req1);
 

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestByteArrayCacheEntrySerializer.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestByteArrayCacheEntrySerializer.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -61,7 +62,12 @@ public class TestByteArrayCacheEntrySerializer {
     }
 
     @Test
-    public void canSerializeEntriesWithVariantMaps() throws Exception {
+    public void canSerializeEntriesWithVariantMapsDeprecatedConstructor() throws Exception {
+        readWriteVerify(makeCacheEntryDeprecatedConstructorWithVariantMap("somekey"));
+    }
+
+    @Test
+    public void canSerializeEntriesWithVariantMapsAndInstant() throws Exception {
         readWriteVerify(makeCacheEntryWithVariantMap("somekey"));
     }
 
@@ -83,6 +89,11 @@ public class TestByteArrayCacheEntrySerializer {
     @Test
     public void isAllowedClassNameDataTrue() {
         assertIsAllowedClassNameTrue(Date.class.getName());
+    }
+
+    @Test
+    public void isAllowedClassNameInstantTrue() {
+        assertIsAllowedClassNameTrue(Instant.class.getName());
     }
 
     @Test
@@ -257,6 +268,27 @@ public class TestByteArrayCacheEntrySerializer {
         assertThat(readEntry.getContent(), HttpCacheEntryMatcher.equivalent(writeEntry.getContent()));
     }
 
+
+    private HttpCacheStorageEntry makeCacheEntryDeprecatedConstructorWithVariantMap(final String key) {
+        final Header[] headers = new Header[5];
+        for (int i = 0; i < headers.length; i++) {
+            headers[i] = new BasicHeader("header" + i, "value" + i);
+        }
+        final String body = "Lorem ipsum dolor sit amet";
+
+        final Map<String,String> variantMap = new HashMap<>();
+        variantMap.put("test variant 1","true");
+        variantMap.put("test variant 2","true");
+        final HttpCacheEntry cacheEntry = new HttpCacheEntry(
+                Instant.now(),
+                Instant.now(),
+                HttpStatus.SC_OK,
+                headers,
+                new HeapResource(body.getBytes(StandardCharsets.UTF_8)), variantMap);
+
+        return new HttpCacheStorageEntry(key, cacheEntry);
+    }
+
     private HttpCacheStorageEntry makeCacheEntryWithVariantMap(final String key) {
         final Header[] headers = new Header[5];
         for (int i = 0; i < headers.length; i++) {
@@ -268,8 +300,8 @@ public class TestByteArrayCacheEntrySerializer {
         variantMap.put("test variant 1","true");
         variantMap.put("test variant 2","true");
         final HttpCacheEntry cacheEntry = new HttpCacheEntry(
-                new Date(),
-                new Date(),
+                Instant.now(),
+                Instant.now(),
                 HttpStatus.SC_OK,
                 headers,
                 new HeapResource(body.getBytes(StandardCharsets.UTF_8)), variantMap);

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestCacheUpdateHandler.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestCacheUpdateHandler.java
@@ -34,7 +34,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.time.Instant;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -83,7 +82,7 @@ public class TestCacheUpdateHandler {
             throws IOException {
         entry = HttpTestUtils.makeCacheEntry();
         final HttpCacheEntry newEntry = impl.updateCacheEntry(null, entry,
-                DateUtils.toDate(requestDate), DateUtils.toDate(responseDate), response);
+                requestDate, responseDate, response);
         assertNotSame(newEntry, entry);
     }
 
@@ -96,7 +95,7 @@ public class TestCacheUpdateHandler {
         response.setHeaders();
 
         final HttpCacheEntry updatedEntry = impl.updateCacheEntry(null, entry,
-                new Date(), new Date(), response);
+                Instant.now(), Instant.now(), response);
 
          assertThat(updatedEntry, ContainsHeaderMatcher.contains("Date", DateUtils.formatStandardDate(responseDate)));
          assertThat(updatedEntry, ContainsHeaderMatcher.contains("ETag", "\"etag\""));
@@ -116,7 +115,7 @@ public class TestCacheUpdateHandler {
                 new BasicHeader("Cache-Control", "public"));
 
         final HttpCacheEntry updatedEntry = impl.updateCacheEntry(null, entry,
-                new Date(), new Date(), response);
+                Instant.now(), Instant.now(), response);
 
          assertThat(updatedEntry, ContainsHeaderMatcher.contains("Date", DateUtils.formatStandardDate(requestDate)));
          assertThat(updatedEntry, ContainsHeaderMatcher.contains("ETag", "\"etag\""));
@@ -136,7 +135,7 @@ public class TestCacheUpdateHandler {
                 new BasicHeader("Cache-Control", "public"));
 
         final HttpCacheEntry updatedEntry = impl.updateCacheEntry(null, entry,
-                new Date(), new Date(), response);
+                Instant.now(), Instant.now(), response);
 
          assertThat(updatedEntry, ContainsHeaderMatcher.contains("Date", DateUtils.formatStandardDate(requestDate)));
          assertThat(updatedEntry, ContainsHeaderMatcher.contains("ETag", "\"etag\""));
@@ -154,8 +153,8 @@ public class TestCacheUpdateHandler {
         entry = HttpTestUtils.makeCacheEntry(twoSecondsAgo, now, headers);
         response.setHeader("Date", DateUtils.formatStandardDate(tenSecondsAgo));
         response.setHeader("ETag", "\"old-etag\"");
-        final HttpCacheEntry result = impl.updateCacheEntry("A", entry, new Date(),
-                new Date(), response);
+        final HttpCacheEntry result = impl.updateCacheEntry("A", entry, Instant.now(),
+                Instant.now(), response);
          assertThat(result, ContainsHeaderMatcher.contains("Date", DateUtils.formatStandardDate(oneSecondAgo)));
          assertThat(result, ContainsHeaderMatcher.contains("ETag", "\"new-etag\""));
     }
@@ -165,10 +164,10 @@ public class TestCacheUpdateHandler {
             throws IOException {
         entry = HttpTestUtils.makeCacheEntry(tenSecondsAgo, eightSecondsAgo);
         final HttpCacheEntry updated = impl.updateCacheEntry(null, entry,
-                DateUtils.toDate(twoSecondsAgo), DateUtils.toDate(oneSecondAgo), response);
+                twoSecondsAgo, oneSecondAgo, response);
 
-        assertEquals(DateUtils.toDate(twoSecondsAgo), updated.getRequestDate());
-        assertEquals(DateUtils.toDate(oneSecondAgo), updated.getResponseDate());
+        assertEquals(twoSecondsAgo, updated.getRequestInstant());
+        assertEquals(oneSecondAgo, updated.getResponseInstant());
     }
 
     @Test
@@ -182,7 +181,7 @@ public class TestCacheUpdateHandler {
         response.setHeader("ETag", "\"new\"");
         response.setHeader("Date", DateUtils.formatStandardDate(twoSecondsAgo));
         final HttpCacheEntry updated = impl.updateCacheEntry(null, entry,
-                DateUtils.toDate(twoSecondsAgo), DateUtils.toDate(oneSecondAgo), response);
+                twoSecondsAgo, oneSecondAgo, response);
 
         assertEquals(0, updated.getHeaders("Warning").length);
     }
@@ -197,7 +196,7 @@ public class TestCacheUpdateHandler {
         response.setHeader("ETag", "\"new\"");
         response.setHeader("Date", DateUtils.formatStandardDate(twoSecondsAgo));
         final HttpCacheEntry updated = impl.updateCacheEntry(null, entry,
-                DateUtils.toDate(twoSecondsAgo), DateUtils.toDate(oneSecondAgo), response);
+                twoSecondsAgo, oneSecondAgo, response);
 
         assertEquals("\"new\"", updated.getFirstHeader("ETag").getValue());
     }
@@ -211,8 +210,8 @@ public class TestCacheUpdateHandler {
         entry = HttpTestUtils.makeCacheEntry(tenSecondsAgo, eightSecondsAgo, headers);
         response.setHeader("ETag", "\"new\"");
         response.setHeader("Date", "bad-date");
-        final HttpCacheEntry updated = impl.updateCacheEntry(null, entry,
-                DateUtils.toDate(twoSecondsAgo), DateUtils.toDate(oneSecondAgo), response);
+        final HttpCacheEntry updated = impl.updateCacheEntry(null, entry, twoSecondsAgo,
+                oneSecondAgo, response);
 
         assertEquals("\"new\"", updated.getFirstHeader("ETag").getValue());
     }
@@ -222,7 +221,7 @@ public class TestCacheUpdateHandler {
         entry = HttpTestUtils.makeCacheEntry();
         response = new BasicHttpResponse(HttpStatus.SC_OK, "OK");
         try {
-            impl.updateCacheEntry("A", entry, new Date(), new Date(),
+            impl.updateCacheEntry("A", entry, Instant.now(), Instant.now(),
                     response);
             fail("should have thrown exception");
         } catch (final IllegalArgumentException expected) {
@@ -261,7 +260,7 @@ public class TestCacheUpdateHandler {
                 new BasicHeader("Content-Encoding", "gzip"));
 
         final HttpCacheEntry updatedEntry = impl.updateCacheEntry(null, entry,
-                new Date(), new Date(), response);
+                Instant.now(), Instant.now(), response);
 
         final Header[] updatedHeaders = updatedEntry.getHeaders();
         headersContain(updatedHeaders, "Content-Encoding", "identity");
@@ -281,7 +280,7 @@ public class TestCacheUpdateHandler {
                 new BasicHeader("Content-Length", "0"));
 
         final HttpCacheEntry updatedEntry = impl.updateCacheEntry(null, entry,
-                new Date(), new Date(), response);
+                Instant.now(), Instant.now(), response);
 
         final Header[] updatedHeaders = updatedEntry.getHeaders();
         headersContain(updatedHeaders, "Transfer-Encoding", "chunked");

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestCacheValidityPolicy.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestCacheValidityPolicy.java
@@ -33,7 +33,6 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Instant;
-import java.util.Date;
 
 import org.apache.hc.client5.http.cache.HttpCacheEntry;
 import org.apache.hc.client5.http.utils.DateUtils;
@@ -141,7 +140,7 @@ public class TestCacheValidityPolicy {
     @Test
     public void testResidentTimeSecondsIsTimeSinceResponseTime() {
         final HttpCacheEntry entry = HttpTestUtils.makeCacheEntry(now, sixSecondsAgo);
-        assertEquals(TimeValue.ofSeconds(6), impl.getResidentTime(entry, DateUtils.toDate(now)));
+        assertEquals(TimeValue.ofSeconds(6), impl.getResidentTime(entry, now));
     }
 
     @Test
@@ -153,11 +152,11 @@ public class TestCacheValidityPolicy {
                 return TimeValue.ofSeconds(11);
             }
             @Override
-            protected TimeValue getResidentTime(final HttpCacheEntry ent, final Date d) {
+            protected TimeValue getResidentTime(final HttpCacheEntry ent, final Instant d) {
                 return TimeValue.ofSeconds(17);
             }
         };
-        assertEquals(TimeValue.ofSeconds(28), impl.getCurrentAge(entry, new Date()));
+        assertEquals(TimeValue.ofSeconds(28), impl.getCurrentAge(entry, Instant.now()));
     }
 
     @Test
@@ -250,9 +249,9 @@ public class TestCacheValidityPolicy {
         final HttpCacheEntry entry = HttpTestUtils.makeCacheEntry();
         impl = new CacheValidityPolicy() {
             @Override
-            public TimeValue getCurrentAge(final HttpCacheEntry e, final Date d) {
+            public TimeValue getCurrentAge(final HttpCacheEntry e, final Instant d) {
                 assertSame(entry, e);
-                assertEquals(DateUtils.toDate(now), d);
+                assertEquals(now, d);
                 return TimeValue.ofSeconds(6);
             }
             @Override
@@ -261,7 +260,7 @@ public class TestCacheValidityPolicy {
                 return TimeValue.ofSeconds(10);
             }
         };
-        assertTrue(impl.isResponseFresh(entry, DateUtils.toDate(now)));
+        assertTrue(impl.isResponseFresh(entry, now));
     }
 
     @Test
@@ -269,8 +268,8 @@ public class TestCacheValidityPolicy {
         final HttpCacheEntry entry = HttpTestUtils.makeCacheEntry();
         impl = new CacheValidityPolicy() {
             @Override
-            public TimeValue getCurrentAge(final HttpCacheEntry e, final Date d) {
-                assertEquals(DateUtils.toDate(now), d);
+            public TimeValue getCurrentAge(final HttpCacheEntry e, final Instant d) {
+                assertEquals(now, d);
                 assertSame(entry, e);
                 return TimeValue.ofSeconds(6);
             }
@@ -280,7 +279,7 @@ public class TestCacheValidityPolicy {
                 return TimeValue.ofSeconds(6);
             }
         };
-        assertFalse(impl.isResponseFresh(entry, DateUtils.toDate(now)));
+        assertFalse(impl.isResponseFresh(entry, now));
     }
 
     @Test
@@ -288,8 +287,8 @@ public class TestCacheValidityPolicy {
         final HttpCacheEntry entry = HttpTestUtils.makeCacheEntry();
         impl = new CacheValidityPolicy() {
             @Override
-            public TimeValue getCurrentAge(final HttpCacheEntry e, final Date d) {
-                assertEquals(DateUtils.toDate(now), d);
+            public TimeValue getCurrentAge(final HttpCacheEntry e, final Instant d) {
+                assertEquals(now, d);
                 assertSame(entry, e);
                 return TimeValue.ofSeconds(10);
             }
@@ -299,7 +298,7 @@ public class TestCacheValidityPolicy {
                 return TimeValue.ofSeconds(6);
             }
         };
-        assertFalse(impl.isResponseFresh(entry, DateUtils.toDate(now)));
+        assertFalse(impl.isResponseFresh(entry, now));
     }
 
     @Test
@@ -421,7 +420,7 @@ public class TestCacheValidityPolicy {
         };
         final HttpCacheEntry entry = HttpTestUtils.makeCacheEntry(now, now, headers);
         final HttpRequest req = new BasicHttpRequest("GET","/");
-        assertTrue(impl.mayReturnStaleIfError(req, entry, DateUtils.toDate(now)));
+        assertTrue(impl.mayReturnStaleIfError(req, entry, now));
     }
 
     @Test
@@ -433,7 +432,7 @@ public class TestCacheValidityPolicy {
         final HttpCacheEntry entry = HttpTestUtils.makeCacheEntry(now, now, headers);
         final HttpRequest req = new BasicHttpRequest("GET","/");
         req.setHeader("Cache-Control","stale-if-error=15");
-        assertTrue(impl.mayReturnStaleIfError(req, entry, DateUtils.toDate(now)));
+        assertTrue(impl.mayReturnStaleIfError(req, entry, now));
     }
 
     @Test
@@ -444,7 +443,7 @@ public class TestCacheValidityPolicy {
         };
         final HttpCacheEntry entry = HttpTestUtils.makeCacheEntry(now, now, headers);
         final HttpRequest req = new BasicHttpRequest("GET","/");
-        assertFalse(impl.mayReturnStaleIfError(req, entry, DateUtils.toDate(now)));
+        assertFalse(impl.mayReturnStaleIfError(req, entry, now));
     }
 
     @Test
@@ -456,7 +455,7 @@ public class TestCacheValidityPolicy {
         final HttpCacheEntry entry = HttpTestUtils.makeCacheEntry(now, now, headers);
         final HttpRequest req = new BasicHttpRequest("GET","/");
         req.setHeader("Cache-Control","stale-if-error=1");
-        assertFalse(impl.mayReturnStaleIfError(req, entry, DateUtils.toDate(now)));
+        assertFalse(impl.mayReturnStaleIfError(req, entry, now));
     }
 
     @Test
@@ -464,7 +463,7 @@ public class TestCacheValidityPolicy {
         final Header[] headers = new Header[] { new BasicHeader("Cache-control", "public") };
         final HttpCacheEntry entry = HttpTestUtils.makeCacheEntry(headers);
 
-        assertFalse(impl.mayReturnStaleWhileRevalidating(entry, DateUtils.toDate(now)));
+        assertFalse(impl.mayReturnStaleWhileRevalidating(entry, now));
     }
 
     @Test
@@ -475,7 +474,7 @@ public class TestCacheValidityPolicy {
         };
         final HttpCacheEntry entry = HttpTestUtils.makeCacheEntry(now, now, headers);
 
-        assertTrue(impl.mayReturnStaleWhileRevalidating(entry, DateUtils.toDate(now)));
+        assertTrue(impl.mayReturnStaleWhileRevalidating(entry, now));
     }
 
     @Test
@@ -487,7 +486,7 @@ public class TestCacheValidityPolicy {
         };
         final HttpCacheEntry entry = HttpTestUtils.makeCacheEntry(now, now, headers);
 
-        assertFalse(impl.mayReturnStaleWhileRevalidating(entry, DateUtils.toDate(now)));
+        assertFalse(impl.mayReturnStaleWhileRevalidating(entry, now));
     }
 
     @Test
@@ -498,6 +497,6 @@ public class TestCacheValidityPolicy {
         };
         final HttpCacheEntry entry = HttpTestUtils.makeCacheEntry(now, now, headers);
 
-        assertFalse(impl.mayReturnStaleWhileRevalidating(entry, DateUtils.toDate(now)));
+        assertFalse(impl.mayReturnStaleWhileRevalidating(entry, now));
     }
 }

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestCachedHttpResponseGenerator.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestCachedHttpResponseGenerator.java
@@ -32,7 +32,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.HashMap;
 
 import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
@@ -112,7 +112,7 @@ public class TestCachedHttpResponseGenerator {
 
         final SimpleHttpResponse response = impl.generateResponse(request, entry);
 
-        verify(mockValidityPolicy).getCurrentAge(same(entry), isA(Date.class));
+        verify(mockValidityPolicy).getCurrentAge(same(entry), isA(Instant.class));
 
         final Header ageHdr = response.getFirstHeader("Age");
         Assertions.assertNotNull(ageHdr);
@@ -125,7 +125,7 @@ public class TestCachedHttpResponseGenerator {
 
         final SimpleHttpResponse response = impl.generateResponse(request, entry);
 
-        verify(mockValidityPolicy).getCurrentAge(same(entry), isA(Date.class));
+        verify(mockValidityPolicy).getCurrentAge(same(entry), isA(Instant.class));
 
         final Header ageHdr = response.getFirstHeader("Age");
         Assertions.assertNull(ageHdr);
@@ -137,7 +137,7 @@ public class TestCachedHttpResponseGenerator {
 
         final SimpleHttpResponse response = impl.generateResponse(request, entry);
 
-        verify(mockValidityPolicy).getCurrentAge(same(entry), isA(Date.class));
+        verify(mockValidityPolicy).getCurrentAge(same(entry), isA(Instant.class));
 
         final Header ageHdr = response.getFirstHeader("Age");
         Assertions.assertNotNull(ageHdr);
@@ -147,7 +147,7 @@ public class TestCachedHttpResponseGenerator {
     private void currentAge(final TimeValue age) {
         when(
                 mockValidityPolicy.getCurrentAge(same(entry),
-                        isA(Date.class))).thenReturn(age);
+                        isA(Instant.class))).thenReturn(age);
     }
 
     @Test

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestCachedResponseSuitabilityChecker.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestCachedResponseSuitabilityChecker.java
@@ -78,7 +78,7 @@ public class TestCachedResponseSuitabilityChecker {
                 new BasicHeader("Content-Length","1")
         };
         entry = getEntry(headers);
-        Assertions.assertFalse(impl.canCachedResponseBeUsed(host, request, entry, DateUtils.toDate(now)));
+        Assertions.assertFalse(impl.canCachedResponseBeUsed(host, request, entry, now));
     }
 
     @Test
@@ -89,7 +89,7 @@ public class TestCachedResponseSuitabilityChecker {
                 new BasicHeader("Content-Length","128")
         };
         entry = getEntry(headers);
-        Assertions.assertTrue(impl.canCachedResponseBeUsed(host, request, entry, DateUtils.toDate(now)));
+        Assertions.assertTrue(impl.canCachedResponseBeUsed(host, request, entry, now));
     }
 
     @Test
@@ -100,7 +100,7 @@ public class TestCachedResponseSuitabilityChecker {
                 new BasicHeader("Content-Length","128")
         };
         entry = getEntry(headers);
-        Assertions.assertFalse(impl.canCachedResponseBeUsed(host, request, entry, DateUtils.toDate(now)));
+        Assertions.assertFalse(impl.canCachedResponseBeUsed(host, request, entry, now));
     }
 
     @Test
@@ -112,7 +112,7 @@ public class TestCachedResponseSuitabilityChecker {
                 new BasicHeader("Content-Length","128")
         };
         entry = getEntry(headers);
-        Assertions.assertFalse(impl.canCachedResponseBeUsed(host, request, entry, DateUtils.toDate(now)));
+        Assertions.assertFalse(impl.canCachedResponseBeUsed(host, request, entry, now));
     }
 
     @Test
@@ -124,7 +124,7 @@ public class TestCachedResponseSuitabilityChecker {
                 new BasicHeader("Content-Length","128")
         };
         entry = getEntry(headers);
-        Assertions.assertFalse(impl.canCachedResponseBeUsed(host, request, entry, DateUtils.toDate(now)));
+        Assertions.assertFalse(impl.canCachedResponseBeUsed(host, request, entry, now));
     }
 
     @Test
@@ -136,7 +136,7 @@ public class TestCachedResponseSuitabilityChecker {
                 new BasicHeader("Content-Length","128")
         };
         entry = getEntry(headers);
-        Assertions.assertTrue(impl.canCachedResponseBeUsed(host, request, entry, DateUtils.toDate(now)));
+        Assertions.assertTrue(impl.canCachedResponseBeUsed(host, request, entry, now));
     }
 
     @Test
@@ -148,7 +148,7 @@ public class TestCachedResponseSuitabilityChecker {
                 new BasicHeader("Content-Length","128")
         };
         entry = getEntry(headers);
-        Assertions.assertTrue(impl.canCachedResponseBeUsed(host, request, entry, DateUtils.toDate(now)));
+        Assertions.assertTrue(impl.canCachedResponseBeUsed(host, request, entry, now));
     }
 
     @Test
@@ -160,7 +160,7 @@ public class TestCachedResponseSuitabilityChecker {
                 new BasicHeader("Content-Length","128")
         };
         entry = getEntry(headers);
-        Assertions.assertFalse(impl.canCachedResponseBeUsed(host, request, entry, DateUtils.toDate(now)));
+        Assertions.assertFalse(impl.canCachedResponseBeUsed(host, request, entry, now));
     }
 
     @Test
@@ -172,7 +172,7 @@ public class TestCachedResponseSuitabilityChecker {
                 new BasicHeader("Content-Length","128")
         };
         entry = getEntry(headers);
-        Assertions.assertTrue(impl.canCachedResponseBeUsed(host, request, entry, DateUtils.toDate(now)));
+        Assertions.assertTrue(impl.canCachedResponseBeUsed(host, request, entry, now));
     }
 
     @Test
@@ -184,7 +184,7 @@ public class TestCachedResponseSuitabilityChecker {
                 new BasicHeader("Content-Length","128")
         };
         entry = getEntry(headers);
-        Assertions.assertFalse(impl.canCachedResponseBeUsed(host, request, entry, DateUtils.toDate(now)));
+        Assertions.assertFalse(impl.canCachedResponseBeUsed(host, request, entry, now));
     }
 
 
@@ -197,7 +197,7 @@ public class TestCachedResponseSuitabilityChecker {
                 new BasicHeader("Content-Length","128")
         };
         entry = getEntry(headers);
-        Assertions.assertFalse(impl.canCachedResponseBeUsed(host, request, entry, DateUtils.toDate(now)));
+        Assertions.assertFalse(impl.canCachedResponseBeUsed(host, request, entry, now));
     }
 
     @Test
@@ -209,7 +209,7 @@ public class TestCachedResponseSuitabilityChecker {
                 new BasicHeader("Content-Length","128")
         };
         entry = getEntry(headers);
-        Assertions.assertFalse(impl.canCachedResponseBeUsed(host, request, entry, DateUtils.toDate(now)));
+        Assertions.assertFalse(impl.canCachedResponseBeUsed(host, request, entry, now));
     }
 
     @Test
@@ -230,7 +230,7 @@ public class TestCachedResponseSuitabilityChecker {
             .setHeuristicCoefficient(0.1f).build();
         impl = new CachedResponseSuitabilityChecker(config);
 
-        Assertions.assertTrue(impl.canCachedResponseBeUsed(host, request, entry, DateUtils.toDate(now)));
+        Assertions.assertTrue(impl.canCachedResponseBeUsed(host, request, entry, now));
     }
 
     @Test
@@ -248,7 +248,7 @@ public class TestCachedResponseSuitabilityChecker {
             .build();
         impl = new CachedResponseSuitabilityChecker(config);
 
-        Assertions.assertTrue(impl.canCachedResponseBeUsed(host, request, entry, DateUtils.toDate(now)));
+        Assertions.assertTrue(impl.canCachedResponseBeUsed(host, request, entry, now));
     }
 
     @Test
@@ -261,7 +261,7 @@ public class TestCachedResponseSuitabilityChecker {
         };
         entry = getEntry(headers);
 
-        Assertions.assertTrue(impl.canCachedResponseBeUsed(host, headRequest, entry, DateUtils.toDate(now)));
+        Assertions.assertTrue(impl.canCachedResponseBeUsed(host, headRequest, entry, now));
     }
 
     @Test
@@ -273,7 +273,7 @@ public class TestCachedResponseSuitabilityChecker {
         };
         entry = HttpTestUtils.makeHeadCacheEntry(headers);
 
-        Assertions.assertFalse(impl.canCachedResponseBeUsed(host, request, entry, DateUtils.toDate(now)));
+        Assertions.assertFalse(impl.canCachedResponseBeUsed(host, request, entry, now));
     }
 
     @Test
@@ -286,7 +286,7 @@ public class TestCachedResponseSuitabilityChecker {
         };
         entry = HttpTestUtils.makeCacheEntryWithNoRequestMethodOrEntity(headers);
 
-        Assertions.assertFalse(impl.canCachedResponseBeUsed(host, request, entry, DateUtils.toDate(now)));
+        Assertions.assertFalse(impl.canCachedResponseBeUsed(host, request, entry, now));
     }
 
     @Test
@@ -299,7 +299,7 @@ public class TestCachedResponseSuitabilityChecker {
         };
         entry = HttpTestUtils.makeCacheEntryWithNoRequestMethod(headers);
 
-        Assertions.assertTrue(impl.canCachedResponseBeUsed(host, request, entry, DateUtils.toDate(now)));
+        Assertions.assertTrue(impl.canCachedResponseBeUsed(host, request, entry, now));
     }
 
     @Test
@@ -311,7 +311,7 @@ public class TestCachedResponseSuitabilityChecker {
         };
         entry = HttpTestUtils.make204CacheEntryWithNoRequestMethod(headers);
 
-        Assertions.assertTrue(impl.canCachedResponseBeUsed(host, request, entry, DateUtils.toDate(now)));
+        Assertions.assertTrue(impl.canCachedResponseBeUsed(host, request, entry, now));
     }
 
     @Test
@@ -325,6 +325,6 @@ public class TestCachedResponseSuitabilityChecker {
         };
         entry = HttpTestUtils.makeHeadCacheEntryWithNoRequestMethod(headers);
 
-        Assertions.assertTrue(impl.canCachedResponseBeUsed(host, headRequest, entry, DateUtils.toDate(now)));
+        Assertions.assertTrue(impl.canCachedResponseBeUsed(host, headRequest, entry, now));
     }
 }

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestCachingExecChain.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestCachingExecChain.java
@@ -1009,8 +1009,7 @@ public class TestCachingExecChain {
         originResponse.setHeader("ETag", "\"etag\"");
 
         final ExecChain.Scope scope = new ExecChain.Scope("test", route, request, mockExecRuntime, context);
-        impl.cacheAndReturnResponse(host, request, originResponse, scope,
-                DateUtils.toDate(requestSent), DateUtils.toDate(responseReceived));
+        impl.cacheAndReturnResponse(host, request, originResponse, scope, requestSent, responseReceived);
 
         Mockito.verify(cache, Mockito.never()).createCacheEntry(
                 Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
@@ -1043,12 +1042,11 @@ public class TestCachingExecChain {
                 RequestEquivalent.eq(request),
                 ResponseEquivalent.eq(response),
                 Mockito.any(),
-                Mockito.eq(DateUtils.toDate(requestSent)),
-                Mockito.eq(DateUtils.toDate(responseReceived)))).thenReturn(httpCacheEntry);
+                Mockito.eq(requestSent),
+                Mockito.eq(responseReceived))).thenReturn(httpCacheEntry);
 
         final ExecChain.Scope scope = new ExecChain.Scope("test", route, request, mockExecRuntime, context);
-        impl.cacheAndReturnResponse(host, request, originResponse, scope,
-                DateUtils.toDate(requestSent), DateUtils.toDate(responseReceived));
+        impl.cacheAndReturnResponse(host, request, originResponse, scope, requestSent, responseReceived);
 
         Mockito.verify(mockCache).createCacheEntry(
                 Mockito.any(),

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestHttpByteArrayCacheEntrySerializer.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestHttpByteArrayCacheEntrySerializer.java
@@ -83,6 +83,98 @@ public class TestHttpByteArrayCacheEntrySerializer {
     }
 
     /**
+     * Deserialize a cache entry in a bad format, expecting an exception.
+     *
+     * @throws Exception is expected
+     */
+    @Test
+    public void testInvalidCacheEntry() throws Exception {
+        // This file is a JPEG not a cache entry, so should fail to deserialize
+        final byte[] bytes = readTestFileBytes(TEST_CONTENT_FILE_NAME);
+        Assertions.assertThrows(ResourceIOException.class, () ->
+                httpCacheStorageEntryFromBytes(serializer, bytes));
+    }
+
+    /**
+     * Deserialize a cache entry with a missing header, from a previously saved file.
+     *
+     * @throws Exception is expected
+     */
+    @Test
+    public void testMissingHeaderCacheEntry() throws Exception {
+        // This file hand-edited to be missing a necessary header
+        final byte[] bytes = readTestFileBytes(MISSING_HEADER_TEST_SERIALIZED_NAME);
+        Assertions.assertThrows(ResourceIOException.class, () ->
+                httpCacheStorageEntryFromBytes(serializer, bytes));
+    }
+
+    /**
+     * Deserialize a cache entry with an invalid header value, from a previously saved file.
+     *
+     * @throws Exception is expected
+     */
+    @Test
+    public void testInvalidHeaderCacheEntry() throws Exception {
+        // This file hand-edited to have an invalid header
+        final byte[] bytes = readTestFileBytes(INVALID_HEADER_TEST_SERIALIZED_NAME);
+        Assertions.assertThrows(ResourceIOException.class, () ->
+                httpCacheStorageEntryFromBytes(serializer, bytes));
+    }
+
+    /**
+     * Deserialize a cache entry with a missing variant map key, from a previously saved file.
+     *
+     * @throws Exception is expected
+     */
+    @Test
+    public void testVariantMapMissingKeyCacheEntry() throws Exception {
+        // This file hand-edited to be missing a VariantCache key
+        final byte[] bytes = readTestFileBytes(VARIANTMAP_MISSING_KEY_TEST_SERIALIZED_NAME);
+        Assertions.assertThrows(ResourceIOException.class, () ->
+                httpCacheStorageEntryFromBytes(serializer, bytes));
+    }
+
+    /**
+     * Deserialize a cache entry with a missing variant map value, from a previously saved file.
+     *
+     * @throws Exception is expected
+     */
+    @Test
+    public void testVariantMapMissingValueCacheEntry() throws Exception {
+        // This file hand-edited to be missing a VariantCache value
+        final byte[] bytes = readTestFileBytes(VARIANTMAP_MISSING_VALUE_TEST_SERIALIZED_NAME);
+        Assertions.assertThrows(ResourceIOException.class, () ->
+                httpCacheStorageEntryFromBytes(serializer, bytes));
+    }
+
+    /**
+     * Test an IOException being thrown while deserializing.
+     *
+     * @throws Exception is expected
+     */
+    @Test
+    public void testDeserializeWithIOException() throws Exception {
+        final AbstractMessageParser<ClassicHttpResponse> throwyParser = Mockito.mock(AbstractMessageParser.class);
+        Mockito.
+                doThrow(new IOException("Test Exception")).
+                when(throwyParser).
+                parse(Mockito.any(SessionInputBuffer.class), Mockito.any(InputStream.class));
+
+        final HttpByteArrayCacheEntrySerializer testSerializer = new HttpByteArrayCacheEntrySerializer() {
+            @Override
+            protected AbstractMessageParser<ClassicHttpResponse> makeHttpResponseParser() {
+                return throwyParser;
+            }
+        };
+        Assertions.assertThrows(ResourceIOException.class, () ->
+                testSerializer.deserialize(new byte[0]));
+    }
+
+
+    ////////////// Using new Constructor with Instant  //////////////
+
+
+    /**
      * Serialize and deserialize a simple object with a tiny body.
      *
      * @throws Exception if anything goes wrong
@@ -194,10 +286,9 @@ public class TestHttpByteArrayCacheEntrySerializer {
     /**
      * Attempt to store a cache entry with a null storage key.
      *
-     * @throws Exception is expected
      */
     @Test
-    public void testNullStorageKey() throws Exception {
+    public void testNullStorageKey() {
         final HttpCacheStorageEntryTestTemplate cacheObjectValues = HttpCacheStorageEntryTestTemplate.makeDefault();
         cacheObjectValues.storageKey = null;
 
@@ -292,71 +383,6 @@ public class TestHttpByteArrayCacheEntrySerializer {
     }
 
     /**
-     * Deserialize a cache entry in a bad format, expecting an exception.
-     *
-     * @throws Exception is expected
-     */
-    @Test
-    public void testInvalidCacheEntry() throws Exception {
-        // This file is a JPEG not a cache entry, so should fail to deserialize
-        final byte[] bytes = readTestFileBytes(TEST_CONTENT_FILE_NAME);
-        Assertions.assertThrows(ResourceIOException.class, () ->
-                httpCacheStorageEntryFromBytes(serializer, bytes));
-    }
-
-    /**
-     * Deserialize a cache entry with a missing header, from a previously saved file.
-     *
-     * @throws Exception is expected
-     */
-    @Test
-    public void testMissingHeaderCacheEntry() throws Exception {
-        // This file hand-edited to be missing a necessary header
-        final byte[] bytes = readTestFileBytes(MISSING_HEADER_TEST_SERIALIZED_NAME);
-        Assertions.assertThrows(ResourceIOException.class, () ->
-                httpCacheStorageEntryFromBytes(serializer, bytes));
-    }
-
-    /**
-     * Deserialize a cache entry with an invalid header value, from a previously saved file.
-     *
-     * @throws Exception is expected
-     */
-    @Test
-    public void testInvalidHeaderCacheEntry() throws Exception {
-        // This file hand-edited to have an invalid header
-        final byte[] bytes = readTestFileBytes(INVALID_HEADER_TEST_SERIALIZED_NAME);
-        Assertions.assertThrows(ResourceIOException.class, () ->
-                httpCacheStorageEntryFromBytes(serializer, bytes));
-    }
-
-    /**
-     * Deserialize a cache entry with a missing variant map key, from a previously saved file.
-     *
-     * @throws Exception is expected
-     */
-    @Test
-    public void testVariantMapMissingKeyCacheEntry() throws Exception {
-        // This file hand-edited to be missing a VariantCache key
-        final byte[] bytes = readTestFileBytes(VARIANTMAP_MISSING_KEY_TEST_SERIALIZED_NAME);
-        Assertions.assertThrows(ResourceIOException.class, () ->
-                httpCacheStorageEntryFromBytes(serializer, bytes));
-    }
-
-    /**
-     * Deserialize a cache entry with a missing variant map value, from a previously saved file.
-     *
-     * @throws Exception is expected
-     */
-    @Test
-    public void testVariantMapMissingValueCacheEntry() throws Exception {
-        // This file hand-edited to be missing a VariantCache value
-        final byte[] bytes = readTestFileBytes(VARIANTMAP_MISSING_VALUE_TEST_SERIALIZED_NAME);
-        Assertions.assertThrows(ResourceIOException.class, () ->
-                httpCacheStorageEntryFromBytes(serializer, bytes));
-    }
-
-    /**
      * Test an HttpException being thrown while serializing.
      *
      * @throws Exception is expected
@@ -382,26 +408,5 @@ public class TestHttpByteArrayCacheEntrySerializer {
                 testSerializer.serialize(testEntry));
     }
 
-    /**
-     * Test an IOException being thrown while deserializing.
-     *
-     * @throws Exception is expected
-     */
-    @Test
-    public void testDeserializeWithIOException() throws Exception {
-        final AbstractMessageParser<ClassicHttpResponse> throwyParser = Mockito.mock(AbstractMessageParser.class);
-        Mockito.
-                doThrow(new IOException("Test Exception")).
-                when(throwyParser).
-                parse(Mockito.any(SessionInputBuffer.class), Mockito.any(InputStream.class));
 
-        final HttpByteArrayCacheEntrySerializer testSerializer = new HttpByteArrayCacheEntrySerializer() {
-            @Override
-            protected AbstractMessageParser<ClassicHttpResponse> makeHttpResponseParser() {
-                return throwyParser;
-            }
-        };
-        Assertions.assertThrows(ResourceIOException.class, () ->
-                testSerializer.deserialize(new byte[0]));
-    }
 }

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestWarningValue.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestWarningValue.java
@@ -204,7 +204,7 @@ public class TestWarningValue {
         Assertions.assertEquals("fred", impl.getWarnAgent());
         Assertions.assertEquals("\"stale\"", impl.getWarnText());
         final Instant target = DateUtils.parseStandardDate("Sun Nov  6 08:49:37 1994");
-        Assertions.assertEquals(target, DateUtils.toInstant(impl.getWarnDate()));
+        Assertions.assertEquals(target, impl.getWarnDate());
     }
 
     @Test
@@ -214,7 +214,7 @@ public class TestWarningValue {
         Assertions.assertEquals("fred", impl.getWarnAgent());
         Assertions.assertEquals("\"stale\"", impl.getWarnText());
         final Instant target = DateUtils.parseStandardDate("Sunday, 06-Nov-94 08:49:37 GMT");
-        Assertions.assertEquals(target, DateUtils.toInstant(impl.getWarnDate()));
+        Assertions.assertEquals(target, impl.getWarnDate());
     }
 
     @Test
@@ -224,7 +224,7 @@ public class TestWarningValue {
         Assertions.assertEquals("fred", impl.getWarnAgent());
         Assertions.assertEquals("\"stale\"", impl.getWarnText());
         final Instant target = DateUtils.parseStandardDate("Sun, 06 Nov 1994 08:49:37 GMT");
-        Assertions.assertEquals(target, DateUtils.toInstant(impl.getWarnDate()));
+        Assertions.assertEquals(target, impl.getWarnDate());
     }
 
 }

--- a/httpclient5-fluent/src/main/java/org/apache/hc/client5/http/fluent/Request.java
+++ b/httpclient5-fluent/src/main/java/org/apache/hc/client5/http/fluent/Request.java
@@ -33,6 +33,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -260,18 +261,45 @@ public class Request {
       return request;
     }
 
+    /**
+     * @deprecated Use {@link #setDate(Instant)}
+     */
+    @Deprecated
     public Request setDate(final Date date) {
         this.request.setHeader(HttpHeader.DATE, DateUtils.formatStandardDate(DateUtils.toInstant(date)));
         return this;
     }
 
+    /**
+     * @deprecated Use {@link #setIfModifiedSince(Instant)}
+     */
+    @Deprecated
     public Request setIfModifiedSince(final Date date) {
         this.request.setHeader(HttpHeader.IF_MODIFIED_SINCE, DateUtils.formatStandardDate(DateUtils.toInstant(date)));
         return this;
     }
 
+    /**
+     * @deprecated Use {@link #setIfUnmodifiedSince(Instant)}
+     */
+    @Deprecated
     public Request setIfUnmodifiedSince(final Date date) {
         this.request.setHeader(HttpHeader.IF_UNMODIFIED_SINCE, DateUtils.formatStandardDate(DateUtils.toInstant(date)));
+        return this;
+    }
+
+    public Request setDate(final Instant instant) {
+        this.request.setHeader(HttpHeader.DATE, DateUtils.formatStandardDate(instant));
+        return this;
+    }
+
+    public Request setIfModifiedSince(final Instant instant) {
+        this.request.setHeader(HttpHeader.IF_MODIFIED_SINCE, DateUtils.formatStandardDate(instant));
+        return this;
+    }
+
+    public Request setIfUnmodifiedSince(final Instant instant) {
+        this.request.setHeader(HttpHeader.IF_UNMODIFIED_SINCE, DateUtils.formatStandardDate(instant));
         return this;
     }
 

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/config/RequestConfig.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/config/RequestConfig.java
@@ -248,7 +248,7 @@ public class RequestConfig implements Cloneable {
     public static RequestConfig.Builder custom() {
         return new Builder();
     }
-
+    @SuppressWarnings("deprecation")
     public static RequestConfig.Builder copy(final RequestConfig config) {
         return new Builder()
             .setExpectContinueEnabled(config.isExpectContinueEnabled())

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/cookie/Cookie.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/cookie/Cookie.java
@@ -27,6 +27,7 @@
 
 package org.apache.hc.client5.http.cookie;
 
+import java.time.Instant;
 import java.util.Date;
 
 /**
@@ -77,8 +78,25 @@ public interface Cookie {
      * considered immutable. Changing it (e.g. using setTime()) could result
      * in undefined behaviour. Do so at your peril. </p>
      * @return Expiration {@link Date}, or {@code null}.
+     * @deprecated Use {{@link #getExpiryInstant()}}
      */
+    @Deprecated
     Date getExpiryDate();
+
+    /**
+     * Returns the expiration {@link Instant} of the cookie, or {@code null} if none exists.
+     * <p><strong>Note:</strong> the object returned by this method is
+     * considered immutable. Changing it (e.g. using setTime()) could result in undefined behaviour.
+     * Do so at your peril. </p>
+     *
+     * @return Expiration {@link Instant}, or {@code null}.
+     * @since 5.2
+     */
+    @SuppressWarnings("deprecated")
+    default Instant getExpiryInstant() {
+        final Date date = getExpiryDate();
+        return date != null ? Instant.ofEpochMilli(date.getTime()) : null;
+    }
 
     /**
      * Returns {@code false} if the cookie should be discarded at the end
@@ -119,13 +137,34 @@ public interface Cookie {
      * @param date Current time
      *
      * @return {@code true} if the cookie has expired.
+     * @deprecated Use {{@link #isExpired(Instant)}}
      */
+    @Deprecated
     boolean isExpired(final Date date);
+
+    /**
+     * Returns true if this cookie has expired.
+     *
+     * @param date Current time
+     * @return {@code true} if the cookie has expired.
+     * @since 5.2
+     */
+    @SuppressWarnings("deprecation")
+    default boolean isExpired(final Instant date) {
+        return isExpired(date != null ? new Date(date.toEpochMilli()) : null);
+    }
+
+    /**
+     * Returns creation time of the cookie.
+     * @deprecated Use {@link #getCreationInstant()}
+     */
+    @Deprecated
+    Date getCreationDate();
 
     /**
      * Returns creation time of the cookie.
      */
-    Date getCreationDate();
+    default Instant getCreationInstant() { return null;  }
 
     /**
      * Checks whether this Cookie has been marked as {@code httpOnly}.

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/cookie/CookiePriorityComparator.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/cookie/CookiePriorityComparator.java
@@ -27,8 +27,8 @@
 
 package org.apache.hc.client5.http.cookie;
 
+import java.time.Instant;
 import java.util.Comparator;
-import java.util.Date;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
@@ -56,10 +56,10 @@ public class CookiePriorityComparator implements Comparator<Cookie> {
         final int l2 = getPathLength(c2);
         final int result = l2 - l1;
         if (result == 0) {
-            final Date d1 = c1.getCreationDate();
-            final Date d2 = c2.getCreationDate();
+            final Instant d1 = c1.getCreationInstant();
+            final Instant d2 = c2.getCreationInstant();
             if (d1 != null && d2 != null) {
-                return (int) (d1.getTime() - d2.getTime());
+                return (int) (d1.toEpochMilli() - d2.toEpochMilli());
             }
         }
         return result;

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/cookie/CookieStore.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/cookie/CookieStore.java
@@ -26,6 +26,7 @@
  */
 package org.apache.hc.client5.http.cookie;
 
+import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 
@@ -58,8 +59,21 @@ public interface CookieStore {
      * the specified {@link java.util.Date}.
      *
      * @return true if any cookies were purged.
+     * @deprecated  Use {@link #clearExpired(Instant)}
      */
+    @Deprecated
     boolean clearExpired(Date date);
+
+    /**
+     * Removes all of {@link Cookie}s in this store that have expired by
+     * the specified {@link Instant}.
+     *
+     * @return true if any cookies were purged.
+     */
+    @SuppressWarnings("deprecation")
+    default boolean clearExpired(Instant date) {
+        return clearExpired(date != null ? new Date(date.toEpochMilli()) : null);
+    }
 
     /**
      * Clears all cookies.

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/cookie/SetCookie.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/cookie/SetCookie.java
@@ -27,7 +27,10 @@
 
 package org.apache.hc.client5.http.cookie;
 
+import java.time.Instant;
 import java.util.Date;
+
+import org.apache.hc.client5.http.utils.DateUtils;
 
 /**
  * This interface represents a {@code Set-Cookie} response header sent by the
@@ -48,9 +51,25 @@ public interface SetCookie extends Cookie {
      * @param expiryDate the {@link Date} after which this cookie is no longer valid.
      *
      * @see Cookie#getExpiryDate
-     *
+     * @deprecated Use {{@link #setExpiryDate(Instant)}}
      */
+    @Deprecated
     void setExpiryDate (Date expiryDate);
+
+    /**
+     * Sets expiration date.
+     * <p><strong>Note:</strong> the object returned by this method is considered
+     * immutable. Changing it (e.g. using setTime()) could result in undefined behaviour. Do so at
+     * your peril.</p>
+     *
+     * @param expiryDate the {@link Instant} after which this cookie is no longer valid.
+     * @see Cookie#getExpiryInstant()
+     * @since 5.2
+     */
+    @SuppressWarnings("deprecated")
+    default void setExpiryDate(Instant expiryDate) {
+        setExpiryDate(DateUtils.toDate(expiryDate));
+    }
 
     /**
      * Sets the domain attribute.

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncClientBuilder.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncClientBuilder.java
@@ -749,7 +749,7 @@ public class HttpAsyncClientBuilder {
         }
         closeables.add(closeable);
     }
-
+    @SuppressWarnings("deprecated")
     public CloseableHttpAsyncClient build() {
         AsyncClientConnectionManager connManagerCopy = this.connManager;
         if (connManagerCopy == null) {

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/cookie/BasicClientCookie.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/cookie/BasicClientCookie.java
@@ -28,12 +28,14 @@
 package org.apache.hc.client5.http.impl.cookie;
 
 import java.io.Serializable;
+import java.time.Instant;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
 import org.apache.hc.client5.http.cookie.SetCookie;
+import org.apache.hc.client5.http.utils.DateUtils;
 import org.apache.hc.core5.util.Args;
 
 /**
@@ -102,6 +104,14 @@ public final class BasicClientCookie implements SetCookie, Cloneable, Serializab
      */
     @Override
     public Date getExpiryDate() {
+        return DateUtils.toDate(cookieExpiryDate);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Instant getExpiryInstant() {
         return cookieExpiryDate;
     }
 
@@ -118,7 +128,22 @@ public final class BasicClientCookie implements SetCookie, Cloneable, Serializab
      */
     @Override
     public void setExpiryDate (final Date expiryDate) {
-        cookieExpiryDate = expiryDate;
+        cookieExpiryDate = DateUtils.toInstant(expiryDate);
+    }
+
+    /**
+     * Sets expiration date.
+     * <p><strong>Note:</strong> the object returned by this method is considered
+     * immutable. Changing it (e.g. using setTime()) could result in undefined behaviour. Do so at
+     * your peril.</p>
+     *
+     * @param expiryInstant the {@link Instant} after which this cookie is no longer valid.
+     * @see #getExpiryInstant()
+     * @since 5.2
+     */
+    @Override
+    public void setExpiryDate (final Instant expiryInstant) {
+        cookieExpiryDate = expiryInstant;
     }
 
 
@@ -238,7 +263,20 @@ public final class BasicClientCookie implements SetCookie, Cloneable, Serializab
     public boolean isExpired(final Date date) {
         Args.notNull(date, "Date");
         return (cookieExpiryDate != null
-            && cookieExpiryDate.getTime() <= date.getTime());
+            && cookieExpiryDate.toEpochMilli() <= DateUtils.toInstant(date).toEpochMilli());
+    }
+
+    /**
+     * Returns true if this cookie has expired.
+     * @param instant Current time
+     *
+     * @return {@code true} if the cookie has expired.
+     */
+    @Override
+    public boolean isExpired(final Instant instant) {
+        Args.notNull(instant, "Instant");
+        return (cookieExpiryDate != null
+                && cookieExpiryDate.toEpochMilli() <= instant.toEpochMilli());
     }
 
     /**
@@ -246,6 +284,14 @@ public final class BasicClientCookie implements SetCookie, Cloneable, Serializab
      */
     @Override
     public Date getCreationDate() {
+        return DateUtils.toDate(creationDate);
+    }
+
+    /**
+     * @since 5.2
+     */
+    @Override
+    public Instant getCreationInstant() {
         return creationDate;
     }
 
@@ -261,8 +307,17 @@ public final class BasicClientCookie implements SetCookie, Cloneable, Serializab
 
     /**
      * @since 4.4
+     * @deprecated Use {@link #setCreationDate(Instant)}
      */
+    @Deprecated
     public void setCreationDate(final Date creationDate) {
+        this.creationDate = DateUtils.toInstant(creationDate);
+    }
+
+    /**
+     * @since 5.2
+     */
+    public void setCreationDate(final Instant creationDate) {
         this.creationDate = creationDate;
     }
 
@@ -329,8 +384,8 @@ public final class BasicClientCookie implements SetCookie, Cloneable, Serializab
     /** Domain attribute. */
     private String  cookieDomain;
 
-    /** Expiration {@link Date}. */
-    private Date cookieExpiryDate;
+    /** Expiration {@link Instant}. */
+    private Instant cookieExpiryDate;
 
     /** Path attribute. */
     private String cookiePath;
@@ -338,7 +393,7 @@ public final class BasicClientCookie implements SetCookie, Cloneable, Serializab
     /** My secure flag. */
     private boolean isSecure;
 
-    private Date creationDate;
+    private Instant creationDate;
 
     /** The {@code httpOnly} flag. */
     private boolean httpOnly;

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/cookie/BasicExpiresHandler.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/cookie/BasicExpiresHandler.java
@@ -86,7 +86,7 @@ public class BasicExpiresHandler extends AbstractCookieAttributeHandler implemen
             throw new MalformedCookieException("Invalid 'expires' attribute: "
                     + value);
         }
-        cookie.setExpiryDate(DateUtils.toDate(expiry));
+        cookie.setExpiryDate(expiry);
     }
 
     @Override

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/cookie/BasicMaxAgeHandler.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/cookie/BasicMaxAgeHandler.java
@@ -26,7 +26,7 @@
  */
 package org.apache.hc.client5.http.impl.cookie;
 
-import java.util.Date;
+import java.time.Instant;
 
 import org.apache.hc.client5.http.cookie.CommonCookieAttributeHandler;
 import org.apache.hc.client5.http.cookie.Cookie;
@@ -66,7 +66,7 @@ public class BasicMaxAgeHandler extends AbstractCookieAttributeHandler implement
             throw new MalformedCookieException ("Negative 'max-age' attribute: "
                     + value);
         }
-        cookie.setExpiryDate(new Date(System.currentTimeMillis() + age * 1000L));
+        cookie.setExpiryDate(Instant.now().plusSeconds(age));
     }
 
     @Override

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/cookie/LaxExpiresHandler.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/cookie/LaxExpiresHandler.java
@@ -41,7 +41,6 @@ import org.apache.hc.client5.http.cookie.CommonCookieAttributeHandler;
 import org.apache.hc.client5.http.cookie.Cookie;
 import org.apache.hc.client5.http.cookie.MalformedCookieException;
 import org.apache.hc.client5.http.cookie.SetCookie;
-import org.apache.hc.client5.http.utils.DateUtils;
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.util.Args;
@@ -180,7 +179,7 @@ public class LaxExpiresHandler extends AbstractCookieAttributeHandler implements
 
         final Instant expiryDate = ZonedDateTime.of(year, month.getValue(), day, hour, minute, second, 0,
                 ZoneId.of("UTC")).toInstant();
-        cookie.setExpiryDate(DateUtils.toDate(expiryDate));
+        cookie.setExpiryDate(expiryDate);
     }
 
     private void skipDelims(final CharSequence buf, final Tokenizer.Cursor cursor) {

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/cookie/LaxMaxAgeHandler.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/cookie/LaxMaxAgeHandler.java
@@ -26,7 +26,7 @@
  */
 package org.apache.hc.client5.http.impl.cookie;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -68,8 +68,8 @@ public class LaxMaxAgeHandler extends AbstractCookieAttributeHandler implements 
             } catch (final NumberFormatException e) {
                 return;
             }
-            final Date expiryDate = age >= 0 ? new Date(System.currentTimeMillis() + age * 1000L) :
-                    new Date(Long.MIN_VALUE);
+            final Instant expiryDate = age >= 0 ? Instant.now().plusSeconds(age) :
+                    Instant.EPOCH;
             cookie.setExpiryDate(expiryDate);
         }
     }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/cookie/RFC6265CookieSpec.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/cookie/RFC6265CookieSpec.java
@@ -27,10 +27,10 @@
 
 package org.apache.hc.client5.http.impl.cookie;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.Collections;
-import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -146,7 +146,7 @@ public class RFC6265CookieSpec implements CookieSpec {
         final BasicClientCookie cookie = new BasicClientCookie(name, value);
         cookie.setPath(getDefaultPath(origin));
         cookie.setDomain(getDefaultDomain(origin));
-        cookie.setCreationDate(new Date());
+        cookie.setCreationDate(Instant.now());
 
         final Map<String, String> attribMap = new LinkedHashMap<>();
         while (!cursor.atEnd()) {

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/BasicHttpClientConnectionManager.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/BasicHttpClientConnectionManager.java
@@ -28,7 +28,7 @@
 package org.apache.hc.client5.http.impl.io;
 
 import java.io.IOException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -259,7 +259,7 @@ public class BasicHttpClientConnectionManager implements HttpClientConnectionMan
     private void checkExpiry() {
         if (this.conn != null && System.currentTimeMillis() >= this.expiry) {
             if (LOG.isDebugEnabled()) {
-                LOG.debug("{} Connection expired @ {}", id, new Date(this.expiry));
+                LOG.debug("{} Connection expired @ {}", id, Instant.ofEpochMilli(this.expiry));
             }
             closeConnection(CloseMode.GRACEFUL);
         }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/protocol/RequestAddCookies.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/protocol/RequestAddCookies.java
@@ -28,8 +28,8 @@
 package org.apache.hc.client5.http.protocol;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 import org.apache.hc.client5.http.RouteInfo;
@@ -150,7 +150,7 @@ public class RequestAddCookies implements HttpRequestInterceptor {
         final List<Cookie> cookies = cookieStore.getCookies();
         // Find cookies matching the given origin
         final List<Cookie> matchedCookies = new ArrayList<>();
-        final Date now = new Date();
+        final Instant now = Instant.now();
         boolean expired = false;
         for (final Cookie cookie : cookies) {
             if (!cookie.isExpired(now)) {

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/protocol/ResponseProcessCookies.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/protocol/ResponseProcessCookies.java
@@ -149,7 +149,7 @@ public class ResponseProcessCookies implements HttpResponseInterceptor {
         buf.append(", path:");
         buf.append(cookie.getPath());
         buf.append(", expiry:");
-        buf.append(cookie.getExpiryDate());
+        buf.append(cookie.getExpiryInstant());
         return buf.toString();
     }
 

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/DefaultClientTlsStrategy.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/DefaultClientTlsStrategy.java
@@ -110,6 +110,7 @@ public class DefaultClientTlsStrategy extends AbstractClientTlsStrategy {
     }
 
     @Override
+    @SuppressWarnings("deprecated")
     TlsDetails createTlsDetails(final SSLEngine sslEngine) {
         return tlsDetailsFactory != null ? tlsDetailsFactory.create(sslEngine) : null;
     }

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/cookie/TestCookiePriorityComparator.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/cookie/TestCookiePriorityComparator.java
@@ -27,8 +27,8 @@
 
 package org.apache.hc.client5.http.cookie;
 
+import java.time.Instant;
 import java.util.Comparator;
-import java.util.Date;
 
 import org.apache.hc.client5.http.impl.cookie.BasicClientCookie;
 import org.junit.jupiter.api.Assertions;
@@ -101,10 +101,10 @@ public class TestCookiePriorityComparator {
     public void testUnequalityCreationDate() {
         final BasicClientCookie cookie1 = new BasicClientCookie("name1", "value");
         cookie1.setPath("/blah");
-        cookie1.setCreationDate(new Date(System.currentTimeMillis() - 200000));
+        cookie1.setCreationDate(Instant.now().minusMillis(200000));
         final BasicClientCookie cookie2 = new BasicClientCookie("name1", "value");
         cookie2.setPath("/blah");
-        cookie2.setCreationDate(new Date(System.currentTimeMillis()));
+        cookie2.setCreationDate(Instant.now());
         Assertions.assertTrue(comparator.compare(cookie1, cookie2) < 0);
         Assertions.assertTrue(comparator.compare(cookie2, cookie1) > 0);
     }

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/cookie/TestBasicCookieAttribHandlers.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/cookie/TestBasicCookieAttribHandlers.java
@@ -267,7 +267,7 @@ public class TestBasicCookieAttribHandlers {
         final BasicClientCookie cookie = new BasicClientCookie("name", "value");
         final CookieAttributeHandler h = new BasicMaxAgeHandler();
         h.parse(cookie, "2000");
-        Assertions.assertNotNull(cookie.getExpiryDate());
+        Assertions.assertNotNull(cookie.getExpiryInstant());
     }
 
     @Test
@@ -327,7 +327,7 @@ public class TestBasicCookieAttribHandlers {
         final CookieAttributeHandler h = new BasicExpiresHandler(DateUtils.FORMATTER_RFC1123);
 
         h.parse(cookie, DateUtils.formatStandardDate(Instant.now()));
-        Assertions.assertNotNull(cookie.getExpiryDate());
+        Assertions.assertNotNull(cookie.getExpiryInstant());
     }
 
     @Test

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/cookie/TestBasicCookieStore.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/cookie/TestBasicCookieStore.java
@@ -31,7 +31,8 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import java.util.Calendar;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import org.apache.hc.client5.http.cookie.BasicCookieStore;
@@ -65,9 +66,8 @@ public class TestBasicCookieStore {
         final BasicCookieStore store = new BasicCookieStore();
         final BasicClientCookie cookie = new BasicClientCookie("name1", "value1");
 
-        final Calendar c = Calendar.getInstance();
-        c.add(Calendar.DAY_OF_YEAR, -10);
-        cookie.setExpiryDate(c.getTime());
+        final Instant  minus_10_days = Instant.now().minus(10, ChronoUnit.DAYS);
+        cookie.setExpiryDate(minus_10_days);
         store.addCookie(cookie);
         final List<Cookie> list = store.getCookies();
         Assertions.assertNotNull(list);

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/cookie/TestLaxCookieAttribHandlers.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/cookie/TestLaxCookieAttribHandlers.java
@@ -43,7 +43,7 @@ public class TestLaxCookieAttribHandlers {
         final BasicClientCookie cookie = new BasicClientCookie("name", "value");
         final CookieAttributeHandler h = new LaxMaxAgeHandler();
         h.parse(cookie, "2000");
-        Assertions.assertNotNull(cookie.getExpiryDate());
+        Assertions.assertNotNull(cookie.getExpiryInstant());
     }
 
     @Test
@@ -51,7 +51,7 @@ public class TestLaxCookieAttribHandlers {
         final BasicClientCookie cookie = new BasicClientCookie("name", "value");
         final CookieAttributeHandler h = new LaxMaxAgeHandler();
         h.parse(cookie, "-2000");
-        Assertions.assertNotNull(cookie.getExpiryDate());
+        Assertions.assertNotNull(cookie.getExpiryInstant());
     }
 
     @Test
@@ -59,7 +59,7 @@ public class TestLaxCookieAttribHandlers {
         final BasicClientCookie cookie = new BasicClientCookie("name", "value");
         final CookieAttributeHandler h = new LaxMaxAgeHandler();
         h.parse(cookie, "0000");
-        Assertions.assertNotNull(cookie.getExpiryDate());
+        Assertions.assertNotNull(cookie.getExpiryInstant());
     }
 
     @Test
@@ -67,7 +67,7 @@ public class TestLaxCookieAttribHandlers {
         final BasicClientCookie cookie = new BasicClientCookie("name", "value");
         final CookieAttributeHandler h = new LaxMaxAgeHandler();
         h.parse(cookie, "  ");
-        Assertions.assertNull(cookie.getExpiryDate());
+        Assertions.assertNull(cookie.getExpiryInstant());
     }
 
     @Test
@@ -75,7 +75,7 @@ public class TestLaxCookieAttribHandlers {
         final BasicClientCookie cookie = new BasicClientCookie("name", "value");
         final CookieAttributeHandler h = new LaxMaxAgeHandler();
         h.parse(cookie, "garbage");
-        Assertions.assertNull(cookie.getExpiryDate());
+        Assertions.assertNull(cookie.getExpiryInstant());
     }
 
     @Test
@@ -98,7 +98,25 @@ public class TestLaxCookieAttribHandlers {
         final CookieAttributeHandler h = new LaxExpiresHandler();
         h.parse(cookie, "1:0:12 8-jan-2012");
 
-        final LocalDateTime expiryDate = DateUtils.toUTC(cookie.getExpiryDate());
+        final LocalDateTime expiryDate = DateUtils.toUTC(cookie.getExpiryInstant());
+        Assertions.assertNotNull(expiryDate);
+
+        Assertions.assertEquals(2012, expiryDate.get(ChronoField.YEAR));
+        Assertions.assertEquals(1, expiryDate.get(ChronoField.MONTH_OF_YEAR));
+        Assertions.assertEquals(8, expiryDate.get(ChronoField.DAY_OF_MONTH));
+        Assertions.assertEquals(1, expiryDate.get(ChronoField.HOUR_OF_DAY));
+        Assertions.assertEquals(0, expiryDate.get(ChronoField.MINUTE_OF_HOUR));
+        Assertions.assertEquals(12, expiryDate.get(ChronoField.SECOND_OF_MINUTE));
+        Assertions.assertEquals(0, expiryDate.get(ChronoField.MILLI_OF_SECOND));
+    }
+
+    @Test
+    public void testParseExpiryInstant() throws Exception {
+        final BasicClientCookie cookie = new BasicClientCookie("name", "value");
+        final CookieAttributeHandler h = new LaxExpiresHandler();
+        h.parse(cookie, "1:0:12 8-jan-2012");
+
+        final LocalDateTime expiryDate = DateUtils.toUTC(cookie.getExpiryInstant());
         Assertions.assertNotNull(expiryDate);
 
         Assertions.assertEquals(2012, expiryDate.get(ChronoField.YEAR));
@@ -115,7 +133,7 @@ public class TestLaxCookieAttribHandlers {
         final BasicClientCookie cookie = new BasicClientCookie("name", "value");
         final CookieAttributeHandler h = new LaxExpiresHandler();
         h.parse(cookie, null);
-        Assertions.assertNull(cookie.getExpiryDate());
+        Assertions.assertNull(cookie.getExpiryInstant());
     }
 
     @Test
@@ -156,7 +174,25 @@ public class TestLaxCookieAttribHandlers {
         final CookieAttributeHandler h = new LaxExpiresHandler();
         h.parse(cookie, "1:59:00blah; 8-feb-2000");
 
-        final LocalDateTime expiryDate = DateUtils.toUTC(cookie.getExpiryDate());
+        final LocalDateTime expiryDate = DateUtils.toUTC(cookie.getExpiryInstant());
+        Assertions.assertNotNull(expiryDate);
+
+        Assertions.assertEquals(2000, expiryDate.get(ChronoField.YEAR_OF_ERA));
+        Assertions.assertEquals(2, expiryDate.get(ChronoField.MONTH_OF_YEAR));
+        Assertions.assertEquals(8, expiryDate.get(ChronoField.DAY_OF_MONTH));
+        Assertions.assertEquals(1, expiryDate.get(ChronoField.HOUR_OF_DAY));
+        Assertions.assertEquals(59, expiryDate.get(ChronoField.MINUTE_OF_HOUR));
+        Assertions.assertEquals(0, expiryDate.get(ChronoField.SECOND_OF_MINUTE));
+        Assertions.assertEquals(0, expiryDate.get(ChronoField.MILLI_OF_SECOND));
+    }
+
+    @Test
+    public void testParseExpiryFunnyTimeInstant() throws Exception {
+        final BasicClientCookie cookie = new BasicClientCookie("name", "value");
+        final CookieAttributeHandler h = new LaxExpiresHandler();
+        h.parse(cookie, "1:59:00blah; 8-feb-2000");
+
+        final LocalDateTime expiryDate = DateUtils.toUTC(cookie.getExpiryInstant());
         Assertions.assertNotNull(expiryDate);
 
         Assertions.assertEquals(2000, expiryDate.get(ChronoField.YEAR_OF_ERA));
@@ -198,7 +234,25 @@ public class TestLaxCookieAttribHandlers {
         final CookieAttributeHandler h = new LaxExpiresHandler();
         h.parse(cookie, "12:00:00 8blah;mar;1880");
 
-        final LocalDateTime expiryDate = DateUtils.toUTC(cookie.getExpiryDate());
+        final LocalDateTime expiryDate = DateUtils.toUTC(cookie.getExpiryInstant());
+        Assertions.assertNotNull(expiryDate);
+
+        Assertions.assertEquals(1880, expiryDate.get(ChronoField.YEAR));
+        Assertions.assertEquals(3, expiryDate.get(ChronoField.MONTH_OF_YEAR));
+        Assertions.assertEquals(8, expiryDate.get(ChronoField.DAY_OF_MONTH));
+        Assertions.assertEquals(12, expiryDate.get(ChronoField.HOUR_OF_DAY));
+        Assertions.assertEquals(0, expiryDate.get(ChronoField.MINUTE_OF_HOUR));
+        Assertions.assertEquals(0, expiryDate.get(ChronoField.SECOND_OF_MINUTE));
+        Assertions.assertEquals(0, expiryDate.get(ChronoField.MILLI_OF_SECOND));
+    }
+
+    @Test
+    public void testParseExpiryFunnyDayOfMonthInstant() throws Exception {
+        final BasicClientCookie cookie = new BasicClientCookie("name", "value");
+        final CookieAttributeHandler h = new LaxExpiresHandler();
+        h.parse(cookie, "12:00:00 8blah;mar;1880");
+
+        final LocalDateTime expiryDate = DateUtils.toUTC(cookie.getExpiryInstant());
         Assertions.assertNotNull(expiryDate);
 
         Assertions.assertEquals(1880, expiryDate.get(ChronoField.YEAR));
@@ -224,7 +278,25 @@ public class TestLaxCookieAttribHandlers {
         final CookieAttributeHandler h = new LaxExpiresHandler();
         h.parse(cookie, "23:59:59; 1-ApriLLLLL-2008");
 
-        final LocalDateTime expiryDate = DateUtils.toUTC(cookie.getExpiryDate());
+        final LocalDateTime expiryDate = DateUtils.toUTC(cookie.getExpiryInstant());
+        Assertions.assertNotNull(expiryDate);
+
+        Assertions.assertEquals(2008, expiryDate.get(ChronoField.YEAR));
+        Assertions.assertEquals(4, expiryDate.get(ChronoField.MONTH_OF_YEAR));
+        Assertions.assertEquals(1, expiryDate.get(ChronoField.DAY_OF_MONTH));
+        Assertions.assertEquals(23, expiryDate.get(ChronoField.HOUR_OF_DAY));
+        Assertions.assertEquals(59, expiryDate.get(ChronoField.MINUTE_OF_HOUR));
+        Assertions.assertEquals(59, expiryDate.get(ChronoField.SECOND_OF_MINUTE));
+        Assertions.assertEquals(0, expiryDate.get(ChronoField.MILLI_OF_SECOND));
+    }
+
+    @Test
+    public void testParseExpiryFunnyMonthInstant() throws Exception {
+        final BasicClientCookie cookie = new BasicClientCookie("name", "value");
+        final CookieAttributeHandler h = new LaxExpiresHandler();
+        h.parse(cookie, "23:59:59; 1-ApriLLLLL-2008");
+
+        final LocalDateTime expiryDate = DateUtils.toUTC(cookie.getExpiryInstant());
         Assertions.assertNotNull(expiryDate);
 
         Assertions.assertEquals(2008, expiryDate.get(ChronoField.YEAR));
@@ -266,7 +338,25 @@ public class TestLaxCookieAttribHandlers {
         final CookieAttributeHandler h = new LaxExpiresHandler();
         h.parse(cookie, "23:59:59; 1-Apr-2008blah");
 
-        final LocalDateTime expiryDate = DateUtils.toUTC(cookie.getExpiryDate());
+        final LocalDateTime expiryDate = DateUtils.toUTC(cookie.getExpiryInstant());
+        Assertions.assertNotNull(expiryDate);
+
+        Assertions.assertEquals(2008, expiryDate.get(ChronoField.YEAR));
+        Assertions.assertEquals(4, expiryDate.get(ChronoField.MONTH_OF_YEAR));
+        Assertions.assertEquals(1, expiryDate.get(ChronoField.DAY_OF_MONTH));
+        Assertions.assertEquals(23, expiryDate.get(ChronoField.HOUR_OF_DAY));
+        Assertions.assertEquals(59, expiryDate.get(ChronoField.MINUTE_OF_HOUR));
+        Assertions.assertEquals(59, expiryDate.get(ChronoField.SECOND_OF_MINUTE));
+        Assertions.assertEquals(0, expiryDate.get(ChronoField.MILLI_OF_SECOND));
+    }
+
+    @Test
+    public void testParseExpiryFunnyYearInstant() throws Exception {
+        final BasicClientCookie cookie = new BasicClientCookie("name", "value");
+        final CookieAttributeHandler h = new LaxExpiresHandler();
+        h.parse(cookie, "23:59:59; 1-Apr-2008blah");
+
+        final LocalDateTime expiryDate = DateUtils.toUTC(cookie.getExpiryInstant());
         Assertions.assertNotNull(expiryDate);
 
         Assertions.assertEquals(2008, expiryDate.get(ChronoField.YEAR));
@@ -284,7 +374,7 @@ public class TestLaxCookieAttribHandlers {
         final CookieAttributeHandler h = new LaxExpiresHandler();
         h.parse(cookie, "23:59:59; 1-Apr-70");
 
-        final LocalDateTime expiryDate = DateUtils.toUTC(cookie.getExpiryDate());
+        final LocalDateTime expiryDate = DateUtils.toUTC(cookie.getExpiryInstant());
         Assertions.assertNotNull(expiryDate);
 
         Assertions.assertEquals(1970, expiryDate.get(ChronoField.YEAR));
@@ -296,7 +386,7 @@ public class TestLaxCookieAttribHandlers {
         final CookieAttributeHandler h = new LaxExpiresHandler();
         h.parse(cookie, "23:59:59; 1-Apr-99");
 
-        final LocalDateTime expiryDate = DateUtils.toUTC(cookie.getExpiryDate());
+        final LocalDateTime expiryDate = DateUtils.toUTC(cookie.getExpiryInstant());
         Assertions.assertNotNull(expiryDate);
 
         Assertions.assertEquals(1999, expiryDate.get(ChronoField.YEAR));
@@ -308,7 +398,7 @@ public class TestLaxCookieAttribHandlers {
         final CookieAttributeHandler h = new LaxExpiresHandler();
         h.parse(cookie, "23:59:59; 1-Apr-00");
 
-        final LocalDateTime expiryDate = DateUtils.toUTC(cookie.getExpiryDate());
+        final LocalDateTime expiryDate = DateUtils.toUTC(cookie.getExpiryInstant());
         Assertions.assertNotNull(expiryDate);
 
         Assertions.assertEquals(2000, expiryDate.get(ChronoField.YEAR));

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/protocol/TestRequestAddCookies.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/protocol/TestRequestAddCookies.java
@@ -26,7 +26,7 @@
  */
 package org.apache.hc.client5.http.protocol;
 
-import java.util.Date;
+import java.time.Instant;
 
 import org.apache.hc.client5.http.HttpRoute;
 import org.apache.hc.client5.http.RouteInfo.LayerType;
@@ -321,7 +321,7 @@ public class TestRequestAddCookies {
         final BasicClientCookie cookie3 = new BasicClientCookie("name3", "value3");
         cookie3.setDomain("localhost.local");
         cookie3.setPath("/");
-        cookie3.setExpiryDate(new Date(System.currentTimeMillis() + 100));
+        cookie3.setExpiryDate(Instant.now().plusMillis(100));
         this.cookieStore.addCookie(cookie3);
 
         Assertions.assertEquals(3, this.cookieStore.getCookies().size());
@@ -346,7 +346,7 @@ public class TestRequestAddCookies {
         Assertions.assertEquals(1, headers.length);
         Assertions.assertEquals("name1=value1; name2=value2", headers[0].getValue());
 
-        Mockito.verify(this.cookieStore, Mockito.times(1)).clearExpired(ArgumentMatchers.any());
+        Mockito.verify(this.cookieStore, Mockito.times(1)).clearExpired(ArgumentMatchers.any(Instant.class));
     }
 
     @Test


### PR DESCRIPTION
Change all the remain classes to use Time. API´s.
Remarks:

- There are tests with name `Deprecated` that indicate that are using a all method (deprecate).  They should be removed when you decide to stop supporting to old API´s.  This way it is easier to delete all the old code when the time comes.
- I had to add support to the java time package used in Cache entity Serializer/deserializer.
- I tried to keep the same of all variable and method, but in some point was´t possible because the conflict name. I've used xxxInstant, e.g `getExpiryInstant`