### PR TITLE
Create daemon threads in InternalAbstractHttpAsyncClient

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalAbstractHttpAsyncClient.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalAbstractHttpAsyncClient.java
@@ -81,7 +81,7 @@ import org.slf4j.LoggerFactory;
 
 abstract class InternalAbstractHttpAsyncClient extends AbstractHttpAsyncClientBase {
 
-    private final static ThreadFactory SCHEDULER_THREAD_FACTORY = new DefaultThreadFactory("Scheduled-executor");
+    private final static ThreadFactory SCHEDULER_THREAD_FACTORY = new DefaultThreadFactory("Scheduled-executor", true);
 
     private static final Logger LOG = LoggerFactory.getLogger(InternalAbstractHttpAsyncClient.class);
     private final AsyncExecChainElement execChain;


### PR DESCRIPTION
This thread pool is currently preventing applications with unclosed clients from exiting. Anyone who needs a client to finish a call before shutting down can continue to block on a non-daemon thread, but now someone needing an immediate shutdown is able to actually trigger one.