### PR TITLE
HTTPCLIENT-2198, Fixed AbstractClientTlsStrategy to respect HttpVersionPolicy

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/AbstractClientTlsStrategy.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/AbstractClientTlsStrategy.java
@@ -135,7 +135,7 @@ abstract class AbstractClientTlsStrategy implements TlsStrategy {
                 H2TlsSupport.setEnableRetransmissions(sslParameters, false);
             }
 
-            applyParameters(sslEngine, sslParameters, H2TlsSupport.selectApplicationProtocols(attachment));
+            applyParameters(sslEngine, sslParameters, H2TlsSupport.selectApplicationProtocols(versionPolicy));
 
             initializeEngine(sslEngine);
 


### PR DESCRIPTION
Updated AbstractClientTlsStrategy to pass only the HttpVersionPolicy instead of the entire TlsConfig to H2TlsSupport.selectApplicationProtocols() method, since this is the expected data type.