### PR TITLE
Safely remove unnecessary unboxing. No need it after Java 5 and later.

### DIFF
--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/AbstractSerializingAsyncCacheStorage.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/AbstractSerializingAsyncCacheStorage.java
@@ -187,8 +187,8 @@ public abstract class AbstractSerializingAsyncCacheStorage<T, CAS> implements Ht
 
                                 @Override
                                 public void completed(final Boolean result) {
-                                    if (result.booleanValue()) {
-                                        callback.completed(result);
+                                    if (result) {
+                                        callback.completed(true);
                                     } else {
                                         if (!complexCancellable.isCancelled()) {
                                             final int numRetries = count.incrementAndGet();

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/DefaultAsyncCacheInvalidator.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/DefaultAsyncCacheInvalidator.java
@@ -70,7 +70,7 @@ public class DefaultAsyncCacheInvalidator extends CacheInvalidatorBase implement
             @Override
             public void completed(final Boolean result) {
                 if (LOG.isDebugEnabled()) {
-                    if (result.booleanValue()) {
+                    if (result) {
                         LOG.debug("Cache entry with key {} successfully flushed", cacheKey);
                     } else {
                         LOG.debug("Cache entry with key {} could not be flushed", cacheKey);


### PR DESCRIPTION
Sorry for so many stupid changes. I'm checking the cache module as was suggest in the mailing list.