### PR TITLE
HTTPCLIENT-2273: Enhance "no-cache" directive handling

### DIFF
--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CacheControl.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CacheControl.java
@@ -31,6 +31,9 @@ import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.Internal;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
 
+import java.util.Collections;
+import java.util.Set;
+
 /**
  * Represents the values of the Cache-Control header in an HTTP response, which indicate whether and for how long
  * the response can be cached by the client and intermediary proxies.
@@ -92,16 +95,22 @@ final class CacheControl {
      * The number of seconds that a stale response is considered fresh for the purpose
      * of serving a response while a revalidation request is made to the origin server.
      */
-    private final long stale_while_revalidate;
+    private final long staleWhileRevalidate;
+
+    /**
+     * A set of field names specified in the "no-cache" directive of the Cache-Control header.
+     */
+    private final Set<String> noCacheFields;
 
 
     /**
      * Creates a new instance of {@code CacheControl} with default values.
      * The default values are: max-age=-1, shared-max-age=-1, must-revalidate=false, no-cache=false,
-     * no-store=false, private=false, proxy-revalidate=false, public=false and stale_while_revalidate=-1.
+     * no-store=false, private=false, proxy-revalidate=false, public=false, stale_while_revalidate=-1,
+     * and noCacheFields as an empty set.
      */
     public CacheControl() {
-        this(-1, -1, false, false, false, false, false, false,-1);
+        this(-1, -1, false, false, false, false, false, false,-1, Collections.emptySet());
     }
 
     /**
@@ -116,10 +125,12 @@ final class CacheControl {
      * @param cachePrivate    The private value from the Cache-Control header.
      * @param proxyRevalidate The proxy-revalidate value from the Cache-Control header.
      * @param cachePublic     The public value from the Cache-Control header.
+     * @param noCacheFields        The set of field names specified in the "no-cache" directive of the Cache-Control header.
      */
     public CacheControl(final long maxAge, final long sharedMaxAge, final boolean mustRevalidate, final boolean noCache, final boolean noStore,
                         final boolean cachePrivate, final boolean proxyRevalidate, final boolean cachePublic,
-                        final long stale_while_revalidate) {
+                        final long staleWhileRevalidate,
+                        final Set<String> noCacheFields) {
         this.maxAge = maxAge;
         this.sharedMaxAge = sharedMaxAge;
         this.noCache = noCache;
@@ -128,7 +139,8 @@ final class CacheControl {
         this.mustRevalidate = mustRevalidate;
         this.proxyRevalidate = proxyRevalidate;
         this.cachePublic = cachePublic;
-        this.stale_while_revalidate = stale_while_revalidate;
+        this.staleWhileRevalidate = staleWhileRevalidate;
+        this.noCacheFields = Collections.unmodifiableSet(noCacheFields);
     }
 
 
@@ -211,12 +223,21 @@ final class CacheControl {
      * @return The stale-while-revalidate value.
      */
     public long getStaleWhileRevalidate() {
-        return stale_while_revalidate;
+        return staleWhileRevalidate;
+    }
+
+    /**
+     * Returns an unmodifiable set of field names specified in the "no-cache" directive of the Cache-Control header.
+     *
+     * @return The set of field names specified in the "no-cache" directive.
+     */
+    public Set<String> getNoCacheFields() {
+        return noCacheFields;
     }
 
     /**
      * Returns a string representation of the {@code CacheControl} object, including the max-age, shared-max-age, no-cache,
-     * no-store, private, must-revalidate, proxy-revalidate, and public values.
+     * no-store, private, must-revalidate, proxy-revalidate, public values, and noCacheFields.
      *
      * @return A string representation of the object.
      */
@@ -226,12 +247,13 @@ final class CacheControl {
                 "maxAge=" + maxAge +
                 ", sharedMaxAge=" + sharedMaxAge +
                 ", noCache=" + noCache +
+                ", noCacheFields=" + noCacheFields +
                 ", noStore=" + noStore +
                 ", cachePrivate=" + cachePrivate +
                 ", mustRevalidate=" + mustRevalidate +
                 ", proxyRevalidate=" + proxyRevalidate +
                 ", cachePublic=" + cachePublic +
-                ", stale_while_revalidate=" + stale_while_revalidate +
+                ", stale_while_revalidate=" + staleWhileRevalidate +
                 '}';
     }
 }

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingExecBase.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingExecBase.java
@@ -369,4 +369,26 @@ public class CachingExecBase {
             }
         }
     }
+
+    /**
+     * Checks if the provided HttpRequest contains a 'no-cache' directive in its Cache-Control header.
+     * <p>
+     * According to the HTTP/1.1 specification, a 'no-cache' directive in a request message means
+     * that the client allows a stored response to be used only if it is first validated with the
+     * origin server (or with an intermediate cache that has a fresh response). This directive
+     * applies to both shared and private caches.
+     *
+     * @param request the HttpRequest to check for the 'no-cache' directive
+     * @return true if the 'no-cache' directive is present in the Cache-Control header of the request,
+     * false otherwise
+     */
+    boolean requestContainsNoCacheDirective(final HttpRequest request) {
+        final Header cacheControlHeader = request.getFirstHeader(HttpHeaders.CACHE_CONTROL);
+        if (cacheControlHeader == null) {
+            return false;
+        } else {
+            final CacheControl cacheControl = CacheControlHeaderParser.INSTANCE.parse(cacheControlHeader);
+            return cacheControl.isNoCache();
+        }
+    }
 }

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/CacheControlParserTest.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/CacheControlParserTest.java
@@ -166,4 +166,16 @@ public class CacheControlParserTest {
 
         assertEquals(120, cacheControl.getStaleWhileRevalidate());
     }
+
+    @Test
+    public void testParseNoCacheFields() {
+        final Header header = new BasicHeader("Cache-Control", "no-cache=Set-Cookie, Content-Language, stale-while-revalidate=120");
+        final CacheControl cacheControl = parser.parse(header);
+
+        assertTrue(cacheControl.isNoCache());
+        assertEquals(2, cacheControl.getNoCacheFields().size());
+        assertTrue(cacheControl.getNoCacheFields().contains("Set-Cookie"));
+        assertTrue(cacheControl.getNoCacheFields().contains("Content-Language"));
+        assertEquals(120, cacheControl.getStaleWhileRevalidate());
+    }
 }

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestResponseCachingPolicy.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestResponseCachingPolicy.java
@@ -45,6 +45,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestResponseCachingPolicy {
@@ -307,14 +308,14 @@ public class TestResponseCachingPolicy {
     public void testIsGetWithNoCacheCacheable() {
         response.addHeader("Cache-Control", "no-cache");
 
-        Assertions.assertFalse(policy.isResponseCacheable("GET", response));
+        Assertions.assertTrue(policy.isResponseCacheable("GET", response));
     }
 
     @Test
     public void testIsHeadWithNoCacheCacheable() {
         response.addHeader("Cache-Control", "no-cache");
 
-        Assertions.assertFalse(policy.isResponseCacheable("HEAD", response));
+        Assertions.assertTrue(policy.isResponseCacheable("HEAD", response));
     }
 
     @Test
@@ -349,14 +350,14 @@ public class TestResponseCachingPolicy {
     public void testIsGetWithNoCacheEmbeddedInListCacheable() {
         response.addHeader("Cache-Control", "public, no-cache");
 
-        Assertions.assertFalse(policy.isResponseCacheable("GET", response));
+        Assertions.assertTrue(policy.isResponseCacheable("GET", response));
     }
 
     @Test
     public void testIsHeadWithNoCacheEmbeddedInListCacheable() {
         response.addHeader("Cache-Control", "public, no-cache");
 
-        Assertions.assertFalse(policy.isResponseCacheable("HEAD", response));
+        Assertions.assertTrue(policy.isResponseCacheable("HEAD", response));
     }
 
     @Test
@@ -938,7 +939,7 @@ public class TestResponseCachingPolicy {
 
         response = new BasicHttpResponse(HttpStatus.SC_OK, "");
         response.setHeader(HttpHeaders.DATE, DateUtils.formatStandardDate(Instant.now()));
-       response.setHeader(HttpHeaders.EXPIRES, DateUtils.formatStandardDate(Instant.now().plus(tenSecondsFromNow)));
+        response.setHeader(HttpHeaders.EXPIRES, DateUtils.formatStandardDate(Instant.now().plus(tenSecondsFromNow)));
 
 
         // Create ResponseCachingPolicy instance and test the method
@@ -1010,5 +1011,37 @@ public class TestResponseCachingPolicy {
         response.setCode(HttpStatus.SC_OK);
         response.setHeader("Date", DateUtils.formatStandardDate(now));
         assertTrue(policy.isResponseCacheable(request, response));
+    }
+
+    @Test
+    void testIsResponseCacheableNoCache() {
+        // Set up test data
+        response = new BasicHttpResponse(HttpStatus.SC_OK, "");
+        response.setHeader(HttpHeaders.DATE, DateUtils.formatStandardDate(Instant.now()));
+
+        // Create ResponseCachingPolicy instance and test the method
+        policy = new ResponseCachingPolicy(0, true, false, false, false);
+        request = new BasicHttpRequest("GET", "/foo");
+        response.addHeader(HttpHeaders.CACHE_CONTROL, "no-cache");
+        final boolean isCacheable = policy.isResponseCacheable(request, response);
+
+        // Verify the result
+        assertTrue(isCacheable);
+    }
+
+    @Test
+    void testIsResponseCacheableNoStore() {
+        // Set up test data
+        response = new BasicHttpResponse(HttpStatus.SC_OK, "");
+        response.setHeader(HttpHeaders.DATE, DateUtils.formatStandardDate(Instant.now()));
+
+        // Create ResponseCachingPolicy instance and test the method
+        policy = new ResponseCachingPolicy(0, true, false, false, false);
+        request = new BasicHttpRequest("GET", "/foo");
+        response.addHeader(HttpHeaders.CACHE_CONTROL, "no-store");
+        final boolean isCacheable = policy.isResponseCacheable(request, response);
+
+        // Verify the result
+        assertFalse(isCacheable);
     }
 }


### PR DESCRIPTION
This pull request addresses ticket [HTTPCLIENT-2273](https://issues.apache.org/jira/browse/HTTPCLIENT-2273), which identifies an issue with the Apache HttpComponents client's handling of the "no-cache" directive when used with specific header fields, as outlined in RFC 7234.

Changes made to address this issue include:

- Updating the caching module to correctly identify and handle "no-cache" directives with specific header fields. This was done by modifying the `responseContainsNoCacheDirective` method.

-  Modifying the `handleCacheHit` method to ensure that a cached entry is revalidated with the origin server when a "no-cache" directive with specific header fields is present in the response.

- Ensuring that the rest of the response is still cacheable when the specified header fields are present, as long as the response complies with other caching requirements.

These changes allow an origin server to prevent the reuse of certain header fields in a response, while still allowing caching of the rest of the response. Corresponding unit tests have been updated to reflect these changes.
