### PR TITLE
HTTPCLIENT-2277: Improve Age Header Handling and Calculation in Accordance with RFC9111.

### DIFF
--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/ResponseCachingPolicy.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/ResponseCachingPolicy.java
@@ -201,11 +201,6 @@ class ResponseCachingPolicy {
             }
         }
 
-        if (response.countHeaders(HttpHeaders.AGE) > 1) {
-            LOG.debug("Multiple Age headers");
-            return false;
-        }
-
         if (response.countHeaders(HttpHeaders.EXPIRES) > 1) {
             LOG.debug("Multiple Expires headers");
             return false;

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestResponseCachingPolicy.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestResponseCachingPolicy.java
@@ -530,10 +530,10 @@ public class TestResponseCachingPolicy {
     }
 
     @Test
-    public void testResponsesWithMultipleAgeHeadersAreNotCacheable() {
+    public void testResponsesWithMultipleAgeHeadersAreCacheable() {
         response.addHeader("Age", "3");
         response.addHeader("Age", "5");
-        Assertions.assertFalse(policy.isResponseCacheable(responseCacheControl, "GET", response));
+        Assertions.assertTrue(policy.isResponseCacheable(responseCacheControl, "GET", response));
     }
 
     @Test
@@ -546,7 +546,7 @@ public class TestResponseCachingPolicy {
         responseCacheControl = ResponseCacheControl.builder()
                 .setCachePublic(true)
                 .build();
-        Assertions.assertFalse(policy.isResponseCacheable(responseCacheControl, request, response));
+        Assertions.assertTrue(policy.isResponseCacheable(responseCacheControl, request, response));
     }
 
     @Test


### PR DESCRIPTION
This commit enhances the processing and calculation of the "Age" response header field to comply fully with Sections 5.1 
and 4.2.3 of RFC9111.

Changes include:

- Parsing of the Age field value as a non-negative integer, representing time in seconds. 
- Handling of messages with list-based Age field values, using the first member and discarding subsequent ones.
- Ignoring of invalid field values (e.g., containing something other than a non-negative integer).
- The presence of an Age header field implies that the response was not generated or validated by the origin server for this request.
- Improved/Fixing the age calculation algorithm considering the apparent age, response delay, corrected age value, and current age to align it with the standard.
- 