### PR TITLE
Bump log4j to 2.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <httpcore.version>5.2-alpha2</httpcore.version>
-    <log4j.version>2.14.1</log4j.version>
+    <log4j.version>2.16.0</log4j.version>
     <commons-codec.version>1.15</commons-codec.version>
     <conscrypt.version>2.5.2</conscrypt.version>
     <ehcache.version>3.9.6</ehcache.version>


### PR DESCRIPTION
Bumping log4j due to CVE-2021-44228