### PR TITLE
Fix Heuristic caching for URIs with query strings by adhering to RFC …

### DIFF
--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CacheConfig.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CacheConfig.java
@@ -155,6 +155,12 @@ public class CacheConfig implements Cloneable {
     private final int asynchronousWorkers;
     private final boolean neverCacheHTTP10ResponsesWithQuery;
 
+    /**
+     * A constant indicating whether HTTP/1.1 responses with a query string should never be cached.
+     *
+     */
+    private final boolean neverCacheHTTP11ResponsesWithQuery;
+
     CacheConfig(
             final long maxObjectSize,
             final int maxCacheEntries,
@@ -167,7 +173,8 @@ public class CacheConfig implements Cloneable {
             final boolean sharedCache,
             final boolean freshnessCheckEnabled,
             final int asynchronousWorkers,
-            final boolean neverCacheHTTP10ResponsesWithQuery) {
+            final boolean neverCacheHTTP10ResponsesWithQuery,
+            final boolean neverCacheHTTP11ResponsesWithQuery) {
         super();
         this.maxObjectSize = maxObjectSize;
         this.maxCacheEntries = maxCacheEntries;
@@ -181,6 +188,7 @@ public class CacheConfig implements Cloneable {
         this.freshnessCheckEnabled = freshnessCheckEnabled;
         this.asynchronousWorkers = asynchronousWorkers;
         this.neverCacheHTTP10ResponsesWithQuery = neverCacheHTTP10ResponsesWithQuery;
+        this.neverCacheHTTP11ResponsesWithQuery = neverCacheHTTP11ResponsesWithQuery;
     }
 
     /**
@@ -200,6 +208,22 @@ public class CacheConfig implements Cloneable {
      */
     public boolean isNeverCacheHTTP10ResponsesWithQuery() {
         return neverCacheHTTP10ResponsesWithQuery;
+    }
+
+    /**
+     * Determines whether HTTP/1.1 responses with query strings should never be cached by the
+     * client. By default, caching of such responses is allowed. Enabling this option may improve
+     * security by preventing responses with sensitive information from being cached.
+     * <p>
+     * Note that this option only applies to HTTP/1.1.
+     * </p>
+     *
+     * @return {@code true} if HTTP/1.1 responses with query strings should never be cached;
+     * {@code false} otherwise.
+     * @since 5.3
+     */
+    public boolean isNeverCacheHTTP11ResponsesWithQuery() {
+        return neverCacheHTTP11ResponsesWithQuery;
     }
 
     /**
@@ -303,7 +327,8 @@ public class CacheConfig implements Cloneable {
             .setHeuristicDefaultLifetime(config.getHeuristicDefaultLifetime())
             .setSharedCache(config.isSharedCache())
             .setAsynchronousWorkers(config.getAsynchronousWorkers())
-            .setNeverCacheHTTP10ResponsesWithQueryString(config.isNeverCacheHTTP10ResponsesWithQuery());
+            .setNeverCacheHTTP10ResponsesWithQueryString(config.isNeverCacheHTTP10ResponsesWithQuery())
+            .setNeverCacheHTTP11ResponsesWithQueryString(config.isNeverCacheHTTP11ResponsesWithQuery());
     }
 
 
@@ -321,6 +346,7 @@ public class CacheConfig implements Cloneable {
         private boolean freshnessCheckEnabled;
         private int asynchronousWorkers;
         private boolean neverCacheHTTP10ResponsesWithQuery;
+        private boolean neverCacheHTTP11ResponsesWithQuery;
 
         Builder() {
             this.maxObjectSize = DEFAULT_MAX_OBJECT_SIZE_BYTES;
@@ -459,6 +485,18 @@ public class CacheConfig implements Cloneable {
             return this;
         }
 
+        /**
+         * Sets the flag indicating whether HTTP/1.1 responses with a query string should never be cached.
+         *
+         * @param neverCacheHTTP11ResponsesWithQuery whether to never cache HTTP/1.1 responses with a query string
+         * @return the builder object
+         */
+        public Builder setNeverCacheHTTP11ResponsesWithQueryString(
+                final boolean neverCacheHTTP11ResponsesWithQuery) {
+            this.neverCacheHTTP11ResponsesWithQuery = neverCacheHTTP11ResponsesWithQuery;
+            return this;
+        }
+
         public CacheConfig build() {
             return new CacheConfig(
                     maxObjectSize,
@@ -472,7 +510,8 @@ public class CacheConfig implements Cloneable {
                     sharedCache,
                     freshnessCheckEnabled,
                     asynchronousWorkers,
-                    neverCacheHTTP10ResponsesWithQuery);
+                    neverCacheHTTP10ResponsesWithQuery,
+                    neverCacheHTTP11ResponsesWithQuery);
         }
 
     }
@@ -492,6 +531,7 @@ public class CacheConfig implements Cloneable {
                 .append(", freshnessCheckEnabled=").append(this.freshnessCheckEnabled)
                 .append(", asynchronousWorkers=").append(this.asynchronousWorkers)
                 .append(", neverCacheHTTP10ResponsesWithQuery=").append(this.neverCacheHTTP10ResponsesWithQuery)
+                .append(", neverCacheHTTP11ResponsesWithQuery=").append(this.neverCacheHTTP11ResponsesWithQuery)
                 .append("]");
         return builder.toString();
     }

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingExecBase.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingExecBase.java
@@ -108,8 +108,11 @@ public class CachingExecBase {
         this.responseCompliance = new ResponseProtocolCompliance();
         this.requestCompliance = new RequestProtocolCompliance(this.cacheConfig.isWeakETagOnPutDeleteAllowed());
         this.responseCachingPolicy = new ResponseCachingPolicy(
-                this.cacheConfig.getMaxObjectSize(), this.cacheConfig.isSharedCache(),
-                this.cacheConfig.isNeverCacheHTTP10ResponsesWithQuery(), this.cacheConfig.is303CachingEnabled());
+                this.cacheConfig.getMaxObjectSize(),
+                this.cacheConfig.isSharedCache(),
+                this.cacheConfig.isNeverCacheHTTP10ResponsesWithQuery(),
+                this.cacheConfig.is303CachingEnabled(),
+                this.cacheConfig.isNeverCacheHTTP11ResponsesWithQuery());
     }
 
     /**

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/ResponseCachingPolicy.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/ResponseCachingPolicy.java
@@ -66,6 +66,7 @@ class ResponseCachingPolicy {
     private final long maxObjectSizeBytes;
     private final boolean sharedCache;
     private final boolean neverCache1_0ResponsesWithQueryString;
+    private final boolean neverCache1_1ResponsesWithQueryString;
     private final Set<Integer> uncacheableStatusCodes;
 
     /**
@@ -78,14 +79,18 @@ class ResponseCachingPolicy {
      * @param neverCache1_0ResponsesWithQueryString true to never cache HTTP 1.0 responses with a query string, false
      * to cache if explicit cache headers are found.
      * @param allow303Caching if this policy is permitted to cache 303 response
+     * @param neverCache1_1ResponsesWithQueryString {@code true} to never cache HTTP 1.1 responses with a query string,
+     * {@code false} to cache if explicit cache headers are found.
      */
     public ResponseCachingPolicy(final long maxObjectSizeBytes,
             final boolean sharedCache,
             final boolean neverCache1_0ResponsesWithQueryString,
-            final boolean allow303Caching) {
+            final boolean allow303Caching,
+            final boolean neverCache1_1ResponsesWithQueryString) {
         this.maxObjectSizeBytes = maxObjectSizeBytes;
         this.sharedCache = sharedCache;
         this.neverCache1_0ResponsesWithQueryString = neverCache1_0ResponsesWithQueryString;
+        this.neverCache1_1ResponsesWithQueryString = neverCache1_1ResponsesWithQueryString;
         if (allow303Caching) {
             uncacheableStatusCodes = new HashSet<>(Collections.singletonList(HttpStatus.SC_PARTIAL_CONTENT));
         } else {
@@ -260,7 +265,7 @@ class ResponseCachingPolicy {
             if (neverCache1_0ResponsesWithQueryString && from1_0Origin(response)) {
                 LOG.debug("Response is not cacheable as it had a query string");
                 return false;
-            } else if (!isExplicitlyCacheable(response)) {
+            } else if (!neverCache1_1ResponsesWithQueryString && !isExplicitlyCacheable(response)) {
                 LOG.debug("Response is not cacheable as it is missing explicit caching headers");
                 return false;
             }

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestResponseCachingPolicy.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestResponseCachingPolicy.java
@@ -43,6 +43,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class TestResponseCachingPolicy {
 
     private static final ProtocolVersion HTTP_1_1 = new ProtocolVersion("HTTP", 1, 1);
@@ -62,7 +64,7 @@ public class TestResponseCachingPolicy {
         sixSecondsAgo = now.minusSeconds(6);
         tenSecondsFromNow = now.plusSeconds(10);
 
-        policy = new ResponseCachingPolicy(0, true, false, false);
+        policy = new ResponseCachingPolicy(0, true, false, false, false);
         request = new BasicHttpRequest("GET","/");
         response = new BasicHttpResponse(HttpStatus.SC_OK, "");
         response.setHeader("Date", DateUtils.formatStandardDate(Instant.now()));
@@ -76,7 +78,7 @@ public class TestResponseCachingPolicy {
 
     @Test
     public void testIsHeadCacheable() {
-        policy = new ResponseCachingPolicy(0, true, false, false);
+        policy = new ResponseCachingPolicy(0, true, false, false, true);
         Assertions.assertTrue(policy.isResponseCacheable("HEAD", response));
     }
 
@@ -89,7 +91,7 @@ public class TestResponseCachingPolicy {
 
     @Test
     public void testResponsesToRequestsWithAuthorizationHeadersAreCacheableByNonSharedCache() {
-        policy = new ResponseCachingPolicy(0, false, false, false);
+        policy = new ResponseCachingPolicy(0, false, false, false, true);
         request = new BasicHttpRequest("GET","/");
         request.setHeader("Authorization", StandardAuthScheme.BASIC + " dXNlcjpwYXNzd2Q=");
         Assertions.assertTrue(policy.isResponseCacheable(request,response));
@@ -141,7 +143,7 @@ public class TestResponseCachingPolicy {
 
     @Test
     public void test206ResponseCodeIsNotCacheableUsingSharedPublicCache() {
-        policy = new ResponseCachingPolicy(0, true, false, false);
+        policy = new ResponseCachingPolicy(0, true, false, false, true);
 
         request.setHeader("Authorization", StandardAuthScheme.BASIC + " QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
         response.setCode(HttpStatus.SC_PARTIAL_CONTENT);
@@ -185,7 +187,7 @@ public class TestResponseCachingPolicy {
 
     @Test
     public void testPlain303ResponseCodeIsNotCacheableEvenIf303CachingEnabled() {
-        policy = new ResponseCachingPolicy(0, true, false, true);
+        policy = new ResponseCachingPolicy(0, true, false, true, true);
         response.setCode(HttpStatus.SC_SEE_OTHER);
         response.removeHeaders("Expires");
         response.removeHeaders("Cache-Control");
@@ -259,7 +261,7 @@ public class TestResponseCachingPolicy {
 
     @Test
     public void test200ResponseWithPrivateCacheControlIsCacheableByNonSharedCache() {
-        policy = new ResponseCachingPolicy(0, false, false, false);
+        policy = new ResponseCachingPolicy(0, false, false, false, true);
         response.setCode(HttpStatus.SC_OK);
         response.setHeader("Cache-Control", "private");
         Assertions.assertTrue(policy.isResponseCacheable("GET", response));
@@ -369,7 +371,7 @@ public class TestResponseCachingPolicy {
 
     @Test
     public void testIsHeadWithAnyCacheControlCacheable() {
-        policy = new ResponseCachingPolicy(0, true, false, false);
+        policy = new ResponseCachingPolicy(0, true, false, false, true);
         response.addHeader("Cache-Control", "max=10");
 
         Assertions.assertTrue(policy.isResponseCacheable("HEAD", response));
@@ -412,7 +414,7 @@ public class TestResponseCachingPolicy {
 
     @Test
     public void testVaryStarIsNotCacheableUsingSharedPublicCache() {
-        policy = new ResponseCachingPolicy(0, true, false, false);
+        policy = new ResponseCachingPolicy(0, true, false, false, true);
 
         request.setHeader("Authorization", StandardAuthScheme.BASIC + " QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
         response.setHeader("Cache-Control", "public");
@@ -428,7 +430,7 @@ public class TestResponseCachingPolicy {
 
     @Test
     public void testIsHeadWithVaryHeaderCacheable() {
-        policy = new ResponseCachingPolicy(0, true, false, false);
+        policy = new ResponseCachingPolicy(0, true, false, false, true);
         response.addHeader("Vary", "Accept-Encoding");
         Assertions.assertTrue(policy.isResponseCacheable("HEAD", response));
     }
@@ -443,7 +445,7 @@ public class TestResponseCachingPolicy {
 
     @Test
     public void testIsArbitraryMethodCacheableUsingSharedPublicCache() {
-        policy = new ResponseCachingPolicy(0, true, false, false);
+        policy = new ResponseCachingPolicy(0, true, false, false, true);
 
         request = new HttpOptions("http://foo.example.com/");
         request.setHeader("Authorization", StandardAuthScheme.BASIC + " QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
@@ -469,7 +471,7 @@ public class TestResponseCachingPolicy {
 
     @Test
     public void testResponsesWithMultipleAgeHeadersAreNotCacheableUsingSharedPublicCache() {
-        policy = new ResponseCachingPolicy(0, true, false, false);
+        policy = new ResponseCachingPolicy(0, true, false, false, true);
 
         request.setHeader("Authorization", StandardAuthScheme.BASIC + " QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
         response.setHeader("Cache-Control", "public");
@@ -487,7 +489,7 @@ public class TestResponseCachingPolicy {
 
     @Test
     public void testResponsesWithMultipleDateHeadersAreNotCacheableUsingSharedPublicCache() {
-        policy = new ResponseCachingPolicy(0, true, false, false);
+        policy = new ResponseCachingPolicy(0, true, false, false, true);
 
         request.setHeader("Authorization", StandardAuthScheme.BASIC + " QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
         response.setHeader("Cache-Control", "public");
@@ -504,7 +506,7 @@ public class TestResponseCachingPolicy {
 
     @Test
     public void testResponsesWithMalformedDateHeadersAreNotCacheableUsingSharedPublicCache() {
-        policy = new ResponseCachingPolicy(0, true, false, false);
+        policy = new ResponseCachingPolicy(0, true, false, false, true);
 
         request.setHeader("Authorization", StandardAuthScheme.BASIC + " QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
         response.setHeader("Cache-Control", "public");
@@ -521,7 +523,7 @@ public class TestResponseCachingPolicy {
 
     @Test
     public void testResponsesWithMultipleExpiresHeadersAreNotCacheableUsingSharedPublicCache() {
-        policy = new ResponseCachingPolicy(0, true, false, false);
+        policy = new ResponseCachingPolicy(0, true, false, false, true);
 
         request.setHeader("Authorization", StandardAuthScheme.BASIC + " QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
         response.setHeader("Cache-Control", "public");
@@ -544,7 +546,7 @@ public class TestResponseCachingPolicy {
 
     @Test
     public void testResponseThatHasTooMuchContentIsNotCacheableUsingSharedPublicCache() {
-        policy = new ResponseCachingPolicy(0, true, false, false);
+        policy = new ResponseCachingPolicy(0, true, false, false, true);
 
         request.setHeader("Authorization", StandardAuthScheme.BASIC + " QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
         response.setHeader("Cache-Control", "public");
@@ -572,14 +574,14 @@ public class TestResponseCachingPolicy {
 
     @Test
     public void testResponsesToGETWithQueryParamsButNoExplicitCachingAreNotCacheableEvenWhen1_0QueryCachingDisabled() {
-        policy = new ResponseCachingPolicy(0, true, true, false);
+        policy = new ResponseCachingPolicy(0, true, true, false, false);
         request = new BasicHttpRequest("GET", "/foo?s=bar");
         Assertions.assertFalse(policy.isResponseCacheable(request, response));
     }
 
     @Test
     public void testResponsesToHEADWithQueryParamsButNoExplicitCachingAreNotCacheableEvenWhen1_0QueryCachingDisabled() {
-        policy = new ResponseCachingPolicy(0, true, true, false);
+        policy = new ResponseCachingPolicy(0, true, true, false, false);
         request = new BasicHttpRequest("HEAD", "/foo?s=bar");
         Assertions.assertFalse(policy.isResponseCacheable(request, response));
     }
@@ -594,7 +596,7 @@ public class TestResponseCachingPolicy {
 
     @Test
     public void testResponsesToHEADWithQueryParamsAndExplicitCachingAreCacheable() {
-        policy = new ResponseCachingPolicy(0, true, false, false);
+        policy = new ResponseCachingPolicy(0, true, false, false, true);
         request = new BasicHttpRequest("HEAD", "/foo?s=bar");
         response.setHeader("Date", DateUtils.formatStandardDate(now));
         response.setHeader("Expires", DateUtils.formatStandardDate(tenSecondsFromNow));
@@ -603,7 +605,7 @@ public class TestResponseCachingPolicy {
 
     @Test
     public void testResponsesToGETWithQueryParamsAndExplicitCachingAreCacheableEvenWhen1_0QueryCachingDisabled() {
-        policy = new ResponseCachingPolicy(0, true, true, false);
+        policy = new ResponseCachingPolicy(0, true, true, false, true);
         request = new BasicHttpRequest("GET", "/foo?s=bar");
         response.setHeader("Date", DateUtils.formatStandardDate(now));
         response.setHeader("Expires", DateUtils.formatStandardDate(tenSecondsFromNow));
@@ -612,7 +614,7 @@ public class TestResponseCachingPolicy {
 
     @Test
     public void testResponsesToHEADWithQueryParamsAndExplicitCachingAreCacheableEvenWhen1_0QueryCachingDisabled() {
-        policy = new ResponseCachingPolicy(0, true, true, false);
+        policy = new ResponseCachingPolicy(0, true, true, false, true);
         request = new BasicHttpRequest("HEAD", "/foo?s=bar");
         response.setHeader("Date", DateUtils.formatStandardDate(now));
         response.setHeader("Expires", DateUtils.formatStandardDate(tenSecondsFromNow));
@@ -637,7 +639,7 @@ public class TestResponseCachingPolicy {
 
     @Test
     public void getsWithQueryParametersDirectlyFrom1_0OriginsAreNotCacheableEvenWithSetting() {
-        policy = new ResponseCachingPolicy(0, true, true, false);
+        policy = new ResponseCachingPolicy(0, true, true, false, true);
         request = new BasicHttpRequest("GET", "/foo?s=bar");
         response = new BasicHttpResponse(HttpStatus.SC_OK, "OK");
         response.setVersion(HttpVersion.HTTP_1_0);
@@ -646,7 +648,7 @@ public class TestResponseCachingPolicy {
 
     @Test
     public void headsWithQueryParametersDirectlyFrom1_0OriginsAreNotCacheableEvenWithSetting() {
-        policy = new ResponseCachingPolicy(0, true, true, false);
+        policy = new ResponseCachingPolicy(0, true, true, false, true);
         request = new BasicHttpRequest("HEAD", "/foo?s=bar");
         response = new BasicHttpResponse(HttpStatus.SC_OK, "OK");
         response.setVersion(HttpVersion.HTTP_1_0);
@@ -665,7 +667,7 @@ public class TestResponseCachingPolicy {
 
     @Test
     public void headsWithQueryParametersDirectlyFrom1_0OriginsAreCacheableWithExpires() {
-        policy = new ResponseCachingPolicy(0, true, false, false);
+        policy = new ResponseCachingPolicy(0, true, false, false, true);
         request = new BasicHttpRequest("HEAD", "/foo?s=bar");
         response = new BasicHttpResponse(HttpStatus.SC_OK, "OK");
         response.setVersion(HttpVersion.HTTP_1_0);
@@ -676,7 +678,7 @@ public class TestResponseCachingPolicy {
 
     @Test
     public void getsWithQueryParametersDirectlyFrom1_0OriginsCanBeNotCacheableEvenWithExpires() {
-        policy = new ResponseCachingPolicy(0, true, true, false);
+        policy = new ResponseCachingPolicy(0, true, true, false, true);
         request = new BasicHttpRequest("GET", "/foo?s=bar");
         response = new BasicHttpResponse(HttpStatus.SC_OK, "OK");
         response.setVersion(HttpVersion.HTTP_1_0);
@@ -687,7 +689,7 @@ public class TestResponseCachingPolicy {
 
     @Test
     public void headsWithQueryParametersDirectlyFrom1_0OriginsCanBeNotCacheableEvenWithExpires() {
-        policy = new ResponseCachingPolicy(0, true, true, false);
+        policy = new ResponseCachingPolicy(0, true, true, false, true);
         request = new BasicHttpRequest("HEAD", "/foo?s=bar");
         response = new BasicHttpResponse(HttpStatus.SC_OK, "OK");
         response.setVersion(HttpVersion.HTTP_1_0);
@@ -721,7 +723,7 @@ public class TestResponseCachingPolicy {
 
     @Test
     public void headsWithQueryParametersFrom1_0OriginsViaProxiesAreCacheableWithExpires() {
-        policy = new ResponseCachingPolicy(0, true, false, false);
+        policy = new ResponseCachingPolicy(0, true, false, false, true);
         request = new BasicHttpRequest("HEAD", "/foo?s=bar");
         response.setHeader("Date", DateUtils.formatStandardDate(now));
         response.setHeader("Expires", DateUtils.formatStandardDate(tenSecondsFromNow));
@@ -731,7 +733,7 @@ public class TestResponseCachingPolicy {
 
     @Test
     public void getsWithQueryParametersFrom1_0OriginsViaProxiesCanNotBeCacheableEvenWithExpires() {
-        policy = new ResponseCachingPolicy(0, true, true, true);
+        policy = new ResponseCachingPolicy(0, true, true, true, true);
         request = new BasicHttpRequest("GET", "/foo?s=bar");
         response.setHeader("Date", DateUtils.formatStandardDate(now));
         response.setHeader("Expires", DateUtils.formatStandardDate(tenSecondsFromNow));
@@ -741,7 +743,7 @@ public class TestResponseCachingPolicy {
 
     @Test
     public void headsWithQueryParametersFrom1_0OriginsViaProxiesCanNotBeCacheableEvenWithExpires() {
-        policy = new ResponseCachingPolicy(0, true, true, true);
+        policy = new ResponseCachingPolicy(0, true, true, true, true);
         request = new BasicHttpRequest("HEAD", "/foo?s=bar");
         response.setHeader("Date", DateUtils.formatStandardDate(now));
         response.setHeader("Expires", DateUtils.formatStandardDate(tenSecondsFromNow));
@@ -760,7 +762,7 @@ public class TestResponseCachingPolicy {
 
     @Test
     public void headsWithQueryParametersFrom1_0OriginsViaExplicitProxiesAreCacheableWithExpires() {
-        policy = new ResponseCachingPolicy(0, true, false, false);
+        policy = new ResponseCachingPolicy(0, true, false, false, false);
         request = new BasicHttpRequest("HEAD", "/foo?s=bar");
         response.setHeader("Date", DateUtils.formatStandardDate(now));
         response.setHeader("Expires", DateUtils.formatStandardDate(tenSecondsFromNow));
@@ -770,7 +772,7 @@ public class TestResponseCachingPolicy {
 
     @Test
     public void getsWithQueryParametersFrom1_0OriginsViaExplicitProxiesCanNotBeCacheableEvenWithExpires() {
-        policy = new ResponseCachingPolicy(0, true, true, true);
+        policy = new ResponseCachingPolicy(0, true, true, true, true);
         request = new BasicHttpRequest("GET", "/foo?s=bar");
         response.setHeader("Date", DateUtils.formatStandardDate(now));
         response.setHeader("Expires", DateUtils.formatStandardDate(tenSecondsFromNow));
@@ -780,7 +782,7 @@ public class TestResponseCachingPolicy {
 
     @Test
     public void headsWithQueryParametersFrom1_0OriginsViaExplicitProxiesCanNotBeCacheableEvenWithExpires() {
-        policy = new ResponseCachingPolicy(0, true, true, true);
+        policy = new ResponseCachingPolicy(0, true, true, true, true);
         request = new BasicHttpRequest("HEAD", "/foo?s=bar");
         response.setHeader("Date", DateUtils.formatStandardDate(now));
         response.setHeader("Expires", DateUtils.formatStandardDate(tenSecondsFromNow));
@@ -801,7 +803,7 @@ public class TestResponseCachingPolicy {
 
     @Test
     public void headsWithQueryParametersFrom1_1OriginsVia1_0ProxiesAreCacheableWithExpires() {
-        policy = new ResponseCachingPolicy(0, true, false, false);
+        policy = new ResponseCachingPolicy(0, true, false, false, true);
         request = new BasicHttpRequest("HEAD", "/foo?s=bar");
         response = new BasicHttpResponse(HttpStatus.SC_OK, "OK");
         response.setVersion(HttpVersion.HTTP_1_0);
@@ -848,7 +850,7 @@ public class TestResponseCachingPolicy {
     public void test303WithExplicitCachingHeadersWhenPermittedByConfig() {
         // HTTPbis working group says ok if explicitly indicated by
         // response headers
-        policy = new ResponseCachingPolicy(0, true, false, true);
+        policy = new ResponseCachingPolicy(0, true, false, true, true);
         response.setCode(HttpStatus.SC_SEE_OTHER);
         response.setHeader("Date", DateUtils.formatStandardDate(now));
         response.setHeader("Cache-Control","max-age=300");
@@ -875,5 +877,16 @@ public class TestResponseCachingPolicy {
         final int rnd = new Random().nextInt(acceptableCodes.length);
 
         return acceptableCodes[rnd];
+    }
+
+    @Test
+    public void testIsResponseCacheable() {
+        request = new BasicHttpRequest("GET","/foo?s=bar");
+        // HTTPbis working group says ok if explicitly indicated by
+        // response headers
+        policy = new ResponseCachingPolicy(0, true, false, false, true);
+        response.setCode(HttpStatus.SC_OK);
+        response.setHeader("Date", DateUtils.formatStandardDate(now));
+        assertTrue(policy.isResponseCacheable(request, response));
     }
 }


### PR DESCRIPTION
This pull request addresses the issue where heuristic caching was not working for URIs with query strings. The problem arises from Section 13.9 of RFC 2616, which prohibits caches from treating responses to such URIs as fresh unless the server provides an explicit expiration time.

However, as noted in Section 4.2.2 of RFC 7234, this prohibition has not been widely implemented, and origin servers are encouraged to send explicit directives if they wish to preclude caching.

The current implementation of the module adheres to the safe interpretation of RFC 2616 and does not cache responses to URIs with query strings. However, it would be possible to introduce a configuration option that relaxed this rule, in line with the updated RFC 7234.

This pull request introduces the configuration option neverCacheHTTP11ResponsesWithQuery, which determines whether HTTP/1.1 responses with query strings should never be cached by the client. By default, caching of such responses is allowed, but enabling this option may improve security by preventing responses with sensitive information from being cached.