### PR TITLE
HTTPCLIENT-2277: Revision and optimization of cache key generation

### DIFF
--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestBasicHttpCache.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestBasicHttpCache.java
@@ -187,7 +187,7 @@ public class TestBasicHttpCache {
 
         final String key = CacheKeyGenerator.INSTANCE.generateKey(host, req);
 
-        impl.storeInCache(host, req, resp, Instant.now(), Instant.now(), key, entry);
+        impl.storeInCache(req, resp, Instant.now(), Instant.now(), key, entry);
         assertSame(entry, backing.map.get(key));
     }
 


### PR DESCRIPTION
Presently a lot of cache operations are sub-optimal and redundant. The same cache key may be generated and the same cache lookup performed over and over again in different places in the course of a single request execution

I am optimizing the cache code starting with the most fundamental bit: the cache key generator

Key generator changes:
* improved normalization of variant keys
* potentially less intermediate garbage and a better performance of key computation

@arturobernalg Please review.