### PR TITLE
refactor: refactor bad smell InnerClassMayBeStatic

### DIFF
--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/HttpByteArrayCacheEntrySerializer.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/HttpByteArrayCacheEntrySerializer.java
@@ -385,7 +385,7 @@ public class HttpByteArrayCacheEntrySerializer implements HttpCacheEntrySerializ
      * Copied from DefaultHttpResponseWriter, but wrapping a SimpleHttpResponse instead of a ClassicHttpResponse
      */
     // Seems like the DefaultHttpResponseWriter should be able to do this, but it doesn't seem to be able to
-    private class SimpleHttpResponseWriter extends AbstractMessageWriter<SimpleHttpResponse> {
+    private static class SimpleHttpResponseWriter extends AbstractMessageWriter<SimpleHttpResponse> {
 
         public SimpleHttpResponseWriter() {
             super(BasicLineFormatter.INSTANCE);

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java
@@ -634,7 +634,7 @@ public class PoolingHttpClientConnectionManager
 
     private static final PrefixedIncrementingId INCREMENTING_ID = new PrefixedIncrementingId("ep-");
 
-    staticclass InternalConnectionEndpoint extends ConnectionEndpoint implements Identifiable {
+    static class InternalConnectionEndpoint extends ConnectionEndpoint implements Identifiable {
 
         private final AtomicReference<PoolEntry<HttpRoute, ManagedHttpClientConnection>> poolEntryRef;
         private final String id;

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java
@@ -634,7 +634,7 @@ public class PoolingHttpClientConnectionManager
 
     private static final PrefixedIncrementingId INCREMENTING_ID = new PrefixedIncrementingId("ep-");
 
-    class InternalConnectionEndpoint extends ConnectionEndpoint implements Identifiable {
+    staticclass InternalConnectionEndpoint extends ConnectionEndpoint implements Identifiable {
 
         private final AtomicReference<PoolEntry<HttpRoute, ManagedHttpClientConnection>> poolEntryRef;
         private final String id;

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java
@@ -670,7 +670,7 @@ public class PoolingAsyncClientConnectionManager implements AsyncClientConnectio
 
     private static final PrefixedIncrementingId INCREMENTING_ID = new PrefixedIncrementingId("ep-");
 
-    staticclass InternalConnectionEndpoint extends AsyncConnectionEndpoint implements Identifiable {
+    static class InternalConnectionEndpoint extends AsyncConnectionEndpoint implements Identifiable {
 
         private final AtomicReference<PoolEntry<HttpRoute, ManagedAsyncClientConnection>> poolEntryRef;
         private final String id;

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java
@@ -670,7 +670,7 @@ public class PoolingAsyncClientConnectionManager implements AsyncClientConnectio
 
     private static final PrefixedIncrementingId INCREMENTING_ID = new PrefixedIncrementingId("ep-");
 
-    class InternalConnectionEndpoint extends AsyncConnectionEndpoint implements Identifiable {
+    staticclass InternalConnectionEndpoint extends AsyncConnectionEndpoint implements Identifiable {
 
         private final AtomicReference<PoolEntry<HttpRoute, ManagedAsyncClientConnection>> poolEntryRef;
         private final String id;


### PR DESCRIPTION
# Repairing Code Style Issues
<!-- laughing-train-refactor -->
## InnerClassMayBeStatic
Inner classes that do not reference their enclosing instances can be made static.
This prevents a common cause of memory leaks and uses less memory per instance of the class.

<!-- fingerprint:1991817202 -->
<!-- fingerprint:1327295172 -->
<!-- fingerprint:1334395164 -->
# Repairing Code Style Issues
* InnerClassMayBeStatic (3)
