### PR TITLE
Fix AbstractClientTlsStrategy to respect HttpVersionPolicy

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/AbstractClientTlsStrategy.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/AbstractClientTlsStrategy.java
@@ -135,7 +135,7 @@ abstract class AbstractClientTlsStrategy implements TlsStrategy {
                 H2TlsSupport.setEnableRetransmissions(sslParameters, false);
             }
 
-            applyParameters(sslEngine, sslParameters, H2TlsSupport.selectApplicationProtocols(attachment));
+            applyParameters(sslEngine, sslParameters, H2TlsSupport.selectApplicationProtocols(versionPolicy));
 
             initializeEngine(sslEngine);
 


### PR DESCRIPTION
Fixed AbstractClientTlsStrategy to respect configured HttpVersionPolicy of TlsConfig by providing the value to H2TlsSupport protocol selection method.