### PR TITLE
HTTPCLIENT-2209: Pass HttpContext to AsyncClientConnectionOperator

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/DefaultAsyncClientConnectionOperator.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/DefaultAsyncClientConnectionOperator.java
@@ -78,7 +78,7 @@ final class DefaultAsyncClientConnectionOperator implements AsyncClientConnectio
             final Object attachment,
             final FutureCallback<ManagedAsyncClientConnection> callback) {
         return connect(connectionInitiator, host, localAddress, connectTimeout,
-            attachment, callback, null);
+            attachment, null, callback);
     }
 
     @Override
@@ -88,8 +88,8 @@ final class DefaultAsyncClientConnectionOperator implements AsyncClientConnectio
             final SocketAddress localAddress,
             final Timeout connectTimeout,
             final Object attachment,
-            final FutureCallback<ManagedAsyncClientConnection> callback,
-            final HttpContext context) {
+            final HttpContext context,
+            final FutureCallback<ManagedAsyncClientConnection> callback) {
         Args.notNull(connectionInitiator, "Connection initiator");
         Args.notNull(host, "Host");
         final ComplexFuture<ManagedAsyncClientConnection> future = new ComplexFuture<>(callback);
@@ -164,7 +164,7 @@ final class DefaultAsyncClientConnectionOperator implements AsyncClientConnectio
             final HttpHost host,
             final Object attachment,
             final HttpContext context) {
-        upgrade(connection, host, attachment, null, context);
+        upgrade(connection, host, attachment, context, null);
     }
 
     @Override
@@ -172,8 +172,8 @@ final class DefaultAsyncClientConnectionOperator implements AsyncClientConnectio
             final ManagedAsyncClientConnection connection,
             final HttpHost host,
             final Object attachment,
-            final FutureCallback<ManagedAsyncClientConnection> callback,
-            final HttpContext context) {
+            final HttpContext context,
+            final FutureCallback<ManagedAsyncClientConnection> callback) {
         final TlsStrategy tlsStrategy = tlsStrategyLookup != null ? tlsStrategyLookup.lookup(host.getSchemeName()) : null;
         if (tlsStrategy != null) {
             tlsStrategy.upgrade(

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/DefaultAsyncClientConnectionOperator.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/DefaultAsyncClientConnectionOperator.java
@@ -47,6 +47,7 @@ import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.URIScheme;
 import org.apache.hc.core5.http.config.Lookup;
 import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
+import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.reactor.ConnectionInitiator;
 import org.apache.hc.core5.reactor.IOSession;
 import org.apache.hc.core5.reactor.ssl.TransportSecurityLayer;
@@ -76,6 +77,19 @@ final class DefaultAsyncClientConnectionOperator implements AsyncClientConnectio
             final Timeout connectTimeout,
             final Object attachment,
             final FutureCallback<ManagedAsyncClientConnection> callback) {
+        return connect(connectionInitiator, host, localAddress, connectTimeout,
+            attachment, callback, null);
+    }
+
+    @Override
+    public Future<ManagedAsyncClientConnection> connect(
+            final ConnectionInitiator connectionInitiator,
+            final HttpHost host,
+            final SocketAddress localAddress,
+            final Timeout connectTimeout,
+            final Object attachment,
+            final FutureCallback<ManagedAsyncClientConnection> callback,
+            final HttpContext context) {
         Args.notNull(connectionInitiator, "Connection initiator");
         Args.notNull(host, "Host");
         final ComplexFuture<ManagedAsyncClientConnection> future = new ComplexFuture<>(callback);
@@ -141,7 +155,7 @@ final class DefaultAsyncClientConnectionOperator implements AsyncClientConnectio
             final ManagedAsyncClientConnection connection,
             final HttpHost host,
             final Object attachment) {
-        upgrade(connection, host, attachment, null);
+        upgrade(connection, host, attachment, null, null);
     }
 
     @Override
@@ -149,7 +163,17 @@ final class DefaultAsyncClientConnectionOperator implements AsyncClientConnectio
             final ManagedAsyncClientConnection connection,
             final HttpHost host,
             final Object attachment,
-            final FutureCallback<ManagedAsyncClientConnection> callback) {
+            final HttpContext context) {
+        upgrade(connection, host, attachment, null, context);
+    }
+
+    @Override
+    public void upgrade(
+            final ManagedAsyncClientConnection connection,
+            final HttpHost host,
+            final Object attachment,
+            final FutureCallback<ManagedAsyncClientConnection> callback,
+            final HttpContext context) {
         final TlsStrategy tlsStrategy = tlsStrategyLookup != null ? tlsStrategyLookup.lookup(host.getSchemeName()) : null;
         if (tlsStrategy != null) {
             tlsStrategy.upgrade(

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java
@@ -469,8 +469,8 @@ public class PoolingAsyncClientConnectionManager implements AsyncClientConnectio
                     public void cancelled() {
                         resultFuture.cancel();
                     }
-
-                });
+                },
+                context);
         resultFuture.setDependency(connectFuture);
         return resultFuture;
     }
@@ -516,8 +516,8 @@ public class PoolingAsyncClientConnectionManager implements AsyncClientConnectio
                             }
                         }
                     }
-
-                });
+                },
+                context);
     }
 
     @Override

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java
@@ -441,6 +441,7 @@ public class PoolingAsyncClientConnectionManager implements AsyncClientConnectio
                 route.isTunnelled() ? TlsConfig.copy(tlsConfig)
                         .setVersionPolicy(HttpVersionPolicy.FORCE_HTTP_1)
                         .build() : tlsConfig,
+                context,
                 new FutureCallback<ManagedAsyncClientConnection>() {
 
                     @Override
@@ -469,8 +470,7 @@ public class PoolingAsyncClientConnectionManager implements AsyncClientConnectio
                     public void cancelled() {
                         resultFuture.cancel();
                     }
-                },
-                context);
+                });
         resultFuture.setDependency(connectFuture);
         return resultFuture;
     }
@@ -491,6 +491,7 @@ public class PoolingAsyncClientConnectionManager implements AsyncClientConnectio
                 poolEntry.getConnection(),
                 route.getTargetHost(),
                 attachment != null ? attachment : tlsConfig,
+                context,
                 new CallbackContribution<ManagedAsyncClientConnection>(callback) {
 
                     @Override
@@ -516,8 +517,7 @@ public class PoolingAsyncClientConnectionManager implements AsyncClientConnectio
                             }
                         }
                     }
-                },
-                context);
+                });
     }
 
     @Override

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/nio/AsyncClientConnectionOperator.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/nio/AsyncClientConnectionOperator.java
@@ -35,6 +35,7 @@ import org.apache.hc.core5.annotation.Internal;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.concurrent.FutureCallback;
 import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.reactor.ConnectionInitiator;
 import org.apache.hc.core5.util.Timeout;
 
@@ -68,6 +69,32 @@ public interface AsyncClientConnectionOperator {
             FutureCallback<ManagedAsyncClientConnection> callback);
 
     /**
+     * Initiates operation to create a connection to the remote endpoint using
+     * the provided {@link ConnectionInitiator}.
+     *
+     * @param connectionInitiator the connection initiator.
+     * @param host the address of the opposite endpoint.
+     * @param localAddress the address of the local endpoint.
+     * @param connectTimeout the timeout of the connect operation.
+     * @param attachment the attachment, which can be any object representing custom parameter
+     *                    of the operation.
+     * @param callback the future result callback.
+     * @param context the execution context.
+     * @since 5.2
+     */
+    default Future<ManagedAsyncClientConnection> connect(
+            ConnectionInitiator connectionInitiator,
+            HttpHost host,
+            SocketAddress localAddress,
+            Timeout connectTimeout,
+            Object attachment,
+            FutureCallback<ManagedAsyncClientConnection> callback,
+            HttpContext context) {
+        return connect(connectionInitiator, host, localAddress, connectTimeout,
+            attachment, callback);
+    }
+
+    /**
      * Upgrades transport security of the given managed connection
      * by using the TLS security protocol.
      *
@@ -86,18 +113,35 @@ public interface AsyncClientConnectionOperator {
      * @param host the address of the opposite endpoint with TLS security.
      * @param attachment the attachment, which can be any object representing custom parameter
      *                    of the operation.
-     *
+     * @param callback the future result callback.
+     * @param context the execution context.
      * @since 5.2
      */
     default void upgrade(
             ManagedAsyncClientConnection conn,
             HttpHost host,
             Object attachment,
-            FutureCallback<ManagedAsyncClientConnection> callback) {
-        upgrade(conn, host, attachment);
+            FutureCallback<ManagedAsyncClientConnection> callback,
+            HttpContext context) {
+        upgrade(conn, host, attachment, context);
         if (callback != null) {
             callback.completed(conn);
         }
+    }
+
+    /**
+     * Upgrades transport security of the given managed connection
+     * by using the TLS security protocol.
+     *
+     * @param conn the managed connection.
+     * @param host the address of the opposite endpoint with TLS security.
+     * @param attachment the attachment, which can be any object representing custom parameter
+     *                    of the operation.
+     * @param context the execution context.
+     * @since 5.2
+     */
+    default void upgrade(ManagedAsyncClientConnection conn, HttpHost host, Object attachment, HttpContext context) {
+        upgrade(conn, host, attachment);
     }
 
 }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/nio/AsyncClientConnectionOperator.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/nio/AsyncClientConnectionOperator.java
@@ -78,8 +78,8 @@ public interface AsyncClientConnectionOperator {
      * @param connectTimeout the timeout of the connect operation.
      * @param attachment the attachment, which can be any object representing custom parameter
      *                    of the operation.
-     * @param callback the future result callback.
      * @param context the execution context.
+     * @param callback the future result callback.
      * @since 5.2
      */
     default Future<ManagedAsyncClientConnection> connect(
@@ -88,8 +88,8 @@ public interface AsyncClientConnectionOperator {
             SocketAddress localAddress,
             Timeout connectTimeout,
             Object attachment,
-            FutureCallback<ManagedAsyncClientConnection> callback,
-            HttpContext context) {
+            HttpContext context,
+            FutureCallback<ManagedAsyncClientConnection> callback) {
         return connect(connectionInitiator, host, localAddress, connectTimeout,
             attachment, callback);
     }
@@ -113,16 +113,16 @@ public interface AsyncClientConnectionOperator {
      * @param host the address of the opposite endpoint with TLS security.
      * @param attachment the attachment, which can be any object representing custom parameter
      *                    of the operation.
-     * @param callback the future result callback.
      * @param context the execution context.
+     * @param callback the future result callback.
      * @since 5.2
      */
     default void upgrade(
             ManagedAsyncClientConnection conn,
             HttpHost host,
             Object attachment,
-            FutureCallback<ManagedAsyncClientConnection> callback,
-            HttpContext context) {
+            HttpContext context,
+            FutureCallback<ManagedAsyncClientConnection> callback) {
         upgrade(conn, host, attachment, context);
         if (callback != null) {
             callback.completed(conn);


### PR DESCRIPTION
Pass HttpContext to AsyncClientConnectionOperator, change is non-breaking by introducing two default methods:

```
    default void upgrade(ManagedAsyncClientConnection conn, HttpHost host, Object attachment, HttpContext context) {
        upgrade(conn, host, attachment);
    }

    default Future<ManagedAsyncClientConnection> connect(
            ConnectionInitiator connectionInitiator,
            HttpHost host,
            SocketAddress localAddress,
            Timeout connectTimeout,
            Object attachment,
            HttpContext context,
            FutureCallback<ManagedAsyncClientConnection> callback) {
        return connect(connectionInitiator, host, localAddress, connectTimeout,
            attachment, callback);
    }
```