### PR TITLE
Improve HttpByteArrayCacheEntrySerializer class by adding new methods and enhancing performance.

### DIFF
--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/cache/HttpCacheEntry.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/cache/HttpCacheEntry.java
@@ -365,7 +365,7 @@ public class HttpCacheEntry implements MessageHeaders, Serializable {
      * the "parent" entry to hold this index of the other variants.
      */
     public Map<String, String> getVariantMap() {
-        return Collections.unmodifiableMap(variantMap);
+        return variantMap != null ? Collections.unmodifiableMap(variantMap) : Collections.emptyMap();
     }
 
     /**
@@ -388,8 +388,14 @@ public class HttpCacheEntry implements MessageHeaders, Serializable {
      */
     @Override
     public String toString() {
-        return "[request date=" + this.requestDate + "; response date=" + this.responseDate
-                + "; status=" + this.status + "]";
+        return "HttpCacheEntry{" +
+                "requestDate=" + requestDate +
+                ", responseDate=" + responseDate +
+                ", status=" + status +
+                ", responseHeaders=" + responseHeaders +
+                ", resource=" + resource +
+                ", variantMap=" + variantMap +
+                ", date=" + date +
+                '}';
     }
-
 }

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/AbstractBinaryAsyncCacheStorage.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/AbstractBinaryAsyncCacheStorage.java
@@ -40,7 +40,7 @@ public abstract class AbstractBinaryAsyncCacheStorage<CAS> extends AbstractSeria
     }
 
     public AbstractBinaryAsyncCacheStorage(final int maxUpdateRetries) {
-        super(maxUpdateRetries, ByteArrayCacheEntrySerializer.INSTANCE);
+        super(maxUpdateRetries, HttpByteArrayCacheEntrySerializer.INSTANCE);
     }
 
 }

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/AbstractBinaryCacheStorage.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/AbstractBinaryCacheStorage.java
@@ -40,7 +40,7 @@ public abstract class AbstractBinaryCacheStorage<CAS> extends AbstractSerializin
     }
 
     public AbstractBinaryCacheStorage(final int maxUpdateRetries) {
-        super(maxUpdateRetries, ByteArrayCacheEntrySerializer.INSTANCE);
+        super(maxUpdateRetries, HttpByteArrayCacheEntrySerializer.INSTANCE);
     }
 
 }

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/ByteArrayCacheEntrySerializer.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/ByteArrayCacheEntrySerializer.java
@@ -51,7 +51,10 @@ import org.apache.hc.core5.annotation.ThreadingBehavior;
  * @see java.io.Serializable
  *
  * @since 4.1
+ * @deprecated This class is deprecated and will be removed in a future release. Please use {@link HttpByteArrayCacheEntrySerializer} for improved performance.
+ * @see HttpByteArrayCacheEntrySerializer
  */
+@Deprecated
 @Contract(threading = ThreadingBehavior.STATELESS)
 public final class ByteArrayCacheEntrySerializer implements HttpCacheEntrySerializer<byte[]> {
 

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/ehcache/EhcacheHttpCacheStorage.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/ehcache/EhcacheHttpCacheStorage.java
@@ -34,8 +34,8 @@ import org.apache.hc.client5.http.cache.HttpCacheEntrySerializer;
 import org.apache.hc.client5.http.cache.HttpCacheStorageEntry;
 import org.apache.hc.client5.http.cache.ResourceIOException;
 import org.apache.hc.client5.http.impl.cache.AbstractSerializingCacheStorage;
-import org.apache.hc.client5.http.impl.cache.ByteArrayCacheEntrySerializer;
 import org.apache.hc.client5.http.impl.cache.CacheConfig;
+import org.apache.hc.client5.http.impl.cache.HttpByteArrayCacheEntrySerializer;
 import org.apache.hc.client5.http.impl.cache.NoopCacheEntrySerializer;
 import org.apache.hc.core5.util.Args;
 import org.ehcache.Cache;
@@ -76,7 +76,7 @@ public class EhcacheHttpCacheStorage<T> extends AbstractSerializingCacheStorage<
      */
     public static EhcacheHttpCacheStorage<byte[]> createSerializedCache(
             final Cache<String, byte[]> cache, final CacheConfig config) {
-        return new EhcacheHttpCacheStorage<>(cache, config, ByteArrayCacheEntrySerializer.INSTANCE);
+        return new EhcacheHttpCacheStorage<>(cache, config, HttpByteArrayCacheEntrySerializer.INSTANCE);
     }
 
     private final Cache<String, T> cache;

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/memcached/MemcachedHttpAsyncCacheStorage.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/memcached/MemcachedHttpAsyncCacheStorage.java
@@ -37,8 +37,8 @@ import org.apache.hc.client5.http.cache.HttpCacheEntrySerializer;
 import org.apache.hc.client5.http.cache.ResourceIOException;
 import org.apache.hc.client5.http.impl.Operations;
 import org.apache.hc.client5.http.impl.cache.AbstractBinaryAsyncCacheStorage;
-import org.apache.hc.client5.http.impl.cache.ByteArrayCacheEntrySerializer;
 import org.apache.hc.client5.http.impl.cache.CacheConfig;
+import org.apache.hc.client5.http.impl.cache.HttpByteArrayCacheEntrySerializer;
 import org.apache.hc.core5.concurrent.Cancellable;
 import org.apache.hc.core5.concurrent.FutureCallback;
 import org.apache.hc.core5.util.Args;
@@ -111,7 +111,7 @@ public class MemcachedHttpAsyncCacheStorage extends AbstractBinaryAsyncCacheStor
      * @param cache client to use for communicating with <i>memcached</i>
      */
     public MemcachedHttpAsyncCacheStorage(final MemcachedClient cache) {
-        this(cache, CacheConfig.DEFAULT, ByteArrayCacheEntrySerializer.INSTANCE, SHA256KeyHashingScheme.INSTANCE);
+        this(cache, CacheConfig.DEFAULT, HttpByteArrayCacheEntrySerializer.INSTANCE, SHA256KeyHashingScheme.INSTANCE);
     }
 
     /**
@@ -130,7 +130,7 @@ public class MemcachedHttpAsyncCacheStorage extends AbstractBinaryAsyncCacheStor
             final HttpCacheEntrySerializer<byte[]> serializer,
             final KeyHashingScheme keyHashingScheme) {
         super((config != null ? config : CacheConfig.DEFAULT).getMaxUpdateRetries(),
-                serializer != null ? serializer : ByteArrayCacheEntrySerializer.INSTANCE);
+                serializer != null ? serializer : HttpByteArrayCacheEntrySerializer.INSTANCE);
         this.client = Args.notNull(client, "Memcached client");
         this.keyHashingScheme = keyHashingScheme;
     }

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/memcached/MemcachedHttpCacheStorage.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/memcached/MemcachedHttpCacheStorage.java
@@ -35,8 +35,8 @@ import java.util.Map;
 import org.apache.hc.client5.http.cache.HttpCacheEntrySerializer;
 import org.apache.hc.client5.http.cache.ResourceIOException;
 import org.apache.hc.client5.http.impl.cache.AbstractBinaryCacheStorage;
-import org.apache.hc.client5.http.impl.cache.ByteArrayCacheEntrySerializer;
 import org.apache.hc.client5.http.impl.cache.CacheConfig;
+import org.apache.hc.client5.http.impl.cache.HttpByteArrayCacheEntrySerializer;
 import org.apache.hc.core5.util.Args;
 
 import net.spy.memcached.CASResponse;
@@ -106,7 +106,7 @@ public class MemcachedHttpCacheStorage extends AbstractBinaryCacheStorage<CASVal
      * @param cache client to use for communicating with <i>memcached</i>
      */
     public MemcachedHttpCacheStorage(final MemcachedClient cache) {
-        this(cache, CacheConfig.DEFAULT, ByteArrayCacheEntrySerializer.INSTANCE, SHA256KeyHashingScheme.INSTANCE);
+        this(cache, CacheConfig.DEFAULT, HttpByteArrayCacheEntrySerializer.INSTANCE, SHA256KeyHashingScheme.INSTANCE);
     }
 
     /**
@@ -118,7 +118,7 @@ public class MemcachedHttpCacheStorage extends AbstractBinaryCacheStorage<CASVal
      * @since 5.2
      */
     public MemcachedHttpCacheStorage(final MemcachedClientIF cache) {
-        this(cache, CacheConfig.DEFAULT, ByteArrayCacheEntrySerializer.INSTANCE, SHA256KeyHashingScheme.INSTANCE);
+        this(cache, CacheConfig.DEFAULT, HttpByteArrayCacheEntrySerializer.INSTANCE, SHA256KeyHashingScheme.INSTANCE);
     }
 
     /**
@@ -157,7 +157,7 @@ public class MemcachedHttpCacheStorage extends AbstractBinaryCacheStorage<CASVal
             final HttpCacheEntrySerializer<byte[]> serializer,
             final KeyHashingScheme keyHashingScheme) {
         super((config != null ? config : CacheConfig.DEFAULT).getMaxUpdateRetries(),
-                serializer != null ? serializer : ByteArrayCacheEntrySerializer.INSTANCE);
+                serializer != null ? serializer : HttpByteArrayCacheEntrySerializer.INSTANCE);
         this.client = Args.notNull(client, "Memcached client");
         this.keyHashingScheme = keyHashingScheme;
     }

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/HttpTestUtils.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/HttpTestUtils.java
@@ -247,7 +247,8 @@ public class HttpTestUtils {
     public static Header[] getStockHeaders(final Instant when) {
         return new Header[] {
                 new BasicHeader("Date", DateUtils.formatStandardDate(when)),
-                new BasicHeader("Server", "MockServer/1.0")
+                new BasicHeader("Server", "MockServer/1.0"),
+                new BasicHeader("Content-Length", "128")
         };
     }
 

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestAbstractSerializingAsyncCacheStorage.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestAbstractSerializingAsyncCacheStorage.java
@@ -68,7 +68,7 @@ public class TestAbstractSerializingAsyncCacheStorage {
     private AbstractBinaryAsyncCacheStorage<String> impl;
 
     public static byte[] serialize(final String key, final HttpCacheEntry value) throws ResourceIOException {
-        return ByteArrayCacheEntrySerializer.INSTANCE.serialize(new HttpCacheStorageEntry(key, value));
+        return HttpByteArrayCacheEntrySerializer.INSTANCE.serialize(new HttpCacheStorageEntry(key, value));
     }
 
     @BeforeEach

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestAbstractSerializingCacheStorage.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestAbstractSerializingCacheStorage.java
@@ -54,7 +54,7 @@ import org.mockito.stubbing.Answer;
 public class TestAbstractSerializingCacheStorage {
 
     public static byte[] serialize(final String key, final HttpCacheEntry value) throws ResourceIOException {
-        return ByteArrayCacheEntrySerializer.INSTANCE.serialize(new HttpCacheStorageEntry(key, value));
+        return HttpByteArrayCacheEntrySerializer.INSTANCE.serialize(new HttpCacheStorageEntry(key, value));
     }
 
     private AbstractBinaryCacheStorage<String> impl;


### PR DESCRIPTION

Improve HttpByteArrayCacheEntrySerializer class:

- Add new method to serialize and deserialize cache entries using HTTP response and request objects.
- Improve performance by optimizing buffer size and output stream usage.
- Add escape headers method to escape headers in the HTTP response.
- Add metadata pseudo headers to the HTTP response headers, including storage key, response date, request date, no content, variant map key, and variant map value.