### PR TITLE
HTTPCLIENT-2277: Update Freshness Lifetime Calculation (RFC 9111 4.2.1)

### DIFF
--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachedResponseSuitabilityChecker.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachedResponseSuitabilityChecker.java
@@ -52,8 +52,6 @@ class CachedResponseSuitabilityChecker {
 
     private final boolean sharedCache;
     private final boolean useHeuristicCaching;
-    private final float heuristicCoefficient;
-    private final TimeValue heuristicDefaultLifetime;
     private final CacheValidityPolicy validityStrategy;
 
     CachedResponseSuitabilityChecker(final CacheValidityPolicy validityStrategy,
@@ -62,12 +60,10 @@ class CachedResponseSuitabilityChecker {
         this.validityStrategy = validityStrategy;
         this.sharedCache = config.isSharedCache();
         this.useHeuristicCaching = config.isHeuristicCachingEnabled();
-        this.heuristicCoefficient = config.getHeuristicCoefficient();
-        this.heuristicDefaultLifetime = config.getHeuristicDefaultLifetime();
     }
 
     CachedResponseSuitabilityChecker(final CacheConfig config) {
-        this(new CacheValidityPolicy(), config);
+        this(new CacheValidityPolicy(config), config);
     }
 
     private boolean isFreshEnough(final RequestCacheControl requestCacheControl,
@@ -77,7 +73,7 @@ class CachedResponseSuitabilityChecker {
             return true;
         }
         if (useHeuristicCaching &&
-                validityStrategy.isResponseHeuristicallyFresh(entry, now, heuristicCoefficient, heuristicDefaultLifetime)) {
+                validityStrategy.isResponseHeuristicallyFresh(entry, now)) {
             return true;
         }
         if (originInsistsOnFreshness(responseCacheControl)) {

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingExecBase.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingExecBase.java
@@ -100,7 +100,7 @@ public class CachingExecBase {
     CachingExecBase(final CacheConfig config) {
         super();
         this.cacheConfig = config != null ? config : CacheConfig.DEFAULT;
-        this.validityPolicy = new CacheValidityPolicy();
+        this.validityPolicy = new CacheValidityPolicy(config);
         this.responseGenerator = new CachedHttpResponseGenerator(this.validityPolicy);
         this.cacheableRequestPolicy = new CacheableRequestPolicy();
         this.suitabilityChecker = new CachedResponseSuitabilityChecker(this.validityPolicy, this.cacheConfig);


### PR DESCRIPTION
This commit enhances the getFreshnessLifetime() method in the CacheValidityPolicy class to better comply with RFC [9111 4.1](https://datatracker.ietf.org/doc/html/rfc9111#name-calculating-freshness-lifet). The method now accounts for a negative Duration between the Date and Expires header fields.