### PR TITLE
Cancel connection request on exception

### DIFF
--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -12,6 +12,9 @@ Change Log
 * Replace deprecated use of LangUtils#equals() with Objects.equals().
   Contributed by Gary Gregory <ggregory at apache.org>
 
+* Deprecated LangUtils#hashCode() in favor of Objects.hash() and Objects.hashCode().
+  Contributed by Gary Gregory <ggregory at apache.org>
+
 
 Release 5.2
 ------------------

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/HttpRoute.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/HttpRoute.java
@@ -39,7 +39,6 @@ import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.util.Args;
-import org.apache.hc.core5.util.LangUtils;
 
 /**
  * Connection route definition for HTTP requests.
@@ -281,18 +280,7 @@ public final class HttpRoute implements RouteInfo, Cloneable {
      */
     @Override
     public int hashCode() {
-        int hash = LangUtils.HASH_SEED;
-        hash = LangUtils.hashCode(hash, this.targetHost);
-        hash = LangUtils.hashCode(hash, this.localAddress);
-        if (this.proxyChain != null) {
-            for (final HttpHost element : this.proxyChain) {
-                hash = LangUtils.hashCode(hash, element);
-            }
-        }
-        hash = LangUtils.hashCode(hash, this.secure);
-        hash = LangUtils.hashCode(hash, this.tunnelled);
-        hash = LangUtils.hashCode(hash, this.layered);
-        return hash;
+        return Objects.hash(targetHost, localAddress, proxyChain, secure, tunnelled, layered);
     }
 
     /**

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/RouteTracker.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/RouteTracker.java
@@ -33,7 +33,6 @@ import java.util.Objects;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.Asserts;
-import org.apache.hc.core5.util.LangUtils;
 
 /**
  * Helps tracking the steps in establishing a route.
@@ -310,19 +309,7 @@ public final class RouteTracker implements RouteInfo, Cloneable {
      */
     @Override
     public int hashCode() {
-        int hash = LangUtils.HASH_SEED;
-        hash = LangUtils.hashCode(hash, this.targetHost);
-        hash = LangUtils.hashCode(hash, this.localAddress);
-        if (this.proxyChain != null) {
-            for (final HttpHost element : this.proxyChain) {
-                hash = LangUtils.hashCode(hash, element);
-            }
-        }
-        hash = LangUtils.hashCode(hash, this.connected);
-        hash = LangUtils.hashCode(hash, this.secure);
-        hash = LangUtils.hashCode(hash, this.tunnelled);
-        hash = LangUtils.hashCode(hash, this.layered);
-        return hash;
+        return Objects.hash(targetHost, localAddress, connected, proxyChain, secure, tunnelled, layered);
     }
 
     /**

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/auth/AuthScope.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/auth/AuthScope.java
@@ -33,7 +33,6 @@ import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.util.Args;
-import org.apache.hc.core5.util.LangUtils;
 
 /**
  * {@code AuthScope} represents an authentication scope consisting of
@@ -225,13 +224,7 @@ public class AuthScope {
 
     @Override
     public int hashCode() {
-        int hash = LangUtils.HASH_SEED;
-        hash = LangUtils.hashCode(hash, this.protocol);
-        hash = LangUtils.hashCode(hash, this.host);
-        hash = LangUtils.hashCode(hash, this.port);
-        hash = LangUtils.hashCode(hash, this.realm);
-        hash = LangUtils.hashCode(hash, toNullSafeLowerCase(this.schemeName));
-        return hash;
+        return Objects.hash(protocol, host, port, realm, toNullSafeLowerCase(this.schemeName));
     }
 
     private String toNullSafeLowerCase(final String str) {

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/auth/BasicUserPrincipal.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/auth/BasicUserPrincipal.java
@@ -33,7 +33,6 @@ import java.util.Objects;
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.util.Args;
-import org.apache.hc.core5.util.LangUtils;
 
 /**
  * Basic username based principal representation.
@@ -60,9 +59,7 @@ public final class BasicUserPrincipal implements Principal, Serializable {
 
     @Override
     public int hashCode() {
-        int hash = LangUtils.HASH_SEED;
-        hash = LangUtils.hashCode(hash, this.username);
-        return hash;
+        return Objects.hashCode(username);
     }
 
     @Override

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/auth/NTCredentials.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/auth/NTCredentials.java
@@ -34,7 +34,6 @@ import java.util.Objects;
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.util.Args;
-import org.apache.hc.core5.util.LangUtils;
 
 /**
  * Microsoft Windows specific {@link Credentials} representation that includes
@@ -146,11 +145,7 @@ public class NTCredentials implements Credentials, Serializable {
 
     @Override
     public int hashCode() {
-        int hash = LangUtils.HASH_SEED;
-        hash = LangUtils.hashCode(hash, this.principal);
-        hash = LangUtils.hashCode(hash, this.workstation);
-        hash = LangUtils.hashCode(hash, this.netbiosDomain);
-        return hash;
+        return Objects.hash(principal, workstation, netbiosDomain);
     }
 
     @Override

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/auth/NTUserPrincipal.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/auth/NTUserPrincipal.java
@@ -34,7 +34,6 @@ import java.util.Objects;
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.util.Args;
-import org.apache.hc.core5.util.LangUtils;
 
 /**
  * Microsoft Windows specific user principal implementation.
@@ -87,10 +86,7 @@ public class NTUserPrincipal implements Principal, Serializable {
 
     @Override
     public int hashCode() {
-        int hash = LangUtils.HASH_SEED;
-        hash = LangUtils.hashCode(hash, this.username);
-        hash = LangUtils.hashCode(hash, this.domain);
-        return hash;
+        return Objects.hash(username, domain);
     }
 
     @Override

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/BasicAuthCache.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/BasicAuthCache.java
@@ -46,7 +46,6 @@ import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.net.NamedEndpoint;
 import org.apache.hc.core5.util.Args;
-import org.apache.hc.core5.util.LangUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -98,12 +97,7 @@ public class BasicAuthCache implements AuthCache {
 
         @Override
         public int hashCode() {
-            int hash = LangUtils.HASH_SEED;
-            hash = LangUtils.hashCode(hash, this.scheme);
-            hash = LangUtils.hashCode(hash, this.host);
-            hash = LangUtils.hashCode(hash, this.port);
-            hash = LangUtils.hashCode(hash, this.pathPrefix);
-            return hash;
+            return Objects.hash(scheme, host, port, pathPrefix);
         }
 
         @Override

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/InternalExecRuntime.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/InternalExecRuntime.java
@@ -116,11 +116,14 @@ class InternalExecRuntime implements ExecRuntime, Cancellable {
                     log.debug("{} acquired endpoint {}", id, ConnPoolSupport.getId(connectionEndpoint));
                 }
             } catch(final TimeoutException ex) {
+                connRequest.cancel();
                 throw new ConnectionRequestTimeoutException(ex.getMessage());
             } catch(final InterruptedException interrupted) {
+                connRequest.cancel();
                 Thread.currentThread().interrupt();
                 throw new RequestFailedException("Request aborted", interrupted);
             } catch(final ExecutionException ex) {
+                connRequest.cancel();
                 Throwable cause = ex.getCause();
                 if (cause == null) {
                     cause = ex;


### PR DESCRIPTION
This PR addresses an issue when interrupting a thread when using an `HttpClient` with the `PoolingHttpClientConnectionManager`. If the pool reaches the max size, and the client is waiting on a lease request, and if the client thread is interrupted, the lease will continue to wait and the pool will not free up until the lease request timeout is reached. This change will explicitly cancel the lease request if an exception occurs.