### PR TITLE
HTTPCLIENT-2218: Use Java 8 Base64 utility

### DIFF
--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/memcached/SHA256KeyHashingScheme.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/memcached/SHA256KeyHashingScheme.java
@@ -29,7 +29,7 @@ package org.apache.hc.client5.http.impl.cache.memcached;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
-import org.apache.commons.codec.binary.Hex;
+import org.apache.hc.client5.http.utils.Hex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/httpclient5-testing/src/main/java/org/apache/hc/client5/testing/auth/BasicAuthTokenExtractor.java
+++ b/httpclient5-testing/src/main/java/org/apache/hc/client5/testing/auth/BasicAuthTokenExtractor.java
@@ -29,9 +29,7 @@ package org.apache.hc.client5.testing.auth;
 
 import java.nio.charset.StandardCharsets;
 
-import org.apache.commons.codec.BinaryDecoder;
-import org.apache.commons.codec.DecoderException;
-import org.apache.commons.codec.binary.Base64;
+import org.apache.hc.client5.http.utils.Base64;
 import org.apache.hc.client5.http.auth.StandardAuthScheme;
 import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.ProtocolException;
@@ -49,9 +47,9 @@ public class BasicAuthTokenExtractor {
                 final String s = challengeResponse.substring(i + 1).trim();
                 try {
                     final byte[] credsRaw = s.getBytes(StandardCharsets.US_ASCII);
-                    final BinaryDecoder codec = new Base64();
+                    final Base64 codec = new Base64();
                     return new String(codec.decode(credsRaw), StandardCharsets.US_ASCII);
-                } catch (final DecoderException ex) {
+                } catch (final IllegalArgumentException ex) {
                     throw new ProtocolException("Malformed Basic credentials");
                 }
             }

--- a/httpclient5-win/src/main/java/org/apache/hc/client5/http/impl/win/WindowsNegotiateScheme.java
+++ b/httpclient5-win/src/main/java/org/apache/hc/client5/http/impl/win/WindowsNegotiateScheme.java
@@ -28,7 +28,7 @@ package org.apache.hc.client5.http.impl.win;
 
 import java.security.Principal;
 
-import org.apache.commons.codec.binary.Base64;
+import org.apache.hc.client5.http.utils.Base64;
 import org.apache.hc.client5.http.RouteInfo;
 import org.apache.hc.client5.http.auth.AuthChallenge;
 import org.apache.hc.client5.http.auth.AuthScheme;

--- a/httpclient5/pom.xml
+++ b/httpclient5/pom.xml
@@ -80,6 +80,7 @@
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.brotli</groupId>

--- a/httpclient5/pom.xml
+++ b/httpclient5/pom.xml
@@ -78,11 +78,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>commons-codec</groupId>
-      <artifactId>commons-codec</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.brotli</groupId>
       <artifactId>dec</artifactId>
       <optional>true</optional>

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/entity/mime/HttpRFC7578Multipart.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/entity/mime/HttpRFC7578Multipart.java
@@ -36,7 +36,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.BitSet;
 import java.util.List;
 
-import org.apache.commons.codec.DecoderException;
 import org.apache.hc.core5.http.NameValuePair;
 import org.apache.hc.core5.util.ByteArrayBuffer;
 
@@ -129,7 +128,7 @@ class HttpRFC7578Multipart extends AbstractMultipartFormat {
             return buffer.toByteArray();
         }
 
-        public byte[] decode(final byte[] bytes) throws DecoderException {
+        public byte[] decode(final byte[] bytes) throws IllegalArgumentException {
             if (bytes == null) {
                 return null;
             }
@@ -138,7 +137,7 @@ class HttpRFC7578Multipart extends AbstractMultipartFormat {
                 final int b = bytes[i];
                 if (b == ESCAPE_CHAR) {
                     if (i >= bytes.length - 2) {
-                        throw new DecoderException("Invalid URL encoding: too short");
+                        throw new IllegalArgumentException("Invalid URL encoding: too short");
                     }
                     final int u = digit16(bytes[++i]);
                     final int l = digit16(bytes[++i]);
@@ -163,13 +162,13 @@ class HttpRFC7578Multipart extends AbstractMultipartFormat {
      *            The byte to be converted.
      * @return The numeric value represented by the character in radix 16.
      *
-     * @throws DecoderException
+     * @throws IllegalArgumentException
      *             Thrown when the byte is not valid per {@link Character#digit(char,int)}
      */
-    static int digit16(final byte b) throws DecoderException {
+    static int digit16(final byte b) throws IllegalArgumentException {
         final int i = Character.digit((char) b, RADIX);
         if (i == -1) {
-            throw new DecoderException("Invalid URL encoding: not a valid digit (radix " + RADIX + "): " + b);
+            throw new IllegalArgumentException("Invalid URL encoding: not a valid digit (radix " + RADIX + "): " + b);
         }
         return i;
     }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/entity/mime/HttpRFC7578Multipart.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/entity/mime/HttpRFC7578Multipart.java
@@ -137,7 +137,7 @@ class HttpRFC7578Multipart extends AbstractMultipartFormat {
                 final int b = bytes[i];
                 if (b == ESCAPE_CHAR) {
                     if (i >= bytes.length - 2) {
-                        throw new IllegalArgumentException("Invalid URL encoding: too short");
+                        throw new IllegalArgumentException("Invalid encoding: too short");
                     }
                     final int u = digit16(bytes[++i]);
                     final int l = digit16(bytes[++i]);
@@ -165,10 +165,10 @@ class HttpRFC7578Multipart extends AbstractMultipartFormat {
      * @throws IllegalArgumentException
      *             Thrown when the byte is not valid per {@link Character#digit(char,int)}
      */
-    static int digit16(final byte b) throws IllegalArgumentException {
+    static int digit16(final byte b) {
         final int i = Character.digit((char) b, RADIX);
         if (i == -1) {
-            throw new IllegalArgumentException("Invalid URL encoding: not a valid digit (radix " + RADIX + "): " + b);
+            throw new IllegalArgumentException("Invalid encoding: not a valid digit (radix " + RADIX + "): " + b);
         }
         return i;
     }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/entity/mime/HttpRFC7578Multipart.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/entity/mime/HttpRFC7578Multipart.java
@@ -128,7 +128,7 @@ class HttpRFC7578Multipart extends AbstractMultipartFormat {
             return buffer.toByteArray();
         }
 
-        public byte[] decode(final byte[] bytes) throws IllegalArgumentException {
+        public byte[] decode(final byte[] bytes) {
             if (bytes == null) {
                 return null;
             }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/BasicScheme.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/BasicScheme.java
@@ -39,7 +39,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import org.apache.commons.codec.binary.Base64;
+import org.apache.hc.client5.http.utils.Base64;
 import org.apache.hc.client5.http.auth.AuthChallenge;
 import org.apache.hc.client5.http.auth.AuthScheme;
 import org.apache.hc.client5.http.auth.AuthScope;

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/GGSSchemeBase.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/GGSSchemeBase.java
@@ -29,7 +29,7 @@ package org.apache.hc.client5.http.impl.auth;
 import java.net.UnknownHostException;
 import java.security.Principal;
 
-import org.apache.commons.codec.binary.Base64;
+import org.apache.hc.client5.http.utils.Base64;
 import org.apache.hc.client5.http.DnsResolver;
 import org.apache.hc.client5.http.SystemDefaultDnsResolver;
 import org.apache.hc.client5.http.auth.AuthChallenge;

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/NTLMEngineImpl.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/NTLMEngineImpl.java
@@ -40,7 +40,7 @@ import java.util.Random;
 import javax.crypto.Cipher;
 import javax.crypto.spec.SecretKeySpec;
 
-import org.apache.commons.codec.binary.Base64;
+import org.apache.hc.client5.http.utils.Base64;
 import org.apache.hc.client5.http.utils.ByteArrayBuilder;
 
 /**

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/utils/Base64.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/utils/Base64.java
@@ -28,6 +28,8 @@
 package org.apache.hc.client5.http.utils;
 
 
+import org.apache.hc.core5.annotation.Internal;
+
 import java.nio.charset.StandardCharsets;
 
 import static java.util.Base64.getEncoder;
@@ -47,7 +49,7 @@ import static java.util.Base64.getMimeDecoder;
  * </ul>
  * <ul>Only the features currently used by http-client are implemented here rather than all the features of commons-coded</ul>
  */
-
+@Internal
 public class Base64 {
     private static final byte[] EMPTY_BYTES = new byte[0];
 

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/utils/Base64.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/utils/Base64.java
@@ -138,6 +138,13 @@ public class Base64 {
         }
 
         try {
+
+            // getMimeDecoder is used instead of getDecoder as it better matches the
+            // functionality of the default Commons Codec implementation (primarily more forgiving of strictly
+            // invalid inputs to decode)
+            // Code using java.util.Base64 directly should make a choice based on whether this forgiving nature is
+            // appropriate.
+
             return getMimeDecoder().decode(base64);
         } catch (final IllegalArgumentException e) {
             return EMPTY_BYTES;

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/utils/Base64.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/utils/Base64.java
@@ -30,8 +30,6 @@ package org.apache.hc.client5.http.utils;
 
 import org.apache.hc.core5.annotation.Internal;
 
-import java.nio.charset.StandardCharsets;
-
 import static java.util.Base64.getEncoder;
 import static java.util.Base64.getMimeDecoder;
 
@@ -39,30 +37,34 @@ import static java.util.Base64.getMimeDecoder;
  * Provide implementations of the Base64 conversion methods from commons-codec, delegating to  the Java Base64
  * implementation.
  * <p>
+ * * <ul>Only the features currently used by http-client are implemented here rather than all the features of commons-coded</ul>
  * Notes:
  * <p>
  * <ul>commons-codec accepts null inputs, so this is also accepted here. This is not done in the Java 8 implementation</ul>
- * <ul>decoding invalid inputs returns an empty value. The Java 8 implementation throws an exception, which is caught here</ul>
- * <ul>commons-codec decoders accept both standard and url-safe variants of input. This needs to be remapped for Java 8, as it
- * will accept either one or the other, but not both. This is likely a rarely-needed requirement, but is provided to avoid
- * compatibility surprises.
+ * <ul>Decoding invalid inputs returns an empty value. The Java 8 implementation throws an exception, which is caught here</ul>
+ * <ul>commons-codec decoders accept both standard and url-safe variants of input. As this is not a requirement for
+ * httpcommons-client, this is NOT implemented here.
  * </ul>
- * <ul>Only the features currently used by http-client are implemented here rather than all the features of commons-coded</ul>
+ * <p>
+ * This class is intended as in interim convenience. Any new code should just use `java.util.Base64` directly.
  */
 @Internal
 public class Base64 {
+    private static final Base64 CODEC = new Base64();
     private static final byte[] EMPTY_BYTES = new byte[0];
 
     /**
-     * Creates a Base64 codec used for decoding (all modes) and encoding in URL-unsafe mode.
+     * Return an instance of the Base64 codec that use the regular Base64 alphabet
+     * (as opposed to the URL-safe alphabet). Note that unlike the commons-codec version,
+     * thus class will NOT decode characters from URL-safe alphabet.
      */
     public Base64() {
     }
 
     /**
-     * Creates a Base64 codec used for decoding (all modes) and encoding in URL-unsafe mode.
+     * Creates a Base64 codec used for decoding and encoding in URL-unsafe mode.
      * <p>
-     * As http-client never uses a non-zero length, this feature is not implemented here.
+     * As httpcommons-client never uses a non-zero length, this feature is not implemented here.
      */
 
     public Base64(final int lineLength) {
@@ -74,48 +76,28 @@ public class Base64 {
     /**
      * Decodes Base64 data into octets.
      * <p>
-     * <b>Note:</b> this method seamlessly handles data encoded in URL-safe or normal mode.
+     * <b>Note:</b> this method does NOT accept URL-safe encodings
      */
     public static byte[] decodeBase64(final byte[] base64) {
-        if (null == base64) {
-            return null;
-        }
-
-        return decodeOrEmptyBytes(UrlByteRemapper.toStandardUrlEncoding(base64));
+        return CODEC.decode(base64);
     }
 
     /**
      * Decodes a Base64 String into octets.
      * <p>
-     * <b>Note:</b> this method seamlessly handles data encoded in URL-safe or normal mode.
+     * <b>Note:</b> this method does NOT accept URL-safe encodings
      */
 
     public static byte[] decodeBase64(final String base64) {
-        if (null == base64) {
-            return null;
-        }
-
-//        The acceptable Base64 alphabets have the same encodings in ASCII, ISO_8859_1, and UTF-8.
-//        ISO_8859_1 is used here because it matches the choice in the Java 8 Base64 implementation, and is
-//        in principle a tiny bit faster than the others to convert in versions of Java that support "compact strings".
-//        Any inputs outside the accepted values will be invalid in any encoding.
-
-        final byte[] bytes = base64.getBytes(StandardCharsets.ISO_8859_1);
-        UrlByteRemapper.replaceUrlSafeBytes(bytes);
-
-        return decodeOrEmptyBytes(bytes);
+        return CODEC.decode(base64);
     }
 
     /**
      * Encodes binary data using the base64 algorithm but does not chunk the output.
      */
 
-    public static byte[] encodeBase64(final byte[] bytes) {
-        if (null == bytes) {
-            return null;
-        }
-
-        return getEncoder().encode(bytes);
+    public static byte[] encodeBase64(final byte[] base64) {
+        return CODEC.encode(base64);
     }
 
     /**
@@ -131,7 +113,7 @@ public class Base64 {
     }
 
     /**
-     * Encode bytes to their Base64 form, using specifications from this codec instance
+     * Decode Base64-encoded bytes to their original form, using specifications from this codec instance
      */
 
     public byte[] decode(final byte[] base64) {
@@ -139,7 +121,27 @@ public class Base64 {
             return null;
         }
 
-        return decodeOrEmptyBytes(UrlByteRemapper.toStandardUrlEncoding(base64));
+        try {
+            return getMimeDecoder().decode(base64);
+        } catch (final IllegalArgumentException e) {
+            return EMPTY_BYTES;
+        }
+    }
+
+    /**
+     * Decode a Base64 String to its original form, using specifications from this codec instance
+     */
+
+    public byte[] decode(final String base64) {
+        if (null == base64) {
+            return null;
+        }
+
+        try {
+            return getMimeDecoder().decode(base64);
+        } catch (final IllegalArgumentException e) {
+            return EMPTY_BYTES;
+        }
     }
 
     /**
@@ -152,74 +154,4 @@ public class Base64 {
         return getEncoder().encode(value);
     }
 
-    /**
-     * Decode the provided byte array.
-     * <p>
-     * If the input cannot be coverted, an empty array is returned
-     */
-    private static byte[] decodeOrEmptyBytes(final byte[] bytes) {
-        try {
-            return getMimeDecoder().decode(bytes);
-        } catch (final IllegalArgumentException e) {
-            return EMPTY_BYTES;
-        }
-    }
-
-    /**
-     * Provide methods to remap values from url-safe Bas64 to standard encoding. The commons-codec
-     * implementation accepts both variants in the same input. The jdk implementaion does not, so
-     * inputs need to be
-     */
-    static class UrlByteRemapper {
-        private static final byte[] base64Url = genMapping();
-
-        /**
-         * generate a mapping that maps url-safe characters to their standard values,
-         * and leaves all other values the same.
-         */
-        private static byte[] genMapping() {
-            final byte[] mapping = new byte[256];
-            for (int i = 0; i < mapping.length; i++) {
-                mapping[i] = (byte) (i & 0xff);
-            }
-
-            mapping['-'] = '+';
-            mapping['_'] = '/';
-
-            return mapping;
-        }
-
-        /**
-         * Convert url-safe values to standard values, modifying the given array in-place.
-         *
-         * @param src Base64 encoded bytes, possibly containing url-safe characters
-         */
-        static void replaceUrlSafeBytes(final byte[] src) {
-            for (int i = 0; i < src.length; i++) {
-                src[i] = base64Url[src[i] & 0xff];
-            }
-        }
-
-
-        /**
-         * Convert url-safe values to standard values. The input array is left unmodified - a new array will be
-         * returned if re-mappings were needed.
-         *
-         * @param src Base64 encoded bytes, possibly containing url-safe characters
-         */
-        static byte[] toStandardUrlEncoding(final byte[] src) {
-            for (int i = 0; i < src.length; i++) {
-                if (src[i] == '-' || src[i] == '_') {
-                    final byte[] dup = src.clone();
-
-                    for (; i < dup.length; i++) {
-                        dup[i] = base64Url[dup[i] & 0xff];
-                    }
-                    return dup;
-                }
-            }
-
-            return src;
-        }
-    }
 }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/utils/Base64.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/utils/Base64.java
@@ -34,19 +34,19 @@ import static java.util.Base64.getEncoder;
 import static java.util.Base64.getMimeDecoder;
 
 /**
- * Provide implementations of the Base64 conversion methods from commons-codec, delegating to  the Java Base64
+ * Provide implementations of the Base64 conversion methods from Commons Codec, delegating to the Java Base64
  * implementation.
  * <p>
- * * <ul>Only the features currently used by http-client are implemented here rather than all the features of commons-coded</ul>
+ * * <ul>Only the features currently used by HttpClient are implemented here rather than all the features of Commons Codec</ul>
  * Notes:
  * <p>
- * <ul>commons-codec accepts null inputs, so this is also accepted here. This is not done in the Java 8 implementation</ul>
- * <ul>Decoding invalid inputs returns an empty value. The Java 8 implementation throws an exception, which is caught here</ul>
- * <ul>commons-codec decoders accept both standard and url-safe variants of input. As this is not a requirement for
- * httpcommons-client, this is NOT implemented here.
+ * <ul>Commons Codec accepts null inputs, so this is also accepted here. This is not done in the Java 8 implementation</ul>
+ * <ul>Decoding invalid input returns an empty value. The Java 8 implementation throws an exception, which is caught here</ul>
+ * <ul>Commons Codec decoders accept both standard and url-safe variants of input. As this is not a requirement for
+ * HttpClient, this is NOT implemented here.
  * </ul>
  * <p>
- * This class is intended as in interim convenience. Any new code should just use `java.util.Base64` directly.
+ * This class is intended as in interim convenience. Any new code should use `java.util.Base64` directly.
  */
 @Internal
 public class Base64 {
@@ -55,7 +55,7 @@ public class Base64 {
 
     /**
      * Return an instance of the Base64 codec that use the regular Base64 alphabet
-     * (as opposed to the URL-safe alphabet). Note that unlike the commons-codec version,
+     * (as opposed to the URL-safe alphabet). Note that unlike the Commons Codec version,
      * thus class will NOT decode characters from URL-safe alphabet.
      */
     public Base64() {
@@ -64,7 +64,7 @@ public class Base64 {
     /**
      * Creates a Base64 codec used for decoding and encoding in URL-unsafe mode.
      * <p>
-     * As httpcommons-client never uses a non-zero length, this feature is not implemented here.
+     * As HttpClient never uses a non-zero length, this feature is not implemented here.
      */
 
     public Base64(final int lineLength) {

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/utils/Base64.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/utils/Base64.java
@@ -1,0 +1,223 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.hc.client5.http.utils;
+
+
+import java.nio.charset.StandardCharsets;
+
+import static java.util.Base64.getEncoder;
+import static java.util.Base64.getMimeDecoder;
+
+/**
+ * Provide implementations of the Base64 conversion methods from commons-codec, delegating to  the Java Base64
+ * implementation.
+ * <p>
+ * Notes:
+ * <p>
+ * <ul>commons-codec accepts null inputs, so this is also accepted here. This is not done in the Java 8 implementation</ul>
+ * <ul>decoding invalid inputs returns an empty value. The Java 8 implementation throws an exception, which is caught here</ul>
+ * <ul>commons-codec decoders accept both standard and url-safe variants of input. This needs to be remapped for Java 8, as it
+ * will accept either one or the other, but not both. This is likely a rarely-needed requirement, but is provided to avoid
+ * compatibility surprises.
+ * </ul>
+ * <ul>Only the features currently used by http-client are implemented here rather than all the features of commons-coded</ul>
+ */
+
+public class Base64 {
+    private static final byte[] EMPTY_BYTES = new byte[0];
+
+    /**
+     * Creates a Base64 codec used for decoding (all modes) and encoding in URL-unsafe mode.
+     */
+    public Base64() {
+    }
+
+    /**
+     * Creates a Base64 codec used for decoding (all modes) and encoding in URL-unsafe mode.
+     * <p>
+     * As http-client never uses a non-zero length, this feature is not implemented here.
+     */
+
+    public Base64(final int lineLength) {
+        if (lineLength != 0) {
+            throw new UnsupportedOperationException("Line breaks not supported");
+        }
+    }
+
+    /**
+     * Decodes Base64 data into octets.
+     * <p>
+     * <b>Note:</b> this method seamlessly handles data encoded in URL-safe or normal mode.
+     */
+    public static byte[] decodeBase64(final byte[] base64) {
+        if (null == base64) {
+            return null;
+        }
+
+        return decodeOrEmptyBytes(UrlByteRemapper.toStandardUrlEncoding(base64));
+    }
+
+    /**
+     * Decodes a Base64 String into octets.
+     * <p>
+     * <b>Note:</b> this method seamlessly handles data encoded in URL-safe or normal mode.
+     */
+
+    public static byte[] decodeBase64(final String base64) {
+        if (null == base64) {
+            return null;
+        }
+
+//        The acceptable Base64 alphabets have the same encodings in ASCII, ISO_8859_1, and UTF-8.
+//        ISO_8859_1 is used here because it matches the choice in the Java 8 Base64 implementation, and is
+//        in principle a tiny bit faster than the others to convert in versions of Java that support "compact strings".
+//        Any inputs outside the accepted values will be invalid in any encoding.
+
+        final byte[] bytes = base64.getBytes(StandardCharsets.ISO_8859_1);
+        UrlByteRemapper.replaceUrlSafeBytes(bytes);
+
+        return decodeOrEmptyBytes(bytes);
+    }
+
+    /**
+     * Encodes binary data using the base64 algorithm but does not chunk the output.
+     */
+
+    public static byte[] encodeBase64(final byte[] bytes) {
+        if (null == bytes) {
+            return null;
+        }
+
+        return getEncoder().encode(bytes);
+    }
+
+    /**
+     * Encodes binary data using the base64 algorithm but does not chunk the output.
+     */
+
+    public static String encodeBase64String(final byte[] bytes) {
+        if (null == bytes) {
+            return null;
+        }
+
+        return getEncoder().encodeToString(bytes);
+    }
+
+    /**
+     * Encode bytes to their Base64 form, using specifications from this codec instance
+     */
+
+    public byte[] decode(final byte[] base64) {
+        if (null == base64) {
+            return null;
+        }
+
+        return decodeOrEmptyBytes(UrlByteRemapper.toStandardUrlEncoding(base64));
+    }
+
+    /**
+     * Encode bytes to their Base64 form, using specifications from this codec instance
+     */
+    public byte[] encode(final byte[] value) {
+        if (null == value) {
+            return null;
+        }
+        return getEncoder().encode(value);
+    }
+
+    /**
+     * Decode the provided byte array.
+     * <p>
+     * If the input cannot be coverted, an empty array is returned
+     */
+    private static byte[] decodeOrEmptyBytes(final byte[] bytes) {
+        try {
+            return getMimeDecoder().decode(bytes);
+        } catch (final IllegalArgumentException e) {
+            return EMPTY_BYTES;
+        }
+    }
+
+    /**
+     * Provide methods to remap values from url-safe Bas64 to standard encoding. The commons-codec
+     * implementation accepts both variants in the same input. The jdk implementaion does not, so
+     * inputs need to be
+     */
+    static class UrlByteRemapper {
+        private static final byte[] base64Url = genMapping();
+
+        /**
+         * generate a mapping that maps url-safe characters to their standard values,
+         * and leaves all other values the same.
+         */
+        private static byte[] genMapping() {
+            final byte[] mapping = new byte[256];
+            for (int i = 0; i < mapping.length; i++) {
+                mapping[i] = (byte) (i & 0xff);
+            }
+
+            mapping['-'] = '+';
+            mapping['_'] = '/';
+
+            return mapping;
+        }
+
+        /**
+         * Convert url-safe values to standard values, modifying the given array in-place.
+         *
+         * @param src Base64 encoded bytes, possibly containing url-safe characters
+         */
+        static void replaceUrlSafeBytes(final byte[] src) {
+            for (int i = 0; i < src.length; i++) {
+                src[i] = base64Url[src[i] & 0xff];
+            }
+        }
+
+
+        /**
+         * Convert url-safe values to standard values. The input array is left unmodified - a new array will be
+         * returned if re-mappings were needed.
+         *
+         * @param src Base64 encoded bytes, possibly containing url-safe characters
+         */
+        static byte[] toStandardUrlEncoding(final byte[] src) {
+            for (int i = 0; i < src.length; i++) {
+                if (src[i] == '-' || src[i] == '_') {
+                    final byte[] dup = src.clone();
+
+                    for (; i < dup.length; i++) {
+                        dup[i] = base64Url[dup[i] & 0xff];
+                    }
+                    return dup;
+                }
+            }
+
+            return src;
+        }
+    }
+}

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/utils/Hex.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/utils/Hex.java
@@ -1,0 +1,91 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+
+package org.apache.hc.client5.http.utils;
+
+public class Hex {
+
+    private Hex() {
+    }
+
+    public static String encodeHexString(final byte[] bytes) {
+
+        final char[] out = new char[bytes.length * 2];
+
+        encodeHex(bytes, 0, bytes.length, DIGITS_LOWER, out, 0);
+        return new String(out);
+    }
+
+    //
+    // The following comes from commons-codec
+    // https://github.com/apache/commons-codec/blob/master/src/main/java/org/apache/commons/codec/binary/Hex.java
+
+    /**
+     * Used to build output as hex.
+     */
+
+    private static final char[] DIGITS_LOWER = {
+            '0', '1', '2', '3', '4', '5', '6', '7',
+            '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'
+    };
+
+    /**
+     * Converts an array of bytes into an array of characters representing the hexadecimal values of each byte in order.
+     *
+     * @param data       a byte[] to convert to hex characters
+     * @param dataOffset the position in {@code data} to start encoding from
+     * @param dataLen    the number of bytes from {@code dataOffset} to encode
+     * @param toDigits   the output alphabet (must contain at least 16 chars)
+     * @param out        a char[] which will hold the resultant appropriate characters from the alphabet.
+     * @param outOffset  the position within {@code out} at which to start writing the encoded characters.
+     */
+    private static void encodeHex(final byte[] data, final int dataOffset, final int dataLen, final char[] toDigits,
+                                  final char[] out, final int outOffset) {
+        // two characters form the hex value.
+        for (int i = dataOffset, j = outOffset; i < dataOffset + dataLen; i++) {
+            out[j++] = toDigits[(0xF0 & data[i]) >>> 4];
+            out[j++] = toDigits[0x0F & data[i]];
+        }
+    }
+
+    /*
+
+       // Can be replaced in Java 17 with the following:
+
+
+    private static final java.util.HexFormat HEX_FORMAT = HexFormat.of();
+
+    public static String encodeHex(byte[] bytes) {
+        return HEX_FORMAT.formatHex(bytes);
+    }
+
+
+     */
+
+
+}

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/utils/Hex.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/utils/Hex.java
@@ -28,6 +28,9 @@
 
 package org.apache.hc.client5.http.utils;
 
+import org.apache.hc.core5.annotation.Internal;
+
+@Internal
 public class Hex {
 
     private Hex() {

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/entity/mime/HttpRFC7578MultipartTest.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/entity/mime/HttpRFC7578MultipartTest.java
@@ -29,7 +29,6 @@ package org.apache.hc.client5.http.entity.mime;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.apache.commons.codec.DecoderException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -37,7 +36,7 @@ public class HttpRFC7578MultipartTest {
 
     @Test
     public void testPercentDecodingWithTooShortMessage() throws Exception {
-        Assertions.assertThrows(DecoderException.class, () ->
+        Assertions.assertThrows(java.lang.IllegalArgumentException.class, () ->
                 new HttpRFC7578Multipart.PercentCodec().decode("%".getBytes()));
     }
 

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestBasicScheme.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestBasicScheme.java
@@ -31,9 +31,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.List;
 
-import org.apache.commons.codec.binary.Base64;
 import org.apache.hc.client5.http.auth.AuthChallenge;
 import org.apache.hc.client5.http.auth.AuthScheme;
 import org.apache.hc.client5.http.auth.AuthScope;
@@ -55,6 +55,7 @@ import org.junit.jupiter.api.Test;
  * Basic authentication test cases.
  */
 public class TestBasicScheme {
+    private static final Base64.Encoder BASE64_ENC = Base64.getEncoder();
 
     private static AuthChallenge parse(final String s) throws ParseException {
         final CharArrayBuffer buffer = new CharArrayBuffer(s.length());
@@ -90,9 +91,10 @@ public class TestBasicScheme {
         Assertions.assertTrue(authscheme.isResponseReady(host, credentialsProvider, null));
         final String authResponse = authscheme.generateAuthResponse(host, request, null);
 
-        final String expected = "Basic " + new String(
-                Base64.encodeBase64("testuser:testpass".getBytes(StandardCharsets.US_ASCII)),
-                StandardCharsets.US_ASCII);
+        final byte[] testCreds =  "testuser:testpass".getBytes(StandardCharsets.US_ASCII);
+
+        final String expected = "Basic " + BASE64_ENC.encodeToString(testCreds);
+
         Assertions.assertEquals(expected, authResponse);
         Assertions.assertEquals("test", authscheme.getRealm());
         Assertions.assertTrue(authscheme.isChallengeComplete());

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/utils/TestBase64.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/utils/TestBase64.java
@@ -1,0 +1,164 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+
+package org.apache.hc.client5.http.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestBase64 {
+
+    public static final String EMOJI = "\uD83D\uDE15";
+    public static final String ACCENT = "\u00E9";
+
+    @Test
+    void nullHandling() {
+        checkDecode(null);
+        checkEncode(null);
+    }
+
+    @Test
+    void zeroLength() {
+        checkDecode("");
+        checkEncode(new byte[0]);
+    }
+
+    @Test
+    void encodeByteValues() {
+        for (int i = 0; i < 256; i++) {
+            final byte[] value = new byte[10];
+            for (int j = 0; j < value.length; j++) {
+                value[j] = (byte) (i + j);
+            }
+            checkEncodeThenDecode(value);
+        }
+    }
+
+    @Test
+    void largeValue() {
+        final byte[] longArray = new byte[8000];
+        checkEncodeThenDecode(longArray);
+    }
+
+
+    @Test
+    void varyingLengths() {
+        for (int i = 0; i < 10; i++) {
+            final byte[] value = new byte[i];
+            checkEncodeThenDecode(value);
+        }
+    }
+
+
+    @Test
+    void decodeIgnoresEmbeddedInvalidChars() {
+        checkDecode("This is\n\nA test\ttest 123\n!\r\ndone");
+        checkDecode("AA AA");
+        checkDecode("AA" + EMOJI + "AA");
+        checkDecode("AA" + ACCENT + "AA");
+        checkDecode(" A A A A ");
+    }
+
+    @Test
+    void decodeInvalid() {
+        final char space = ' ';
+
+        checkDecode(fourOf(EMOJI));
+        checkDecode(fourOf(ACCENT));
+        checkDecode("A");
+        checkDecode("A===");
+        checkDecode(fourOf(space));
+        checkDecode(fourOf('='));
+        checkDecode(fourOf('@'));
+        checkDecode(fourOf((char) 0));
+    }
+
+    @Test
+    void decodeUnpadded() {
+        checkDecode("AA");
+        checkDecode("AAA");
+        checkDecode("BBBBAA");
+        checkDecode("BBBBAAA");
+    }
+
+    @Test
+    void decodeUrlSafe() {
+        final char underscore = '_';
+        final char minus = '-';
+
+        checkDecode(fourOf(minus));
+        checkDecode(fourOf(underscore));
+    }
+
+    @Test
+    void mixedUrlAndRegularEncoded() {
+        checkDecode("++__");
+        checkDecode("--//");
+    }
+
+    String checkEncode(final byte[] toEncode) {
+        final String expected = encodeWithCommonsCodec(toEncode);
+        final String actual = Base64.encodeBase64String(toEncode);
+
+        assertEquals(expected, actual);
+        return actual;
+    }
+
+    void checkDecode(final String encoded) {
+        final byte[] expected = decodeWithCommonsCodec(encoded);
+        final byte[] actual = Base64.decodeBase64(encoded);
+
+        assertArrayEquals(expected, actual);
+    }
+
+    private void checkEncodeThenDecode(final byte[] longArray) {
+        final String encoded = checkEncode(longArray);
+        checkDecode(encoded);
+    }
+
+    private static String fourOf(final char c) {
+        final String charStr = String.valueOf(c);
+        return fourOf(charStr);
+    }
+
+    private static String fourOf(final String str) {
+        return str + str + str + str;
+    }
+    // baseline methods
+
+    String encodeWithCommonsCodec(final byte[] value) {
+        return org.apache.commons.codec.binary.Base64.encodeBase64String(value);
+    }
+
+    byte[] decodeWithCommonsCodec(final String value) {
+        return org.apache.commons.codec.binary.Base64.decodeBase64(value);
+    }
+
+}

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/utils/TestBase64.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/utils/TestBase64.java
@@ -73,9 +73,9 @@ public class TestBase64 {
 
     @Test
     void validValues() {
-        final byte[] unencodedByes = "Hello World!".getBytes(US_ASCII);
-        checkDecode(unencodedByes, "SGVsbG8gV29ybGQh");
-        checkEncode("SGVsbG8gV29ybGQh", unencodedByes);
+        final byte[] unencodedBytes = "Hello World!".getBytes(US_ASCII);
+        checkDecode(unencodedBytes, "SGVsbG8gV29ybGQh");
+        checkEncode("SGVsbG8gV29ybGQh", unencodedBytes);
     }
 
     @Test

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/utils/TestBase64.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/utils/TestBase64.java
@@ -108,21 +108,6 @@ public class TestBase64 {
         checkDecode("BBBBAAA");
     }
 
-    @Test
-    void decodeUrlSafe() {
-        final char underscore = '_';
-        final char minus = '-';
-
-        checkDecode(fourOf(minus));
-        checkDecode(fourOf(underscore));
-    }
-
-    @Test
-    void mixedUrlAndRegularEncoded() {
-        checkDecode("++__");
-        checkDecode("--//");
-    }
-
     String checkEncode(final byte[] toEncode) {
         final String expected = encodeWithCommonsCodec(toEncode);
         final String actual = Base64.encodeBase64String(toEncode);

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,6 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <httpcore.version>5.2-beta1</httpcore.version>
     <log4j.version>2.17.0</log4j.version>
-    <commons-codec.version>1.15</commons-codec.version>
     <brotli.version>0.1.2</brotli.version>
     <conscrypt.version>2.5.2</conscrypt.version>
     <ehcache.version>3.9.6</ehcache.version>
@@ -143,11 +142,6 @@
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
         <version>${log4j.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>commons-codec</groupId>
-        <artifactId>commons-codec</artifactId>
-        <version>${commons-codec.version}</version>
       </dependency>
       <dependency>
         <groupId>org.brotli</groupId>


### PR DESCRIPTION
Add a utility to implement the parts of commons-codec Base64 that are needed by httpcomponents-client on top of Java 8 `java.util.Base64`,

Also updated the relevant places to make use of this new utility.

One note - I do not know what the Android compatibility needs are, or what portions of Java 8 are readily available in the versions of Android that are expected to be supported.  

From here: https://developer.android.com/reference/java/util/Base64

It appears that Api Level 26 added support.

At first glance, this change almost removes the need for the production commons-codec dependency. The remaining use is for hex-encoding, and a reused exception. These could easily also be removed. I have added a separate commit to implement this.