### PR TITLE
ResponseEntityProxy.writeTo(null) leaves connections in the correct state

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/ResponseEntityProxy.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/ResponseEntityProxy.java
@@ -94,9 +94,7 @@ class ResponseEntityProxy extends HttpEntityWrapper implements EofSensorWatcher 
     @Override
     public void writeTo(final OutputStream outStream) throws IOException {
         try {
-            if (outStream != null) {
-                super.writeTo(outStream);
-            }
+            super.writeTo(outStream != null ? outStream : NullOutputStream.INSTANCE);
             releaseConnection();
         } catch (final IOException | RuntimeException ex) {
             discardConnection();
@@ -186,6 +184,45 @@ class ResponseEntityProxy extends HttpEntityWrapper implements EofSensorWatcher 
             throw ex;
         } finally {
             cleanup();
+        }
+    }
+
+    private static final class NullOutputStream extends OutputStream {
+        private static final NullOutputStream INSTANCE = new NullOutputStream();
+
+        private NullOutputStream() {}
+
+        @Override
+        public void write(@SuppressWarnings("unused") final int byteValue) {
+            // no-op
+        }
+
+        @Override
+        public void write(@SuppressWarnings("unused") final byte[] buffer) {
+            // no-op
+        }
+
+        @Override
+        public void write(
+                @SuppressWarnings("unused") final byte[] buffer,
+                @SuppressWarnings("unused") final int off,
+                @SuppressWarnings("unused") final int len) {
+            // no-op
+        }
+
+        @Override
+        public void flush() {
+            // no-op
+        }
+
+        @Override
+        public void close() {
+            // no-op
+        }
+
+        @Override
+        public String toString() {
+            return "NullOutputStream{}";
         }
     }
 }


### PR DESCRIPTION
Previously writeTo would conditionally delegate to the wrapped
entity if the provided outputstream was non-null, however in the
null case the entity would not be drained and the connection would
be released potentially with bytes remaining. If this occurs in
practice, it may result in timeouts as the server expects to write
data to the response while the client is attempting to send a
request.

I haven't seen this create issues in practice, but I noticed the
oddity while working on #371.