### PR TITLE
feature(SSLConnectionSocketFactory): Pass HttpContext to prepareSocket method

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/SSLConnectionSocketFactory.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/SSLConnectionSocketFactory.java
@@ -183,7 +183,6 @@ public class SSLConnectionSocketFactory implements LayeredConnectionSocketFactor
      * @deprecated Use {@link #prepareSocket(SSLSocket, HttpContext)}
      */
     @Deprecated
-    @SuppressWarnings("deprecation")
     protected void prepareSocket(final SSLSocket socket) throws IOException {
     }
 
@@ -195,6 +194,7 @@ public class SSLConnectionSocketFactory implements LayeredConnectionSocketFactor
      * call {@link javax.net.ssl.SSLSocket#setEnabledCipherSuites(String[])}.
      * @throws IOException may be thrown if overridden
      */
+    @SuppressWarnings("deprecation")
     protected void prepareSocket(final SSLSocket socket, final HttpContext context) throws IOException {
         prepareSocket(socket);
     }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/SSLConnectionSocketFactory.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/SSLConnectionSocketFactory.java
@@ -56,7 +56,6 @@ import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.http.ssl.TLS;
 import org.apache.hc.core5.http.ssl.TlsCiphers;
 import org.apache.hc.core5.io.Closer;
-import org.apache.hc.core5.reactor.ssl.SSLBufferMode;
 import org.apache.hc.core5.ssl.SSLContexts;
 import org.apache.hc.core5.ssl.SSLInitializationException;
 import org.apache.hc.core5.util.Args;

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/SSLConnectionSocketFactory.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/SSLConnectionSocketFactory.java
@@ -56,6 +56,7 @@ import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.http.ssl.TLS;
 import org.apache.hc.core5.http.ssl.TlsCiphers;
 import org.apache.hc.core5.io.Closer;
+import org.apache.hc.core5.reactor.ssl.SSLBufferMode;
 import org.apache.hc.core5.ssl.SSLContexts;
 import org.apache.hc.core5.ssl.SSLInitializationException;
 import org.apache.hc.core5.util.Args;
@@ -178,6 +179,10 @@ public class SSLConnectionSocketFactory implements LayeredConnectionSocketFactor
         this.tlsSessionValidator = new TlsSessionValidator(LOG);
     }
 
+    /**
+     * @deprecated Use {@link #prepareSocket(SSLSocket, HttpContext)}
+     */
+    @Deprecated
     protected void prepareSocket(final SSLSocket socket) throws IOException {
     }
 

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/SSLConnectionSocketFactory.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/SSLConnectionSocketFactory.java
@@ -178,6 +178,9 @@ public class SSLConnectionSocketFactory implements LayeredConnectionSocketFactor
         this.tlsSessionValidator = new TlsSessionValidator(LOG);
     }
 
+    protected void prepareSocket(final SSLSocket socket) throws IOException {
+    }
+
     /**
      * Performs any custom initialization for a newly created SSLSocket
      * (before the SSL handshake happens).
@@ -187,6 +190,7 @@ public class SSLConnectionSocketFactory implements LayeredConnectionSocketFactor
      * @throws IOException may be thrown if overridden
      */
     protected void prepareSocket(final SSLSocket socket, final HttpContext context) throws IOException {
+        prepareSocket(socket);
     }
 
     @Override

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/SSLConnectionSocketFactory.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/SSLConnectionSocketFactory.java
@@ -186,7 +186,7 @@ public class SSLConnectionSocketFactory implements LayeredConnectionSocketFactor
      * call {@link javax.net.ssl.SSLSocket#setEnabledCipherSuites(String[])}.
      * @throws IOException may be thrown if overridden
      */
-    protected void prepareSocket(final SSLSocket socket) throws IOException {
+    protected void prepareSocket(final SSLSocket socket, final HttpContext context) throws IOException {
     }
 
     @Override
@@ -245,7 +245,7 @@ public class SSLConnectionSocketFactory implements LayeredConnectionSocketFactor
         // Setup SSL layering if necessary
         if (sock instanceof SSLSocket) {
             final SSLSocket sslsock = (SSLSocket) sock;
-            executeHandshake(sslsock, host.getHostName(), attachment);
+            executeHandshake(sslsock, host.getHostName(), attachment, context);
             return sock;
         }
         return createLayeredSocket(sock, host.getHostName(), remoteAddress.getPort(), attachment, context);
@@ -272,11 +272,15 @@ public class SSLConnectionSocketFactory implements LayeredConnectionSocketFactor
                 target,
                 port,
                 true);
-        executeHandshake(sslsock, target, attachment);
+        executeHandshake(sslsock, target, attachment, context);
         return sslsock;
     }
 
-    private void executeHandshake(final SSLSocket sslsock, final String target, final Object attachment) throws IOException {
+    private void executeHandshake(
+            final SSLSocket sslsock,
+            final String target,
+            final Object attachment,
+            final HttpContext context) throws IOException {
         final TlsConfig tlsConfig = attachment instanceof TlsConfig ? (TlsConfig) attachment : TlsConfig.DEFAULT;
         if (supportedProtocols != null) {
             sslsock.setEnabledProtocols(supportedProtocols);
@@ -293,7 +297,7 @@ public class SSLConnectionSocketFactory implements LayeredConnectionSocketFactor
             sslsock.setSoTimeout(handshakeTimeout.toMillisecondsIntBound());
         }
 
-        prepareSocket(sslsock);
+        prepareSocket(sslsock, context);
 
         if (LOG.isDebugEnabled()) {
             LOG.debug("Enabled protocols: {}", (Object) sslsock.getEnabledProtocols());

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/SSLConnectionSocketFactory.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/SSLConnectionSocketFactory.java
@@ -183,6 +183,7 @@ public class SSLConnectionSocketFactory implements LayeredConnectionSocketFactor
      * @deprecated Use {@link #prepareSocket(SSLSocket, HttpContext)}
      */
     @Deprecated
+    @SuppressWarnings("deprecation")
     protected void prepareSocket(final SSLSocket socket) throws IOException {
     }
 


### PR DESCRIPTION
Some implementations might depend on a variable present in the `HttpContext` which is available in most other methods.