### PR TITLE
Updated copyright statement in NOTICE.txt

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache HttpComponents Client
-Copyright 1999-2021 The Apache Software Foundation
+Copyright 1999-2022 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
Updated the copyright in notice to the present year 2022.

- This came up in a discussion on PR for including this notice in Apache Iceberg 
  - https://github.com/apache/iceberg/pull/4688#discussion_r864419657