### PR TITLE
HTTPCLIENT-2198, Fixed NPE in TlsConfig.toString()

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/config/TlsConfig.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/config/TlsConfig.java
@@ -108,8 +108,8 @@ public class TlsConfig implements Cloneable {
         final StringBuilder builder = new StringBuilder();
         builder.append("[");
         builder.append("handshakeTimeout=").append(handshakeTimeout);
-        builder.append(", supportedProtocols=").append(Arrays.asList(supportedProtocols));
-        builder.append(", supportedCipherSuites=").append(Arrays.asList(supportedCipherSuites));
+        builder.append(", supportedProtocols=").append(Arrays.toString(supportedProtocols));
+        builder.append(", supportedCipherSuites=").append(Arrays.toString(supportedCipherSuites));
         builder.append(", httpVersionPolicy=").append(httpVersionPolicy);
         builder.append("]");
         return builder.toString();

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/AbstractClientTlsStrategy.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/AbstractClientTlsStrategy.java
@@ -135,7 +135,7 @@ abstract class AbstractClientTlsStrategy implements TlsStrategy {
                 H2TlsSupport.setEnableRetransmissions(sslParameters, false);
             }
 
-            applyParameters(sslEngine, sslParameters, H2TlsSupport.selectApplicationProtocols(attachment));
+            applyParameters(sslEngine, sslParameters, H2TlsSupport.selectApplicationProtocols(versionPolicy));
 
             initializeEngine(sslEngine);
 


### PR DESCRIPTION
Replaced calls to Arrays.asList() with Arrays.toString(), which allows for null argument.