### PR TITLE
Update Apache Commons Codec from 1.11 to 1.15.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
     <maven.compiler.target>1.6</maven.compiler.target>
     <httpcore.version>4.4.16</httpcore.version>
     <commons-logging.version>1.2</commons-logging.version>
-    <commons-codec.version>1.11</commons-codec.version>
+    <commons-codec.version>1.15</commons-codec.version>
     <ehcache.version>2.6.11</ehcache.version>
     <memcached.version>2.12.3</memcached.version>
     <slf4j.version>1.7.25</slf4j.version>


### PR DESCRIPTION
There was a vulnerability found with commons-codec (https://sca.analysiscenter.veracode.com/vulnerability-database/security/sca/vulnerability/sid-22742/summary) that was fixed in v1.13.  
The latest version is 1.15 so I've updated the dependency to the latest.