### PR TITLE
Add private constructor so that no instances can be created

### DIFF
--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/cache/HeaderConstants.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/cache/HeaderConstants.java
@@ -76,4 +76,12 @@ public class HeaderConstants {
     public static final String PROXY_AUTHENTICATE = "Proxy-Authenticate";
     public static final String AUTHORIZATION = "Authorization";
 
+    /**
+     * Private constructor so that no instances can be created. This class contains only static
+     * utility constant.
+     */
+    private HeaderConstants() {
+        throw new UnsupportedOperationException("No instance of HeaderConstants is allowed");
+    }
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -302,6 +302,7 @@
             </overrideCompatibilityChangeParameters>
             <excludes>
               <exclude>@org.apache.hc.core5.annotation.Internal</exclude>
+              <exclude>org.apache.hc.client5.http.cache.HeaderConstants</exclude>
             </excludes>
           </parameter>
         </configuration>


### PR DESCRIPTION
Private constructors prevent a class from being explicitly instantiated by its callers. Java Part 4 - Enforce noninstantiability 