### PR TITLE
Avoid unnecessary use of Instant.toEpochMilli

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/cookie/CookiePriorityComparator.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/cookie/CookiePriorityComparator.java
@@ -59,7 +59,7 @@ public class CookiePriorityComparator implements Comparator<Cookie> {
             final Instant d1 = c1.getCreationInstant();
             final Instant d2 = c2.getCreationInstant();
             if (d1 != null && d2 != null) {
-                return (int) (d1.toEpochMilli() - d2.toEpochMilli());
+                return d1.compareTo(d2);
             }
         }
         return result;

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/cookie/BasicClientCookie.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/cookie/BasicClientCookie.java
@@ -269,7 +269,7 @@ public final class BasicClientCookie implements SetCookie, Cloneable, Serializab
     public boolean isExpired(final Date date) {
         Args.notNull(date, "Date");
         return (cookieExpiryDate != null
-            && cookieExpiryDate.toEpochMilli() <= DateUtils.toInstant(date).toEpochMilli());
+            && cookieExpiryDate.compareTo(DateUtils.toInstant(date)) <= 0);
     }
 
     /**
@@ -282,7 +282,7 @@ public final class BasicClientCookie implements SetCookie, Cloneable, Serializab
     public boolean isExpired(final Instant instant) {
         Args.notNull(instant, "Instant");
         return (cookieExpiryDate != null
-                && cookieExpiryDate.toEpochMilli() <= instant.toEpochMilli());
+                && cookieExpiryDate.compareTo(instant) <= 0);
     }
 
     /**


### PR DESCRIPTION
Avoid unnecessary use of Instant.toEpochMilli by using Instant.compareTo
to compare Instants direclty