### PR TITLE
Avoid redundant validation of '\"'. Its checked before.

### DIFF
--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/WarningValue.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/WarningValue.java
@@ -221,7 +221,7 @@ class WarningValue {
             } else if (c == '\"') {
                 foundEnd = true;
                 offs++;
-            } else if (c != '\"' && !isControl(c)) {
+            } else if (!isControl(c)) {
                 offs++;
             } else {
                 parseError();


### PR DESCRIPTION
No need check again if the Chart is `\` or not.

`
else if (c == '\"') {
                foundEnd = true;
                offs++;
} else if (c != '\"' && !isControl(c)) {
`