### PR TITLE
Use HTTP header name constants

### DIFF
--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachedHttpResponseGenerator.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachedHttpResponseGenerator.java
@@ -116,7 +116,7 @@ class CachedHttpResponseGenerator {
             response.addHeader(etagHeader);
         }
 
-        final Header contentLocationHeader = entry.getFirstHeader("Content-Location");
+        final Header contentLocationHeader = entry.getFirstHeader(HttpHeaders.CONTENT_LOCATION);
         if (contentLocationHeader != null) {
             response.addHeader(contentLocationHeader);
         }

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingExecBase.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingExecBase.java
@@ -360,9 +360,9 @@ public class CachingExecBase {
      */
     void storeRequestIfModifiedSinceFor304Response(final HttpRequest request, final HttpResponse backendResponse) {
         if (backendResponse.getCode() == HttpStatus.SC_NOT_MODIFIED) {
-            final Header h = request.getFirstHeader("If-Modified-Since");
+            final Header h = request.getFirstHeader(HttpHeaders.IF_MODIFIED_SINCE);
             if (h != null) {
-                backendResponse.addHeader("Last-Modified", h.getValue());
+                backendResponse.addHeader(HttpHeaders.LAST_MODIFIED, h.getValue());
             }
         }
     }

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/DefaultAsyncCacheInvalidator.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/DefaultAsyncCacheInvalidator.java
@@ -43,6 +43,7 @@ import org.apache.hc.core5.concurrent.Cancellable;
 import org.apache.hc.core5.concurrent.FutureCallback;
 import org.apache.hc.core5.function.Resolver;
 import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.HttpResponse;
@@ -120,7 +121,7 @@ public class DefaultAsyncCacheInvalidator extends CacheInvalidatorBase implement
                         if (LOG.isWarnEnabled()) {
                             LOG.warn("{} is not a valid URI", s);
                         }
-                        final Header clHdr = request.getFirstHeader("Content-Location");
+                        final Header clHdr = request.getFirstHeader(HttpHeaders.CONTENT_LOCATION);
                         if (clHdr != null) {
                             final URI contentLocation = HttpCacheSupport.normalizeQuietly(clHdr.getValue());
                             if (contentLocation != null) {
@@ -129,7 +130,7 @@ public class DefaultAsyncCacheInvalidator extends CacheInvalidatorBase implement
                                 }
                             }
                         }
-                        final Header lHdr = request.getFirstHeader("Location");
+                        final Header lHdr = request.getFirstHeader(HttpHeaders.LOCATION);
                         if (lHdr != null) {
                             final URI location = HttpCacheSupport.normalizeQuietly(lHdr.getValue());
                             if (location != null) {

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/DefaultCacheInvalidator.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/DefaultCacheInvalidator.java
@@ -38,6 +38,7 @@ import org.apache.hc.core5.annotation.Internal;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.function.Resolver;
 import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.HttpResponse;
@@ -104,7 +105,7 @@ public class DefaultCacheInvalidator extends CacheInvalidatorBase implements Htt
                 if (LOG.isWarnEnabled()) {
                     LOG.warn("{} is not a valid URI", s);
                 }
-                final Header clHdr = request.getFirstHeader("Content-Location");
+                final Header clHdr = request.getFirstHeader(HttpHeaders.CONTENT_LOCATION);
                 if (clHdr != null) {
                     final URI contentLocation = HttpCacheSupport.normalizeQuietly(clHdr.getValue());
                     if (contentLocation != null) {
@@ -113,7 +114,7 @@ public class DefaultCacheInvalidator extends CacheInvalidatorBase implements Htt
                         }
                     }
                 }
-                final Header lHdr = request.getFirstHeader("Location");
+                final Header lHdr = request.getFirstHeader(HttpHeaders.LOCATION);
                 if (lHdr != null) {
                     final URI location = HttpCacheSupport.normalizeQuietly(lHdr.getValue());
                     if (location != null) {

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/DefaultRedirectStrategy.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/DefaultRedirectStrategy.java
@@ -90,7 +90,7 @@ public class DefaultRedirectStrategy implements RedirectStrategy {
         Args.notNull(context, "HTTP context");
 
         //get the location header to find out where to redirect to
-        final Header locationHeader = response.getFirstHeader("location");
+        final Header locationHeader = response.getFirstHeader(HttpHeaders.LOCATION);
         if (locationHeader == null) {
             throw new HttpException("Redirect location is missing");
         }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/protocol/ResponseProcessCookies.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/protocol/ResponseProcessCookies.java
@@ -41,6 +41,7 @@ import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.http.EntityDetails;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpException;
+import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.HttpResponseInterceptor;
 import org.apache.hc.core5.http.protocol.HttpContext;
@@ -96,7 +97,7 @@ public class ResponseProcessCookies implements HttpResponseInterceptor {
             }
             return;
         }
-        final Iterator<Header> it = response.headerIterator("Set-Cookie");
+        final Iterator<Header> it = response.headerIterator(HttpHeaders.SET_COOKIE);
         processCookies(exchangeId, it, cookieSpec, cookieOrigin, cookieStore);
     }
 


### PR DESCRIPTION
Use HTTP header name constants instead of string literals.