### PR TITLE
Httpclient-2194 async retries not including body

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/AsyncHttpRequestRetryExec.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/AsyncHttpRequestRetryExec.java
@@ -128,6 +128,9 @@ public final class AsyncHttpRequestRetryExec implements AsyncExecChainHandler {
             public void completed() {
                 if (state.retrying) {
                     scope.execCount.incrementAndGet();
+                    if (entityProducer != null && entityProducer.isRepeatable()) {
+                       entityProducer.releaseResources();
+                    }
                     scope.scheduler.scheduleExecution(request, entityProducer, scope, asyncExecCallback, state.delay);
                 } else {
                     asyncExecCallback.completed();

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/AsyncHttpRequestRetryExec.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/AsyncHttpRequestRetryExec.java
@@ -128,7 +128,7 @@ public final class AsyncHttpRequestRetryExec implements AsyncExecChainHandler {
             public void completed() {
                 if (state.retrying) {
                     scope.execCount.incrementAndGet();
-                    if (entityProducer != null && entityProducer.isRepeatable()) {
+                    if (entityProducer != null) {
                        entityProducer.releaseResources();
                     }
                     scope.scheduler.scheduleExecution(request, entityProducer, scope, asyncExecCallback, state.delay);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HTTPCLIENT-2194

We found that our async retries were failing because there was no body being set.  Releasing the entityProducer resets the starting point to 0 and resolved the issue for us.