### PR TITLE
HTTPCLIENT-2277: optimization of internal cache operations

### DIFF
--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/cache/HeaderConstants.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/cache/HeaderConstants.java
@@ -33,12 +33,40 @@ package org.apache.hc.client5.http.cache;
  */
 public class HeaderConstants {
 
+    /**
+     * @deprecated Use {@link org.apache.hc.core5.http.Method}
+     */
+    @Deprecated
     public static final String GET_METHOD = "GET";
+    /**
+     * @deprecated Use {@link org.apache.hc.core5.http.Method}
+     */
+    @Deprecated
     public static final String HEAD_METHOD = "HEAD";
+    /**
+     * @deprecated Use {@link org.apache.hc.core5.http.Method}
+     */
+    @Deprecated
     public static final String OPTIONS_METHOD = "OPTIONS";
+    /**
+     * @deprecated Use {@link org.apache.hc.core5.http.Method}
+     */
+    @Deprecated
     public static final String PUT_METHOD = "PUT";
+    /**
+     * @deprecated Use {@link org.apache.hc.core5.http.Method}
+     */
+    @Deprecated
     public static final String DELETE_METHOD = "DELETE";
+    /**
+     * @deprecated Use {@link org.apache.hc.core5.http.Method}
+     */
+    @Deprecated
     public static final String TRACE_METHOD = "TRACE";
+    /**
+     * @deprecated Use {@link org.apache.hc.core5.http.Method}
+     */
+    @Deprecated
     public static final String POST_METHOD = "POST";
 
     /**

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/BasicHttpAsyncCache.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/BasicHttpAsyncCache.java
@@ -27,24 +27,26 @@
 package org.apache.hc.client5.http.impl.cache;
 
 import java.time.Instant;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.hc.client5.http.cache.HttpAsyncCacheInvalidator;
 import org.apache.hc.client5.http.cache.HttpAsyncCacheStorage;
 import org.apache.hc.client5.http.cache.HttpCacheEntry;
 import org.apache.hc.client5.http.cache.HttpCacheEntryFactory;
 import org.apache.hc.client5.http.cache.HttpCacheUpdateException;
+import org.apache.hc.client5.http.cache.Resource;
 import org.apache.hc.client5.http.cache.ResourceFactory;
 import org.apache.hc.client5.http.cache.ResourceIOException;
 import org.apache.hc.client5.http.impl.Operations;
 import org.apache.hc.core5.concurrent.Cancellable;
 import org.apache.hc.core5.concurrent.ComplexCancellable;
 import org.apache.hc.core5.concurrent.FutureCallback;
-import org.apache.hc.core5.http.Header;
-import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.HttpResponse;
@@ -90,111 +92,152 @@ class BasicHttpAsyncCache implements HttpAsyncCache {
     }
 
     @Override
-    public String generateKey(final HttpHost host, final HttpRequest request, final HttpCacheEntry cacheEntry) {
-        final String root = cacheKeyGenerator.generateKey(host, request);
-        if (cacheEntry != null && cacheEntry.isVariantRoot()) {
-            final List<String> variantNames = CacheKeyGenerator.variantNames(cacheEntry);
-            if (!variantNames.isEmpty()) {
-                final String variantKey = cacheKeyGenerator.generateVariantKey(request, variantNames);
-                return variantKey + root;
-            }
-        }
-        return root;
-    }
-
-    @Override
-    public Cancellable flushCacheEntriesFor(
-            final HttpHost host, final HttpRequest request, final FutureCallback<Boolean> callback) {
+    public Cancellable match(final HttpHost host, final HttpRequest request, final FutureCallback<CacheMatch> callback) {
+        final String rootKey = cacheKeyGenerator.generateKey(host, request);
         if (LOG.isDebugEnabled()) {
-            LOG.debug("Flush cache entries: {}; {}", host, new RequestLine(request));
+            LOG.debug("Get cache entry: {}", rootKey);
         }
-        if (!Method.isSafe(request.getMethod())) {
-            final String rootKey = cacheKeyGenerator.generateKey(host, request);
-            return storage.removeEntry(rootKey, new FutureCallback<Boolean>() {
-
-                @Override
-                public void completed(final Boolean result) {
-                    callback.completed(result);
-                }
-
-                @Override
-                public void failed(final Exception ex) {
-                    if (ex instanceof ResourceIOException) {
-                        if (LOG.isWarnEnabled()) {
-                            LOG.warn("I/O error removing cache entry with key {}", rootKey);
-                        }
-                        callback.completed(Boolean.TRUE);
-                    } else {
-                        callback.failed(ex);
-                    }
-                }
-
-                @Override
-                public void cancelled() {
-                    callback.cancelled();
-                }
-
-            });
-        }
-        callback.completed(Boolean.TRUE);
-        return Operations.nonCancellable();
-    }
-
-    @Override
-    public Cancellable flushCacheEntriesInvalidatedByRequest(
-            final HttpHost host, final HttpRequest request, final FutureCallback<Boolean> callback) {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Flush cache entries invalidated by request: {}; {}", host, new RequestLine(request));
-        }
-        return cacheInvalidator.flushCacheEntriesInvalidatedByRequest(host, request, cacheKeyGenerator, storage, callback);
-    }
-
-    @Override
-    public Cancellable flushCacheEntriesInvalidatedByExchange(
-            final HttpHost host, final HttpRequest request, final HttpResponse response, final FutureCallback<Boolean> callback) {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Flush cache entries invalidated by exchange: {}; {} -> {}", host, new RequestLine(request), new StatusLine(response));
-        }
-        if (!Method.isSafe(request.getMethod())) {
-            return cacheInvalidator.flushCacheEntriesInvalidatedByExchange(host, request, response, cacheKeyGenerator, storage, callback);
-        }
-        callback.completed(Boolean.TRUE);
-        return Operations.nonCancellable();
-    }
-
-    Cancellable storeInCache(
-            final HttpRequest request,
-            final HttpResponse originResponse,
-            final Instant requestSent,
-            final Instant responseReceived,
-            final String rootKey,
-            final HttpCacheEntry entry,
-            final FutureCallback<Boolean> callback) {
-        if (entry.hasVariants()) {
-            return storeVariantEntry(request, originResponse, requestSent, responseReceived, rootKey, entry, callback);
-        } else {
-            return storeEntry(rootKey, entry, callback);
-        }
-    }
-
-    Cancellable storeEntry(
-            final String cacheKey,
-            final HttpCacheEntry entry,
-            final FutureCallback<Boolean> callback) {
-        return storage.putEntry(cacheKey, entry, new FutureCallback<Boolean>() {
+        final ComplexCancellable complexCancellable = new ComplexCancellable();
+        complexCancellable.setDependency(storage.getEntry(rootKey, new FutureCallback<HttpCacheEntry>() {
 
             @Override
-            public void completed(final Boolean result) {
-                callback.completed(result);
+            public void completed(final HttpCacheEntry root) {
+                if (root != null) {
+                    if (root.isVariantRoot()) {
+                        final List<String> variantNames = CacheKeyGenerator.variantNames(root);
+                        final String variantKey = cacheKeyGenerator.generateVariantKey(request, variantNames);
+                        final String cacheKey = root.getVariantMap().get(variantKey);
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("Get cache variant entry: {}", cacheKey);
+                        }
+                        if (cacheKey != null) {
+                            complexCancellable.setDependency(storage.getEntry(
+                                    cacheKey,
+                                    new FutureCallback<HttpCacheEntry>() {
+
+                                        @Override
+                                        public void completed(final HttpCacheEntry entry) {
+                                            callback.completed(new CacheMatch(
+                                                    entry != null ? new CacheHit(rootKey, cacheKey, entry) : null,
+                                                    new CacheHit(rootKey, root)));
+                                        }
+
+                                        @Override
+                                        public void failed(final Exception ex) {
+                                            if (ex instanceof ResourceIOException) {
+                                                if (LOG.isWarnEnabled()) {
+                                                    LOG.warn("I/O error retrieving cache entry with key {}", cacheKey);
+                                                }
+                                                callback.completed(null);
+                                            } else {
+                                                callback.failed(ex);
+                                            }
+                                        }
+
+                                        @Override
+                                        public void cancelled() {
+                                            callback.cancelled();
+                                        }
+
+                                    }));
+                            return;
+                        }
+                    }
+                    callback.completed(new CacheMatch(new CacheHit(rootKey, root), null));
+                } else {
+                    callback.completed(null);
+                }
             }
 
             @Override
             public void failed(final Exception ex) {
                 if (ex instanceof ResourceIOException) {
                     if (LOG.isWarnEnabled()) {
-                        LOG.warn("I/O error storing cache entry with key {}", cacheKey);
+                        LOG.warn("I/O error retrieving cache entry with key {}", rootKey);
                     }
-                    callback.completed(Boolean.TRUE);
+                    callback.completed(null);
+                } else {
+                    callback.failed(ex);
+                }
+            }
+
+            @Override
+            public void cancelled() {
+                callback.cancelled();
+            }
+
+        }));
+        return complexCancellable;
+    }
+
+    @Override
+    public Cancellable getVariants(
+            final CacheHit hit, final FutureCallback<Collection<CacheHit>> callback) {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Get variant cache entries: {}", hit.rootKey);
+        }
+        final ComplexCancellable complexCancellable = new ComplexCancellable();
+        final HttpCacheEntry root = hit.entry;
+        if (root != null && root.isVariantRoot()) {
+            final Set<String> variantCacheKeys = root.getVariantMap().keySet();
+            complexCancellable.setDependency(storage.getEntries(
+                    variantCacheKeys,
+                    new FutureCallback<Map<String, HttpCacheEntry>>() {
+
+                        @Override
+                        public void completed(final Map<String, HttpCacheEntry> resultMap) {
+                            final List<CacheHit> cacheHits = resultMap.entrySet().stream()
+                                    .map(e -> new CacheHit(hit.rootKey, e.getKey(), e.getValue()))
+                                    .collect(Collectors.toList());
+                            callback.completed(cacheHits);
+                        }
+
+                        @Override
+                        public void failed(final Exception ex) {
+                            if (ex instanceof ResourceIOException) {
+                                if (LOG.isWarnEnabled()) {
+                                    LOG.warn("I/O error retrieving cache entry with keys {}", variantCacheKeys);
+                                }
+                                callback.completed(Collections.emptyList());
+                            } else {
+                                callback.failed(ex);
+                            }
+                        }
+
+                        @Override
+                        public void cancelled() {
+                            callback.cancelled();
+                        }
+
+                    }));
+        } else {
+            callback.completed(Collections.emptyList());
+        }
+        return complexCancellable;
+    }
+
+    Cancellable storeEntry(
+            final String rootKey,
+            final HttpCacheEntry entry,
+            final FutureCallback<CacheHit> callback) {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Put entry in cache: {}", rootKey);
+        }
+
+        return storage.putEntry(rootKey, entry, new FutureCallback<Boolean>() {
+
+            @Override
+            public void completed(final Boolean result) {
+                callback.completed(new CacheHit(rootKey, entry));
+            }
+
+            @Override
+            public void failed(final Exception ex) {
+                if (ex instanceof ResourceIOException) {
+                    if (LOG.isWarnEnabled()) {
+                        LOG.warn("I/O error storing cache entry with key {}", rootKey);
+                    }
+                    callback.completed(new CacheHit(rootKey, entry));
                 } else {
                     callback.failed(ex);
                 }
@@ -208,21 +251,30 @@ class BasicHttpAsyncCache implements HttpAsyncCache {
         });
     }
 
-    Cancellable storeVariantEntry(
+    Cancellable storeVariant(
             final HttpRequest request,
             final HttpResponse originResponse,
             final Instant requestSent,
             final Instant responseReceived,
             final String rootKey,
             final HttpCacheEntry entry,
-            final FutureCallback<Boolean> callback) {
+            final FutureCallback<CacheHit> callback) {
         final List<String> variantNames = CacheKeyGenerator.variantNames(entry);
         final String variantKey = cacheKeyGenerator.generateVariantKey(request, variantNames);
         final String variantCacheKey = variantKey + rootKey;
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Put variant entry in cache: {}", variantCacheKey);
+        }
+
         return storage.putEntry(variantCacheKey, entry, new FutureCallback<Boolean>() {
 
             @Override
             public void completed(final Boolean result) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Update root entry: {}", rootKey);
+                }
+
                 storage.updateEntry(rootKey,
                         existing -> {
                             final Map<String,String> variantMap = existing != null ? new HashMap<>(existing.getVariantMap()) : new HashMap<>();
@@ -233,7 +285,7 @@ class BasicHttpAsyncCache implements HttpAsyncCache {
 
                             @Override
                             public void completed(final Boolean result) {
-                                callback.completed(result);
+                                callback.completed(new CacheHit(rootKey, variantCacheKey, entry));
                             }
 
                             @Override
@@ -265,6 +317,165 @@ class BasicHttpAsyncCache implements HttpAsyncCache {
                     if (LOG.isWarnEnabled()) {
                         LOG.warn("I/O error updating cache entry with key {}", variantCacheKey);
                     }
+                    callback.completed(new CacheHit(rootKey, variantCacheKey, entry));
+                } else {
+                    callback.failed(ex);
+                }
+            }
+
+            @Override
+            public void cancelled() {
+                callback.cancelled();
+            }
+
+        });
+    }
+
+    Cancellable store(
+            final HttpRequest request,
+            final HttpResponse originResponse,
+            final Instant requestSent,
+            final Instant responseReceived,
+            final String rootKey,
+            final HttpCacheEntry entry,
+            final FutureCallback<CacheHit> callback) {
+        if (entry.hasVariants()) {
+            return storeVariant(request, originResponse, requestSent, responseReceived, rootKey, entry, callback);
+        } else {
+            return storeEntry(rootKey, entry, callback);
+        }
+    }
+
+    @Override
+    public Cancellable store(
+            final HttpHost host,
+            final HttpRequest request,
+            final HttpResponse originResponse,
+            final ByteArrayBuffer content,
+            final Instant requestSent,
+            final Instant responseReceived,
+            final FutureCallback<CacheHit> callback) {
+        final String rootKey = cacheKeyGenerator.generateKey(host, request);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Create cache entry: {}", rootKey);
+        }
+        final Resource resource;
+        try {
+            resource = content != null ? resourceFactory.generate(request.getRequestUri(), content.array(), 0, content.length()) : null;
+        } catch (final ResourceIOException ex) {
+            if (LOG.isWarnEnabled()) {
+                LOG.warn("I/O error creating cache entry with key {}", rootKey);
+            }
+            final HttpCacheEntry backup = cacheEntryFactory.create(
+                    requestSent,
+                    responseReceived,
+                    request,
+                    originResponse,
+                    content != null ? HeapResourceFactory.INSTANCE.generate(null, content.array(), 0, content.length()) : null);
+            callback.completed(new CacheHit(rootKey, backup));
+            return Operations.nonCancellable();
+        }
+        final HttpCacheEntry entry = cacheEntryFactory.create(requestSent, responseReceived, request, originResponse, resource);
+        return store(
+                request,
+                originResponse,
+                requestSent,
+                responseReceived,
+                rootKey,
+                entry,
+                callback);
+    }
+
+    @Override
+    public Cancellable update(
+            final CacheHit stale,
+            final HttpRequest request,
+            final HttpResponse originResponse,
+            final Instant requestSent,
+            final Instant responseReceived,
+            final FutureCallback<CacheHit> callback) {
+        final String entryKey = stale.getEntryKey();
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Update cache entry: {}", entryKey);
+        }
+        final HttpCacheEntry updatedEntry = cacheEntryFactory.createUpdated(
+                requestSent,
+                responseReceived,
+                originResponse,
+                stale.entry);
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Put entry in cache: {}", entryKey);
+        }
+
+        return store(
+                request,
+                originResponse,
+                requestSent,
+                responseReceived,
+                entryKey,
+                updatedEntry,
+                callback);
+    }
+
+    @Override
+    public Cancellable update(
+            final CacheHit stale,
+            final HttpResponse originResponse,
+            final Instant requestSent,
+            final Instant responseReceived,
+            final FutureCallback<CacheHit> callback) {
+        final String entryKey = stale.getEntryKey();
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Update cache entry (no root): {}", entryKey);
+        }
+        final HttpCacheEntry updatedEntry = cacheEntryFactory.createUpdated(
+                requestSent,
+                responseReceived,
+                originResponse,
+                stale.entry);
+        return storeEntry(
+                entryKey,
+                updatedEntry,
+                callback);
+    }
+
+    @Override
+    public Cancellable storeReusing(
+            final CacheHit hit,
+            final HttpHost host,
+            final HttpRequest request,
+            final HttpResponse originResponse,
+            final Instant requestSent,
+            final Instant responseReceived,
+            final FutureCallback<CacheHit> callback) {
+        final String rootKey = cacheKeyGenerator.generateKey(host, request);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Store cache entry using existing entry: {} -> {}", rootKey, hit.rootKey);
+        }
+        return store(request, originResponse, requestSent, responseReceived, rootKey, hit.entry, callback);
+    }
+
+    @Override
+    public Cancellable flushCacheEntriesFor(
+            final HttpHost host, final HttpRequest request, final FutureCallback<Boolean> callback) {
+        final String rootKey = cacheKeyGenerator.generateKey(host, request);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Flush cache entries: {}", rootKey);
+        }
+        return storage.removeEntry(rootKey, new FutureCallback<Boolean>() {
+
+            @Override
+            public void completed(final Boolean result) {
+                callback.completed(result);
+            }
+
+            @Override
+            public void failed(final Exception ex) {
+                if (ex instanceof ResourceIOException) {
+                    if (LOG.isWarnEnabled()) {
+                        LOG.warn("I/O error removing cache entry with key {}", rootKey);
+                    }
                     callback.completed(Boolean.TRUE);
                 } else {
                     callback.failed(ex);
@@ -280,304 +491,25 @@ class BasicHttpAsyncCache implements HttpAsyncCache {
     }
 
     @Override
-    public Cancellable reuseVariantEntryFor(
-            final HttpHost host,
-            final HttpRequest request,
-            final HttpResponse originResponse,
-            final HttpCacheEntry entry,
-            final Instant requestSent,
-            final Instant responseReceived,
-            final FutureCallback<Boolean> callback) {
+    public Cancellable flushCacheEntriesInvalidatedByRequest(
+            final HttpHost host, final HttpRequest request, final FutureCallback<Boolean> callback) {
         if (LOG.isDebugEnabled()) {
-            LOG.debug("Re-use variant entry: {}; {} / {}", host, new RequestLine(request), entry);
+            LOG.debug("Flush cache entries invalidated by request: {}; {}", host, new RequestLine(request));
         }
-        final String rootKey = cacheKeyGenerator.generateKey(host, request);
-        return storeVariantEntry(request, originResponse, requestSent, responseReceived, rootKey, entry, callback);
+        return cacheInvalidator.flushCacheEntriesInvalidatedByRequest(host, request, cacheKeyGenerator, storage, callback);
     }
 
     @Override
-    public Cancellable updateEntry(
-            final HttpHost host,
-            final HttpRequest request,
-            final HttpCacheEntry stale,
-            final HttpResponse originResponse,
-            final Instant requestSent,
-            final Instant responseReceived,
-            final FutureCallback<HttpCacheEntry> callback) {
+    public Cancellable flushCacheEntriesInvalidatedByExchange(
+            final HttpHost host, final HttpRequest request, final HttpResponse response, final FutureCallback<Boolean> callback) {
         if (LOG.isDebugEnabled()) {
-            LOG.debug("Update cache entry: {}; {}", host, new RequestLine(request));
+            LOG.debug("Flush cache entries invalidated by exchange: {}; {} -> {}", host, new RequestLine(request), new StatusLine(response));
         }
-        final String rootKey = cacheKeyGenerator.generateKey(host, request);
-        final HttpCacheEntry updatedEntry = cacheEntryFactory.createUpdated(
-                requestSent,
-                responseReceived,
-                originResponse,
-                stale);
-        return storeInCache(
-                request,
-                originResponse,
-                requestSent,
-                responseReceived,
-                rootKey,
-                updatedEntry,
-                new FutureCallback<Boolean>() {
-
-                    @Override
-                    public void completed(final Boolean result) {
-                        callback.completed(updatedEntry);
-                    }
-
-                    @Override
-                    public void failed(final Exception ex) {
-                        callback.failed(ex);
-                    }
-
-                    @Override
-                    public void cancelled() {
-                        callback.cancelled();
-                    }
-
-                });
-    }
-
-    @Override
-    public Cancellable updateVariantEntry(
-            final HttpHost host,
-            final HttpRequest request,
-            final HttpResponse originResponse,
-            final HttpCacheEntry entry,
-            final Instant requestSent,
-            final Instant responseReceived,
-            final FutureCallback<HttpCacheEntry> callback) {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Update variant cache entry: {}; {} / {}", host, new RequestLine(request), entry);
+        if (!Method.isSafe(request.getMethod())) {
+            return cacheInvalidator.flushCacheEntriesInvalidatedByExchange(host, request, response, cacheKeyGenerator, storage, callback);
         }
-        final String rootKey = cacheKeyGenerator.generateKey(host, request);
-        final HttpCacheEntry updatedEntry = cacheEntryFactory.createUpdated(
-                requestSent,
-                responseReceived,
-                originResponse,
-                entry);
-        return storeEntry(rootKey, updatedEntry, new FutureCallback<Boolean>() {
-
-            @Override
-            public void completed(final Boolean result) {
-                callback.completed(updatedEntry);
-            }
-
-            @Override
-            public void failed(final Exception ex) {
-                callback.failed(ex);
-            }
-
-            @Override
-            public void cancelled() {
-                callback.cancelled();
-            }
-
-        });
-    }
-
-    @Override
-    public Cancellable createEntry(
-            final HttpHost host,
-            final HttpRequest request,
-            final HttpResponse originResponse,
-            final ByteArrayBuffer content,
-            final Instant requestSent,
-            final Instant responseReceived,
-            final FutureCallback<HttpCacheEntry> callback) {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Create cache entry: {}; {}", host, new RequestLine(request));
-        }
-        final String rootKey = cacheKeyGenerator.generateKey(host, request);
-        try {
-            final HttpCacheEntry entry = cacheEntryFactory.create(requestSent, responseReceived, request, originResponse,
-                    content != null ? resourceFactory.generate(request.getRequestUri(), content.array(), 0, content.length()) : null);
-            return storeInCache(
-                    request,
-                    originResponse,
-                    requestSent,
-                    responseReceived,
-                    rootKey,
-                    entry, new FutureCallback<Boolean>() {
-
-                        @Override
-                        public void completed(final Boolean result) {
-                            callback.completed(entry);
-                        }
-
-                        @Override
-                        public void failed(final Exception ex) {
-                            callback.failed(ex);
-                        }
-
-                        @Override
-                        public void cancelled() {
-                            callback.cancelled();
-                        }
-
-                    });
-        } catch (final ResourceIOException ex) {
-            if (LOG.isWarnEnabled()) {
-                LOG.warn("I/O error creating cache entry with key {}", rootKey);
-            }
-            callback.completed(cacheEntryFactory.create(
-                    requestSent,
-                    responseReceived,
-                    request,
-                    originResponse,
-                    content != null ? HeapResourceFactory.INSTANCE.generate(null, content.array(), 0, content.length()) : null));
-            return Operations.nonCancellable();
-        }
-    }
-
-    @Override
-    public Cancellable getCacheEntry(final HttpHost host, final HttpRequest request, final FutureCallback<HttpCacheEntry> callback) {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Get cache entry: {}; {}", host, new RequestLine(request));
-        }
-        final ComplexCancellable complexCancellable = new ComplexCancellable();
-        final String rootKey = cacheKeyGenerator.generateKey(host, request);
-        complexCancellable.setDependency(storage.getEntry(rootKey, new FutureCallback<HttpCacheEntry>() {
-
-            @Override
-            public void completed(final HttpCacheEntry root) {
-                if (root != null) {
-                    if (root.isVariantRoot()) {
-                        final List<String> variantNames = CacheKeyGenerator.variantNames(root);
-                        final String variantKey = cacheKeyGenerator.generateVariantKey(request, variantNames);
-                        final String variantCacheKey = root.getVariantMap().get(variantKey);
-                        if (variantCacheKey != null) {
-                            complexCancellable.setDependency(storage.getEntry(
-                                    variantCacheKey,
-                                    new FutureCallback<HttpCacheEntry>() {
-
-                                        @Override
-                                        public void completed(final HttpCacheEntry result) {
-                                            callback.completed(result);
-                                        }
-
-                                        @Override
-                                        public void failed(final Exception ex) {
-                                            if (ex instanceof ResourceIOException) {
-                                                if (LOG.isWarnEnabled()) {
-                                                    LOG.warn("I/O error retrieving cache entry with key {}", variantCacheKey);
-                                                }
-                                                callback.completed(null);
-                                            } else {
-                                                callback.failed(ex);
-                                            }
-                                        }
-
-                                        @Override
-                                        public void cancelled() {
-                                            callback.cancelled();
-                                        }
-
-                                    }));
-                            return;
-                        }
-                    }
-                }
-                callback.completed(root);
-            }
-
-            @Override
-            public void failed(final Exception ex) {
-                if (ex instanceof ResourceIOException) {
-                    if (LOG.isWarnEnabled()) {
-                        LOG.warn("I/O error retrieving cache entry with key {}", rootKey);
-                    }
-                    callback.completed(null);
-                } else {
-                    callback.failed(ex);
-                }
-            }
-
-            @Override
-            public void cancelled() {
-                callback.cancelled();
-            }
-
-        }));
-        return complexCancellable;
-    }
-
-    @Override
-    public Cancellable getVariantCacheEntriesWithEtags(
-            final HttpHost host, final HttpRequest request, final FutureCallback<Map<String, Variant>> callback) {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Get variant cache entries: {}; {}", host, new RequestLine(request));
-        }
-        final ComplexCancellable complexCancellable = new ComplexCancellable();
-        final String rootKey = cacheKeyGenerator.generateKey(host, request);
-        final Map<String, Variant> variants = new HashMap<>();
-        complexCancellable.setDependency(storage.getEntry(rootKey, new FutureCallback<HttpCacheEntry>() {
-
-            @Override
-            public void completed(final HttpCacheEntry rootEntry) {
-                if (rootEntry != null && rootEntry.isVariantRoot()) {
-                    final Set<String> variantCacheKeys = rootEntry.getVariantMap().keySet();
-                    complexCancellable.setDependency(storage.getEntries(
-                            variantCacheKeys,
-                            new FutureCallback<Map<String, HttpCacheEntry>>() {
-
-                                @Override
-                                public void completed(final Map<String, HttpCacheEntry> resultMap) {
-                                    for (final Map.Entry<String, HttpCacheEntry> resultMapEntry : resultMap.entrySet()) {
-                                        final String cacheKey = resultMapEntry.getKey();
-                                        final HttpCacheEntry cacheEntry = resultMapEntry.getValue();
-                                        final Header etagHeader = cacheEntry.getFirstHeader(HttpHeaders.ETAG);
-                                        if (etagHeader != null) {
-                                            variants.put(etagHeader.getValue(), new Variant(cacheKey, cacheEntry));
-                                        }
-                                    }
-                                    callback.completed(variants);
-                                }
-
-                                @Override
-                                public void failed(final Exception ex) {
-                                    if (ex instanceof ResourceIOException) {
-                                        if (LOG.isWarnEnabled()) {
-                                            LOG.warn("I/O error retrieving cache entry with keys {}", variantCacheKeys);
-                                        }
-                                        callback.completed(variants);
-                                    } else {
-                                        callback.failed(ex);
-                                    }
-                                }
-
-                                @Override
-                                public void cancelled() {
-                                    callback.cancelled();
-                                }
-
-                            }));
-                } else {
-                    callback.completed(variants);
-                }
-            }
-
-            @Override
-            public void failed(final Exception ex) {
-                if (ex instanceof ResourceIOException) {
-                    if (LOG.isWarnEnabled()) {
-                        LOG.warn("I/O error retrieving cache entry with key {}", rootKey);
-                    }
-                    callback.completed(variants);
-                } else {
-                    callback.failed(ex);
-                }
-            }
-
-            @Override
-            public void cancelled() {
-                callback.cancelled();
-            }
-
-        }));
-        return complexCancellable;
+        callback.completed(Boolean.TRUE);
+        return Operations.nonCancellable();
     }
 
 }

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/BasicHttpCache.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/BasicHttpCache.java
@@ -27,19 +27,21 @@
 package org.apache.hc.client5.http.impl.cache;
 
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.hc.client5.http.cache.HttpCacheCASOperation;
 import org.apache.hc.client5.http.cache.HttpCacheEntry;
 import org.apache.hc.client5.http.cache.HttpCacheEntryFactory;
 import org.apache.hc.client5.http.cache.HttpCacheInvalidator;
 import org.apache.hc.client5.http.cache.HttpCacheStorage;
 import org.apache.hc.client5.http.cache.HttpCacheUpdateException;
+import org.apache.hc.client5.http.cache.Resource;
 import org.apache.hc.client5.http.cache.ResourceFactory;
 import org.apache.hc.client5.http.cache.ResourceIOException;
-import org.apache.hc.core5.http.Header;
-import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.HttpResponse;
@@ -92,32 +94,236 @@ class BasicHttpCache implements HttpCache {
         this(CacheConfig.DEFAULT);
     }
 
-    @Override
-    public String generateKey(final HttpHost host, final HttpRequest request, final HttpCacheEntry cacheEntry) {
-        final String root = cacheKeyGenerator.generateKey(host, request);
-        if (cacheEntry != null && cacheEntry.isVariantRoot()) {
-            final List<String> variantNames = CacheKeyGenerator.variantNames(cacheEntry);
-            if (!variantNames.isEmpty()) {
-                final String variantKey = cacheKeyGenerator.generateVariantKey(request, variantNames);
-                return variantKey + root;
+    void storeInternal(final String cacheKey, final HttpCacheEntry entry) {
+        try {
+            storage.putEntry(cacheKey, entry);
+        } catch (final ResourceIOException ex) {
+            if (LOG.isWarnEnabled()) {
+                LOG.warn("I/O error storing cache entry with key {}", cacheKey);
             }
         }
-        return root;
+    }
+
+    void updateInternal(final String cacheKey, final HttpCacheCASOperation casOperation) {
+        try {
+            storage.updateEntry(cacheKey, casOperation);
+        } catch (final HttpCacheUpdateException ex) {
+            if (LOG.isWarnEnabled()) {
+                LOG.warn("Cannot update cache entry with key {}", cacheKey);
+            }
+        } catch (final ResourceIOException ex) {
+            if (LOG.isWarnEnabled()) {
+                LOG.warn("I/O error updating cache entry with key {}", cacheKey);
+            }
+        }
+    }
+
+    HttpCacheEntry getInternal(final String cacheKey) {
+        try {
+            return storage.getEntry(cacheKey);
+        } catch (final ResourceIOException ex) {
+            if (LOG.isWarnEnabled()) {
+                LOG.warn("I/O error retrieving cache entry with key {}", cacheKey);
+            }
+            return null;
+        }
+    }
+
+    @Override
+    public CacheMatch match(final HttpHost host, final HttpRequest request) {
+        final String rootKey = cacheKeyGenerator.generateKey(host, request);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Get cache root entry: {}", rootKey);
+        }
+        final HttpCacheEntry root = getInternal(rootKey);
+        if (root == null) {
+            return null;
+        }
+        if (root.isVariantRoot()) {
+            final List<String> variantNames = CacheKeyGenerator.variantNames(root);
+            final String variantKey = cacheKeyGenerator.generateVariantKey(request, variantNames);
+            final String cacheKey = root.getVariantMap().get(variantKey);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Get cache variant entry: {}", cacheKey);
+            }
+            if (cacheKey != null) {
+                final HttpCacheEntry entry = getInternal(cacheKey);
+                if (entry != null) {
+                    return new CacheMatch(new CacheHit(rootKey, cacheKey, entry), new CacheHit(rootKey, root));
+                }
+            }
+            return new CacheMatch(null, new CacheHit(rootKey, root));
+        } else {
+            return new CacheMatch(new CacheHit(rootKey, root), null);
+        }
+    }
+
+    @Override
+    public List<CacheHit> getVariants(final CacheHit hit) {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Get variant cache entries: {}", hit.rootKey);
+        }
+        final HttpCacheEntry root = hit.entry;
+        if (root != null && root.isVariantRoot()) {
+            final List<CacheHit> variants = new ArrayList<>();
+            for (final String variantKey : root.getVariantMap().values()) {
+                final HttpCacheEntry variant = getInternal(variantKey);
+                if (variant != null) {
+                    variants.add(new CacheHit(hit.rootKey, variantKey, variant));
+                }
+            }
+            return variants;
+        }
+        return Collections.emptyList();
+    }
+
+    CacheHit store(
+            final HttpRequest request,
+            final HttpResponse originResponse,
+            final Instant requestSent,
+            final Instant responseReceived,
+            final String rootKey,
+            final HttpCacheEntry entry) {
+        if (entry.hasVariants()) {
+            return storeVariant(request, originResponse, requestSent, responseReceived, rootKey, entry);
+        } else {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Put entry in cache: {}", rootKey);
+            }
+            storeInternal(rootKey, entry);
+            return new CacheHit(rootKey, entry);
+        }
+    }
+
+    CacheHit storeVariant(
+            final HttpRequest request,
+            final HttpResponse originResponse,
+            final Instant requestSent,
+            final Instant responseReceived,
+            final String rootKey,
+            final HttpCacheEntry entry) {
+        final List<String> variantNames = CacheKeyGenerator.variantNames(entry);
+        final String variantKey = cacheKeyGenerator.generateVariantKey(request, variantNames);
+        final String variantCacheKey = variantKey + rootKey;
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Put variant entry in cache: {}", variantCacheKey);
+        }
+
+        storeInternal(variantCacheKey, entry);
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Update root entry: {}", rootKey);
+        }
+
+        updateInternal(rootKey, existing -> {
+            final Map<String, String> variantMap = existing != null ? new HashMap<>(existing.getVariantMap()) : new HashMap<>();
+            variantMap.put(variantKey, variantCacheKey);
+            return cacheEntryFactory.createRoot(requestSent, responseReceived, request, originResponse, variantMap);
+        });
+        return new CacheHit(rootKey, variantCacheKey, entry);
+    }
+
+    @Override
+    public CacheHit store(
+            final HttpHost host,
+            final HttpRequest request,
+            final HttpResponse originResponse,
+            final ByteArrayBuffer content,
+            final Instant requestSent,
+            final Instant responseReceived) {
+        final String rootKey = cacheKeyGenerator.generateKey(host, request);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Store cache entry: {}", rootKey);
+        }
+        final Resource resource;
+        try {
+            resource = content != null ? resourceFactory.generate(request.getRequestUri(), content.array(), 0, content.length()) : null;
+        } catch (final ResourceIOException ex) {
+            if (LOG.isWarnEnabled()) {
+                LOG.warn("I/O error creating cache entry with key {}", rootKey);
+            }
+            final HttpCacheEntry backup = cacheEntryFactory.create(
+                    requestSent,
+                    responseReceived,
+                    request,
+                    originResponse,
+                    content != null ? HeapResourceFactory.INSTANCE.generate(null, content.array(), 0, content.length()) : null);
+            return new CacheHit(rootKey, backup);
+        }
+        final HttpCacheEntry entry = cacheEntryFactory.create(requestSent, responseReceived, request, originResponse, resource);
+        return store(request, originResponse, requestSent, responseReceived, rootKey, entry);
+    }
+
+    @Override
+    public CacheHit update(
+            final CacheHit stale,
+            final HttpRequest request,
+            final HttpResponse originResponse,
+            final Instant requestSent,
+            final Instant responseReceived) {
+        final String entryKey = stale.getEntryKey();
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Update cache entry: {}", entryKey);
+        }
+        final HttpCacheEntry updatedEntry = cacheEntryFactory.createUpdated(
+                requestSent,
+                responseReceived,
+                originResponse,
+                stale.entry);
+        return store(request, originResponse, requestSent, responseReceived, entryKey, updatedEntry);
+    }
+
+    @Override
+    public CacheHit update(
+            final CacheHit stale,
+            final HttpResponse originResponse,
+            final Instant requestSent,
+            final Instant responseReceived) {
+        final String entryKey = stale.getEntryKey();
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Update cache entry (no root)): {}", entryKey);
+        }
+        final HttpCacheEntry updatedEntry = cacheEntryFactory.createUpdated(
+                requestSent,
+                responseReceived,
+                originResponse,
+                stale.entry);
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Put entry in cache: {}", entryKey);
+        }
+
+        storeInternal(entryKey, updatedEntry);
+        return new CacheHit(stale.rootKey, stale.variantKey, updatedEntry);
+    }
+
+    @Override
+    public CacheHit storeReusing(
+            final CacheHit hit,
+            final HttpHost host,
+            final HttpRequest request,
+            final HttpResponse originResponse,
+            final Instant requestSent,
+            final Instant responseReceived) {
+        final String rootKey = cacheKeyGenerator.generateKey(host, request);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Store cache entry using existing entry: {} -> {}", rootKey, hit.rootKey);
+        }
+        return store(request, originResponse, requestSent, responseReceived, rootKey, hit.entry);
     }
 
     @Override
     public void flushCacheEntriesFor(final HttpHost host, final HttpRequest request) {
+        final String rootKey = cacheKeyGenerator.generateKey(host, request);
         if (LOG.isDebugEnabled()) {
-            LOG.debug("Flush cache entries: {}; {}", host, new RequestLine(request));
+            LOG.debug("Flush cache entries: {}", rootKey);
         }
-        if (!Method.isSafe(request.getMethod())) {
-            final String rootKey = cacheKeyGenerator.generateKey(host, request);
-            try {
-                storage.removeEntry(rootKey);
-            } catch (final ResourceIOException ex) {
-                if (LOG.isWarnEnabled()) {
-                    LOG.warn("I/O error removing cache entry with key {}", rootKey);
-                }
+        try {
+            storage.removeEntry(rootKey);
+        } catch (final ResourceIOException ex) {
+            if (LOG.isWarnEnabled()) {
+                LOG.warn("I/O error removing cache entry with key {}", rootKey);
             }
         }
     }
@@ -138,220 +344,6 @@ class BasicHttpCache implements HttpCache {
         if (!Method.isSafe(request.getMethod())) {
             cacheInvalidator.flushCacheEntriesInvalidatedByExchange(host, request, response, cacheKeyGenerator, storage);
         }
-    }
-
-    void storeInCache(
-            final HttpRequest request,
-            final HttpResponse originResponse,
-            final Instant requestSent,
-            final Instant responseReceived,
-            final String rootKey,
-            final HttpCacheEntry entry) {
-        if (entry.hasVariants()) {
-            storeVariantEntry(request, originResponse, requestSent, responseReceived, rootKey, entry);
-        } else {
-            storeEntry(rootKey, entry);
-        }
-    }
-
-    void storeEntry(final String cacheKey, final HttpCacheEntry entry) {
-        try {
-            storage.putEntry(cacheKey, entry);
-        } catch (final ResourceIOException ex) {
-            if (LOG.isWarnEnabled()) {
-                LOG.warn("I/O error storing cache entry with key {}", cacheKey);
-            }
-        }
-    }
-
-    void storeVariantEntry(
-            final HttpRequest request,
-            final HttpResponse originResponse,
-            final Instant requestSent,
-            final Instant responseReceived,
-            final String rootKey,
-            final HttpCacheEntry entry) {
-        final List<String> variantNames = CacheKeyGenerator.variantNames(entry);
-        final String variantKey = cacheKeyGenerator.generateVariantKey(request, variantNames);
-        final String variantCacheKey = variantKey + request;
-        storeEntry(variantCacheKey, entry);
-        try {
-            storage.updateEntry(rootKey, existing -> {
-                        final Map<String,String> variantMap = existing != null ? new HashMap<>(existing.getVariantMap()) : new HashMap<>();
-                        variantMap.put(variantKey, variantCacheKey);
-                        return cacheEntryFactory.createRoot(requestSent, responseReceived, request, originResponse, variantMap);
-                    });
-        } catch (final HttpCacheUpdateException ex) {
-            if (LOG.isWarnEnabled()) {
-                LOG.warn("Cannot update cache entry with key {}", rootKey);
-            }
-        } catch (final ResourceIOException ex) {
-            if (LOG.isWarnEnabled()) {
-                LOG.warn("I/O error updating cache entry with key {}", rootKey);
-            }
-        }
-    }
-
-    @Override
-    public void reuseVariantEntryFor(
-            final HttpHost host,
-            final HttpRequest request,
-            final HttpResponse originResponse,
-            final HttpCacheEntry entry,
-            final Instant requestSent,
-            final Instant responseReceived) {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Re-use variant entry: {}; {} / {}", host, new RequestLine(request), entry);
-        }
-        final String rootKey = cacheKeyGenerator.generateKey(host, request);
-        storeVariantEntry(request, originResponse, requestSent, responseReceived, rootKey, entry);
-    }
-
-    @Override
-    public HttpCacheEntry updateEntry(
-            final HttpHost host,
-            final HttpRequest request,
-            final HttpCacheEntry stale,
-            final HttpResponse originResponse,
-            final Instant requestSent,
-            final Instant responseReceived) {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Update cache entry: {}; {}", host, new RequestLine(request));
-        }
-        final String rootKey = cacheKeyGenerator.generateKey(host, request);
-        final HttpCacheEntry updatedEntry = cacheEntryFactory.createUpdated(
-                requestSent,
-                responseReceived,
-                originResponse,
-                stale);
-        storeInCache(request, originResponse, requestSent, responseReceived, rootKey, updatedEntry);
-        return updatedEntry;
-    }
-
-    @Override
-    public HttpCacheEntry updateVariantEntry(
-            final HttpHost host,
-            final HttpRequest request,
-            final HttpResponse originResponse,
-            final HttpCacheEntry entry,
-            final Instant requestSent,
-            final Instant responseReceived) {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Update variant cache entry: {}; {} / {}", host, new RequestLine(request), entry);
-        }
-        final String rootKey = cacheKeyGenerator.generateKey(host, request);
-        final HttpCacheEntry updatedEntry = cacheEntryFactory.createUpdated(
-                requestSent,
-                responseReceived,
-                originResponse,
-                entry);
-        storeEntry(rootKey, updatedEntry);
-        return updatedEntry;
-    }
-
-    @Override
-    public HttpCacheEntry createEntry(
-            final HttpHost host,
-            final HttpRequest request,
-            final HttpResponse originResponse,
-            final ByteArrayBuffer content,
-            final Instant requestSent,
-            final Instant responseReceived) {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Create cache entry: {}; {}", host, new RequestLine(request));
-        }
-        final String rootKey = cacheKeyGenerator.generateKey(host, request);
-        try {
-            final HttpCacheEntry entry = cacheEntryFactory.create(requestSent, responseReceived, request, originResponse,
-                    content != null ? resourceFactory.generate(request.getRequestUri(), content.array(), 0, content.length()) : null);
-            storeInCache(request, originResponse, requestSent, responseReceived, rootKey, entry);
-            return entry;
-        } catch (final ResourceIOException ex) {
-            if (LOG.isWarnEnabled()) {
-                LOG.warn("I/O error creating cache entry with key {}", rootKey);
-            }
-            return cacheEntryFactory.create(
-                    requestSent,
-                    responseReceived,
-                    request,
-                    originResponse,
-                    content != null ? HeapResourceFactory.INSTANCE.generate(null, content.array(), 0, content.length()) : null);
-        }
-    }
-
-    @Override
-    public HttpCacheEntry getCacheEntry(final HttpHost host, final HttpRequest request) {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Get cache entry: {}; {}", host, new RequestLine(request));
-        }
-        final String rootKey = cacheKeyGenerator.generateKey(host, request);
-        final HttpCacheEntry root;
-        try {
-            root = storage.getEntry(rootKey);
-        } catch (final ResourceIOException ex) {
-            if (LOG.isWarnEnabled()) {
-                LOG.warn("I/O error retrieving cache entry with key {}", rootKey);
-            }
-            return null;
-        }
-        if (root == null) {
-            return null;
-        }
-        if (root.isVariantRoot()) {
-            final List<String> variantNames = CacheKeyGenerator.variantNames(root);
-            final String variantKey = cacheKeyGenerator.generateVariantKey(request, variantNames);
-            final String variantCacheKey = root.getVariantMap().get(variantKey);
-            if (variantCacheKey != null) {
-                try {
-                    return storage.getEntry(variantCacheKey);
-                } catch (final ResourceIOException ex) {
-                    if (LOG.isWarnEnabled()) {
-                        LOG.warn("I/O error retrieving cache entry with key {}", variantCacheKey);
-                    }
-                }
-            }
-            return null;
-        } else {
-            return root;
-        }
-    }
-
-    @Override
-    public Map<String, Variant> getVariantCacheEntriesWithEtags(final HttpHost host, final HttpRequest request) {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Get variant cache entries: {}; {}", host, new RequestLine(request));
-        }
-        final Map<String,Variant> variants = new HashMap<>();
-        final String rootKey = cacheKeyGenerator.generateKey(host, request);
-        final HttpCacheEntry root;
-        try {
-            root = storage.getEntry(rootKey);
-        } catch (final ResourceIOException ex) {
-            if (LOG.isWarnEnabled()) {
-                LOG.warn("I/O error retrieving cache entry with key {}", rootKey);
-            }
-            return variants;
-        }
-        if (root != null && root.isVariantRoot()) {
-            for(final Map.Entry<String, String> variant : root.getVariantMap().entrySet()) {
-                final String variantCacheKey = variant.getValue();
-                try {
-                    final HttpCacheEntry entry = storage.getEntry(variantCacheKey);
-                    if (entry != null) {
-                        final Header etagHeader = entry.getFirstHeader(HttpHeaders.ETAG);
-                        if (etagHeader != null) {
-                            variants.put(etagHeader.getValue(), new Variant(variantCacheKey, entry));
-                        }
-                    }
-                } catch (final ResourceIOException ex) {
-                    if (LOG.isWarnEnabled()) {
-                        LOG.warn("I/O error retrieving cache entry with key {}", variantCacheKey);
-                    }
-                    return variants;
-                }
-            }
-        }
-        return variants;
     }
 
 }

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CacheHit.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CacheHit.java
@@ -28,28 +28,33 @@ package org.apache.hc.client5.http.impl.cache;
 
 import org.apache.hc.client5.http.cache.HttpCacheEntry;
 
-/** Records a set of information describing a cached variant. */
-class Variant {
+class CacheHit {
 
-    private final String cacheKey;
-    private final HttpCacheEntry entry;
+    final String rootKey;
+    final String variantKey;
+    final HttpCacheEntry entry;
 
-    public Variant(final String cacheKey, final HttpCacheEntry entry) {
-        this.cacheKey = cacheKey;
+    public CacheHit(final String rootKey, final String variantKey, final HttpCacheEntry entry) {
+        this.rootKey = rootKey;
+        this.variantKey = variantKey;
         this.entry = entry;
     }
 
-    public String getCacheKey() {
-        return cacheKey;
+    public CacheHit(final String rootKey, final HttpCacheEntry entry) {
+        this(rootKey, null, entry);
     }
 
-    public HttpCacheEntry getEntry() {
-        return entry;
+    public String getEntryKey() {
+        return variantKey != null ? variantKey : rootKey;
     }
 
     @Override
     public String toString() {
-        return cacheKey;
+        return "CacheHit{" +
+                "rootKey='" + rootKey + '\'' +
+                ", variantKey='" + variantKey + '\'' +
+                ", entry=" + entry +
+                '}';
     }
 
 }

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CacheInvalidatorBase.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CacheInvalidatorBase.java
@@ -28,13 +28,13 @@ package org.apache.hc.client5.http.impl.cache;
 
 import java.net.URI;
 
-import org.apache.hc.client5.http.cache.HeaderConstants;
 import org.apache.hc.client5.http.cache.HttpCacheEntry;
 import org.apache.hc.client5.http.utils.URIUtils;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.Method;
 
 class CacheInvalidatorBase {
 
@@ -43,11 +43,11 @@ class CacheInvalidatorBase {
     }
 
     static boolean requestIsGet(final HttpRequest req) {
-        return req.getMethod().equals((HeaderConstants.GET_METHOD));
+        return Method.GET.isSame(req.getMethod());
     }
 
     static boolean isAHeadCacheEntry(final HttpCacheEntry parentCacheEntry) {
-        return parentCacheEntry != null && parentCacheEntry.getRequestMethod().equals(HeaderConstants.HEAD_METHOD);
+        return parentCacheEntry != null && Method.HEAD.isSame(parentCacheEntry.getRequestMethod());
     }
 
     static boolean isSameHost(final URI requestURI, final URI targetURI) {
@@ -60,7 +60,7 @@ class CacheInvalidatorBase {
     }
 
     static boolean notGetOrHeadRequest(final String method) {
-        return !(HeaderConstants.GET_METHOD.equals(method) || HeaderConstants.HEAD_METHOD.equals(method));
+        return !(Method.GET.isSame(method) || Method.HEAD.isSame(method));
     }
 
     private static URI getLocationURI(final URI requestUri, final HttpResponse response, final String headerName) {

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CacheMatch.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CacheMatch.java
@@ -1,0 +1,51 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.client5.http.impl.cache;
+
+/**
+ * Represents a full match or a partial match (variant options)
+ * result of a cache lookup operation.
+ */
+class CacheMatch {
+
+    final CacheHit hit;
+    final CacheHit root;
+
+    CacheMatch(final CacheHit hit, final CacheHit root) {
+        this.hit = hit;
+        this.root = root;
+    }
+
+    @Override
+    public String toString() {
+        return "CacheLookupResult{" +
+                "hit=" + hit +
+                ", root=" + root +
+                '}';
+    }
+
+}

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CacheableRequestPolicy.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CacheableRequestPolicy.java
@@ -26,10 +26,10 @@
  */
 package org.apache.hc.client5.http.impl.cache;
 
-import org.apache.hc.client5.http.cache.HeaderConstants;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.HttpVersion;
+import org.apache.hc.core5.http.Method;
 import org.apache.hc.core5.http.ProtocolVersion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,7 +57,7 @@ class CacheableRequestPolicy {
             return false;
         }
 
-        if (!method.equals(HeaderConstants.GET_METHOD) && !method.equals(HeaderConstants.HEAD_METHOD)) {
+        if (!Method.GET.isSame(method) && !Method.HEAD.isSame(method)) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("{} request is not serveable from cache", method);
             }

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachedHttpResponseGenerator.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachedHttpResponseGenerator.java
@@ -64,7 +64,7 @@ class CachedHttpResponseGenerator {
      * @return {@link SimpleHttpResponse} constructed response
      */
     SimpleHttpResponse generateResponse(final HttpRequest request, final HttpCacheEntry entry) throws ResourceIOException {
-        final Instant now =Instant.now();
+        final Instant now = Instant.now();
         final SimpleHttpResponse response = new SimpleHttpResponse(entry.getStatus());
         response.setVersion(HttpVersion.DEFAULT);
 

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachedHttpResponseGenerator.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachedHttpResponseGenerator.java
@@ -29,7 +29,6 @@ package org.apache.hc.client5.http.impl.cache;
 import java.time.Instant;
 
 import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
-import org.apache.hc.client5.http.cache.HeaderConstants;
 import org.apache.hc.client5.http.cache.HttpCacheEntry;
 import org.apache.hc.client5.http.cache.Resource;
 import org.apache.hc.client5.http.cache.ResourceIOException;
@@ -41,6 +40,7 @@ import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.http.HttpVersion;
+import org.apache.hc.core5.http.Method;
 import org.apache.hc.core5.http.message.BasicHeader;
 import org.apache.hc.core5.util.TimeValue;
 
@@ -160,7 +160,7 @@ class CachedHttpResponseGenerator {
     }
 
     private boolean responseShouldContainEntity(final HttpRequest request, final HttpCacheEntry cacheEntry) {
-        return request.getMethod().equals(HeaderConstants.GET_METHOD) && cacheEntry.getResource() != null;
+        return Method.GET.isSame(request.getMethod()) && cacheEntry.getResource() != null;
     }
 
     /**

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachedResponseSuitabilityChecker.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachedResponseSuitabilityChecker.java
@@ -29,7 +29,6 @@ package org.apache.hc.client5.http.impl.cache;
 import java.time.Instant;
 import java.util.Iterator;
 
-import org.apache.hc.client5.http.cache.HeaderConstants;
 import org.apache.hc.client5.http.cache.HttpCacheEntry;
 import org.apache.hc.client5.http.utils.DateUtils;
 import org.apache.hc.core5.http.Header;
@@ -37,6 +36,7 @@ import org.apache.hc.core5.http.HeaderElement;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.Method;
 import org.apache.hc.core5.http.message.MessageSupport;
 import org.apache.hc.core5.util.TimeValue;
 import org.slf4j.Logger;
@@ -176,7 +176,11 @@ class CachedResponseSuitabilityChecker {
     }
 
     private boolean isGet(final HttpRequest request) {
-        return request.getMethod().equals(HeaderConstants.GET_METHOD);
+        return Method.GET.isSame(request.getMethod());
+    }
+
+    private boolean isHead(final HttpRequest request) {
+        return Method.HEAD.isSame(request.getMethod());
     }
 
     private boolean entryIsNotA204Response(final HttpCacheEntry entry) {
@@ -201,17 +205,18 @@ class CachedResponseSuitabilityChecker {
     }
 
     /**
-     * Determines whether the given request is a {@link HeaderConstants#GET_METHOD} request and the associated cache entry was created by a
-     * {@link HeaderConstants#HEAD_METHOD} request.
+     * Determines whether the given request is a {@link org.apache.hc.core5.http.Method#GET} request and the
+     * associated cache entry was created by a {@link org.apache.hc.core5.http.Method#HEAD} request.
      *
-     * @param request The {@link HttpRequest} to check if it is a {@link HeaderConstants#GET_METHOD} request.
-     * @param entry   The {@link HttpCacheEntry} to check if it was created by a {@link HeaderConstants#HEAD_METHOD} request.
-     * @return true if the request is a {@link HeaderConstants#GET_METHOD} request and the cache entry was created by a
-     * {@link HeaderConstants#HEAD_METHOD} request, otherwise {@code false}.
+     * @param request The {@link HttpRequest} to check if it is a {@link org.apache.hc.core5.http.Method#GET} request.
+     * @param entry   The {@link HttpCacheEntry} to check if it was created by
+     *                a {@link org.apache.hc.core5.http.Method#HEAD} request.
+     * @return true if the request is a {@link org.apache.hc.core5.http.Method#GET} request and the cache entry was
+     * created by a {@link org.apache.hc.core5.http.Method#HEAD} request, otherwise {@code false}.
      * @since 5.3
      */
     public boolean isGetRequestWithHeadCacheEntry(final HttpRequest request, final HttpCacheEntry entry) {
-        return isGet(request) && HeaderConstants.HEAD_METHOD.equalsIgnoreCase(entry.getRequestMethod());
+        return isGet(request) && Method.HEAD.isSame(entry.getRequestMethod());
     }
 
 

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingExecBase.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingExecBase.java
@@ -35,7 +35,6 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
 import org.apache.hc.client5.http.cache.CacheResponseStatus;
-import org.apache.hc.client5.http.cache.HeaderConstants;
 import org.apache.hc.client5.http.cache.HttpCacheContext;
 import org.apache.hc.client5.http.cache.HttpCacheEntry;
 import org.apache.hc.client5.http.cache.ResourceIOException;
@@ -48,6 +47,7 @@ import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.http.HttpVersion;
+import org.apache.hc.core5.http.Method;
 import org.apache.hc.core5.http.ProtocolVersion;
 import org.apache.hc.core5.http.URIScheme;
 import org.apache.hc.core5.http.protocol.HttpContext;
@@ -332,7 +332,7 @@ public class CachingExecBase {
     }
 
     boolean clientRequestsOurOptions(final HttpRequest request) {
-        if (!HeaderConstants.OPTIONS_METHOD.equals(request.getMethod())) {
+        if (!Method.OPTIONS.isSame(request.getMethod())) {
             return false;
         }
 

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingExecBase.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingExecBase.java
@@ -185,9 +185,9 @@ public class CachingExecBase {
 
     SimpleHttpResponse generateCachedResponse(
             final ResponseCacheControl responseCacheControl,
+            final HttpCacheEntry entry,
             final HttpRequest request,
             final HttpContext context,
-            final HttpCacheEntry entry,
             final Instant now) throws ResourceIOException {
         final SimpleHttpResponse cachedResponse;
         if (request.containsHeader(HttpHeaders.IF_NONE_MATCH)
@@ -223,9 +223,9 @@ public class CachingExecBase {
     SimpleHttpResponse handleRevalidationFailure(
             final RequestCacheControl requestCacheControl,
             final ResponseCacheControl responseCacheControl,
+            final HttpCacheEntry entry,
             final HttpRequest request,
             final HttpContext context,
-            final HttpCacheEntry entry,
             final Instant now) throws IOException {
         if (staleResponseNotAllowed(requestCacheControl, responseCacheControl, entry, now)) {
             return generateGatewayTimeout(context);
@@ -259,8 +259,8 @@ public class CachingExecBase {
             || explicitFreshnessRequest(requestCacheControl, responseCacheControl, entry, now);
     }
 
-    boolean mayCallBackend(final RequestCacheControl cacheControl) {
-        if (cacheControl.isOnlyIfCached()) {
+    boolean mayCallBackend(final RequestCacheControl requestCacheControl) {
+        if (requestCacheControl.isOnlyIfCached()) {
             LOG.debug("Request marked only-if-cached");
             return false;
         }
@@ -268,7 +268,8 @@ public class CachingExecBase {
     }
 
     boolean explicitFreshnessRequest(final RequestCacheControl requestCacheControl,
-                                     final ResponseCacheControl responseCacheControl, final HttpCacheEntry entry,
+                                     final ResponseCacheControl responseCacheControl,
+                                     final HttpCacheEntry entry,
                                      final Instant now) {
         if (requestCacheControl.getMaxStale() >= 0) {
             final TimeValue age = validityPolicy.getCurrentAge(entry, now);

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/ConditionalRequestBuilder.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/ConditionalRequestBuilder.java
@@ -26,7 +26,7 @@
  */
 package org.apache.hc.client5.http.impl.cache;
 
-import java.util.Map;
+import java.util.Set;
 
 import org.apache.hc.client5.http.cache.HeaderConstants;
 import org.apache.hc.client5.http.cache.HttpCacheEntry;
@@ -84,9 +84,9 @@ class ConditionalRequestBuilder<T extends HttpRequest> {
      * @param variants
      * @return the wrapped request
      */
-    public T buildConditionalRequestFromVariants(final T request, final Map<String, Variant> variants) {
+    public T buildConditionalRequestFromVariants(final T request, final Set<String> variants) {
         final T newRequest = messageCopier.create(request);
-        newRequest.setHeader(MessageSupport.format(HttpHeaders.IF_NONE_MATCH, variants.keySet()));
+        newRequest.setHeader(MessageSupport.format(HttpHeaders.IF_NONE_MATCH, variants));
         return newRequest;
     }
 

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/RequestProtocolCompliance.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/RequestProtocolCompliance.java
@@ -33,11 +33,11 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import org.apache.hc.client5.http.cache.HeaderConstants;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.HttpVersion;
+import org.apache.hc.core5.http.Method;
 import org.apache.hc.core5.http.ProtocolVersion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -97,7 +97,7 @@ class RequestProtocolCompliance {
     }
 
     private void decrementOPTIONSMaxForwardsIfGreaterThen0(final HttpRequest request) {
-        if (!HeaderConstants.OPTIONS_METHOD.equals(request.getMethod())) {
+        if (!Method.OPTIONS.isSame(request.getMethod())) {
             return;
         }
 
@@ -131,7 +131,7 @@ class RequestProtocolCompliance {
 
     private RequestProtocolError requestHasWeakETagAndRange(final HttpRequest request) {
         final String method = request.getMethod();
-        if (!(HeaderConstants.GET_METHOD.equals(method) || HeaderConstants.HEAD_METHOD.equals(method))) {
+        if (!(Method.GET.isSame(method) || Method.HEAD.isSame(method))) {
             return null;
         }
 
@@ -165,8 +165,7 @@ class RequestProtocolCompliance {
 
     private RequestProtocolError requestHasWeekETagForPUTOrDELETEIfMatch(final HttpRequest request, final boolean resourceExists) {
         final String method = request.getMethod();
-        if (!(HeaderConstants.PUT_METHOD.equals(method) || HeaderConstants.DELETE_METHOD.equals(method)
-                || HeaderConstants.POST_METHOD.equals(method))
+        if (!(Method.PUT.isSame(method) || Method.DELETE.isSame(method) || Method.POST.isSame(method))
         ) {
             return null;
         }

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/ResponseCachingPolicy.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/ResponseCachingPolicy.java
@@ -35,7 +35,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
-import org.apache.hc.client5.http.cache.HeaderConstants;
 import org.apache.hc.client5.http.cache.HttpCacheEntry;
 import org.apache.hc.client5.http.utils.DateUtils;
 import org.apache.hc.core5.http.Header;
@@ -45,6 +44,7 @@ import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.http.HttpVersion;
+import org.apache.hc.core5.http.Method;
 import org.apache.hc.core5.http.ProtocolVersion;
 import org.apache.hc.core5.http.message.MessageSupport;
 import org.slf4j.Logger;
@@ -164,8 +164,7 @@ class ResponseCachingPolicy {
     public boolean isResponseCacheable(final ResponseCacheControl cacheControl, final String httpMethod, final HttpResponse response) {
         boolean cacheable = false;
 
-        if (!HeaderConstants.GET_METHOD.equals(httpMethod) && !HeaderConstants.HEAD_METHOD.equals(httpMethod)
-                && !HeaderConstants.POST_METHOD.equals(httpMethod)) {
+        if (!Method.GET.isSame(httpMethod) && !Method.HEAD.isSame(httpMethod) && !Method.POST.isSame((httpMethod))) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("{} method response is not cacheable", httpMethod);
             }

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/ResponseProtocolCompliance.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/ResponseProtocolCompliance.java
@@ -32,7 +32,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.hc.client5.http.ClientProtocolException;
-import org.apache.hc.client5.http.cache.HeaderConstants;
 import org.apache.hc.client5.http.utils.DateUtils;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HeaderElement;
@@ -42,6 +41,7 @@ import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.http.HttpVersion;
+import org.apache.hc.core5.http.Method;
 import org.apache.hc.core5.http.ProtocolVersion;
 import org.apache.hc.core5.http.message.BasicHeader;
 import org.apache.hc.core5.http.message.MessageSupport;
@@ -169,7 +169,7 @@ class ResponseProtocolCompliance {
 
     private void ensure200ForOPTIONSRequestWithNoBodyHasContentLengthZero(final HttpRequest request,
             final HttpResponse response) {
-        if (!request.getMethod().equalsIgnoreCase(HeaderConstants.OPTIONS_METHOD)) {
+        if (!Method.OPTIONS.isSame(request.getMethod())) {
             return;
         }
 

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/cache/TestHttpCacheEntry.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/cache/TestHttpCacheEntry.java
@@ -45,6 +45,7 @@ import org.apache.hc.client5.http.impl.cache.HttpTestUtils;
 import org.apache.hc.client5.http.utils.DateUtils;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.Method;
 import org.apache.hc.core5.http.message.BasicHeader;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -151,7 +152,7 @@ public class TestHttpCacheEntry {
                 new BasicHeader("bar", "barValue2")
         };
         entry = makeEntry(headers);
-        assertEquals(HeaderConstants.GET_METHOD, entry.getRequestMethod());
+        assertEquals(Method.GET.name(), entry.getRequestMethod());
     }
 
     @Test

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/ContainsHeaderMatcher.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/ContainsHeaderMatcher.java
@@ -61,7 +61,7 @@ public class ContainsHeaderMatcher extends BaseMatcher<MessageHeaders> {
 
     @Override
     public void describeTo(final Description description) {
-        description.appendText("contains header ").appendValue(headerValue).appendText(": ").appendValue(headerValue);
+        description.appendText("contains header ").appendValue(headerName).appendText(": ").appendValue(headerValue);
     }
 
     public static Matcher<MessageHeaders> contains(final String headerName, final Object headerValue) {

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/HttpTestUtils.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/HttpTestUtils.java
@@ -318,6 +318,11 @@ public class HttpTestUtils {
         return makeCacheEntry(requestDate, responseDate, Method.GET, "/", null, HttpStatus.SC_OK, headers, variantMap);
     }
 
+    public static HttpCacheEntry makeCacheEntry(final Map<String, String> variantMap) {
+        final Instant now = Instant.now();
+        return makeCacheEntry(now, now, new Header[] {}, variantMap);
+    }
+
     public static HttpCacheEntry makeCacheEntry(final Header[] headers, final byte[] bytes) {
         final Instant now = Instant.now();
         return makeCacheEntry(now, now, headers, bytes);

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestCacheableRequestPolicy.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestCacheableRequestPolicy.java
@@ -140,7 +140,7 @@ public class TestCacheableRequestPolicy {
 
         Assertions.assertFalse(policy.isServableFromCache(cacheControl, request));
 
-        final BasicHttpRequest request2 = new BasicHttpRequest("get", "someUri");
+        final BasicHttpRequest request2 = new BasicHttpRequest("huh", "someUri");
 
         Assertions.assertFalse(policy.isServableFromCache(cacheControl, request2));
 

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestConditionalRequestBuilder.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestConditionalRequestBuilder.java
@@ -27,9 +27,10 @@
 package org.apache.hc.client5.http.impl.cache;
 
 import java.time.Instant;
-import java.util.HashMap;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Iterator;
-import java.util.Map;
+import java.util.Set;
 
 import org.apache.hc.client5.http.cache.HttpCacheEntry;
 import org.apache.hc.client5.http.utils.DateUtils;
@@ -280,10 +281,7 @@ public class TestConditionalRequestBuilder {
         final String etag2 = "\"456\"";
         final String etag3 = "\"789\"";
 
-        final Map<String,Variant> variantEntries = new HashMap<>();
-        variantEntries.put(etag1, new Variant("A", HttpTestUtils.makeCacheEntry(new BasicHeader("ETag", etag1))));
-        variantEntries.put(etag2, new Variant("B", HttpTestUtils.makeCacheEntry(new BasicHeader("ETag", etag2))));
-        variantEntries.put(etag3, new Variant("C", HttpTestUtils.makeCacheEntry(new BasicHeader("ETag", etag3))));
+        final Set<String> variantEntries = new HashSet<>(Arrays.asList(etag1, etag2, etag3));
 
         final HttpRequest conditional = impl.buildConditionalRequestFromVariants(request, variantEntries);
 

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestProtocolRequirements.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestProtocolRequirements.java
@@ -1848,24 +1848,23 @@ public class TestProtocolRequirements {
         notModified.setHeader("Date", DateUtils.formatStandardDate(now));
         notModified.setHeader("ETag", "\"etag\"");
 
-        Mockito.when(mockCache.getCacheEntry(Mockito.eq(host), RequestEquivalent.eq(request))).thenReturn(entry);
+        Mockito.when(mockCache.match(Mockito.eq(host), RequestEquivalent.eq(request))).thenReturn(
+                new CacheMatch(new CacheHit("key", entry), null));
         Mockito.when(mockExecChain.proceed(RequestEquivalent.eq(validate), Mockito.any())).thenReturn(notModified);
-        Mockito.when(mockCache.updateEntry(
-                Mockito.eq(host),
-                RequestEquivalent.eq(request),
-                Mockito.eq(entry),
-                ResponseEquivalent.eq(notModified),
-                Mockito.any(),
-                Mockito.any()))
-                .thenReturn(HttpTestUtils.makeCacheEntry());
+        Mockito.when(mockCache.update(
+                        Mockito.any(),
+                        Mockito.any(),
+                        Mockito.any(),
+                        Mockito.any(),
+                        Mockito.any()))
+                .thenReturn(new CacheHit("key", HttpTestUtils.makeCacheEntry()));
 
         execute(request);
 
-        Mockito.verify(mockCache).updateEntry(
+        Mockito.verify(mockCache).update(
                 Mockito.any(),
-                Mockito.any(),
-                Mockito.any(),
-                Mockito.any(),
+                RequestEquivalent.eq(request),
+                ResponseEquivalent.eq(notModified),
                 Mockito.any(),
                 Mockito.any());
     }
@@ -1892,7 +1891,8 @@ public class TestProtocolRequirements {
         impl = new CachingExec(mockCache, null, config);
         request = new BasicClassicHttpRequest("GET", "/thing");
 
-        Mockito.when(mockCache.getCacheEntry(Mockito.eq(host), RequestEquivalent.eq(request))).thenReturn(entry);
+        Mockito.when(mockCache.match(Mockito.eq(host), RequestEquivalent.eq(request))).thenReturn(
+                new CacheMatch(new CacheHit("key", entry), null));
 
         final ClassicHttpResponse result = execute(request);
 
@@ -1936,7 +1936,8 @@ public class TestProtocolRequirements {
         impl = new CachingExec(mockCache, null, config);
         request = new BasicClassicHttpRequest("GET", "/thing");
 
-        Mockito.when(mockCache.getCacheEntry(Mockito.eq(host), RequestEquivalent.eq(request))).thenReturn(entry);
+        Mockito.when(mockCache.match(Mockito.eq(host), RequestEquivalent.eq(request))).thenReturn(
+                new CacheMatch(new CacheHit("key", entry), null));
         Mockito.when(mockExecChain.proceed(Mockito.any(), Mockito.any())).thenThrow(
                 new IOException("can't talk to origin!"));
 
@@ -2120,7 +2121,8 @@ public class TestProtocolRequirements {
         impl = new CachingExec(mockCache, null, config);
         request = new BasicClassicHttpRequest("GET", "/thing");
 
-        Mockito.when(mockCache.getCacheEntry(Mockito.eq(host), RequestEquivalent.eq(request))).thenReturn(entry);
+        Mockito.when(mockCache.match(Mockito.eq(host), RequestEquivalent.eq(request))).thenReturn(
+                new CacheMatch(new CacheHit("key", entry), null));
 
         final ClassicHttpResponse result = execute(request);
 
@@ -2183,15 +2185,16 @@ public class TestProtocolRequirements {
 
         final HttpCacheEntry cacheEntry = HttpTestUtils.makeCacheEntry();
 
-        Mockito.when(mockCache.getCacheEntry(Mockito.eq(host), RequestEquivalent.eq(request))).thenReturn(entry);
+        Mockito.when(mockCache.match(Mockito.eq(host), RequestEquivalent.eq(request))).thenReturn(
+                new CacheMatch(new CacheHit("key", entry), null));
         Mockito.when(mockExecChain.proceed(Mockito.any(), Mockito.any())).thenReturn(validated);
-        Mockito.when(mockCache.createEntry(
+        Mockito.when(mockCache.store(
                 Mockito.any(),
                 Mockito.any(),
                 ResponseEquivalent.eq(validated),
                 Mockito.any(),
                 Mockito.any(),
-                Mockito.any())).thenReturn(cacheEntry);
+                Mockito.any())).thenReturn(new CacheHit("key", cacheEntry));
 
         final ClassicHttpResponse result = execute(request);
 
@@ -2214,7 +2217,7 @@ public class TestProtocolRequirements {
             }
             Assertions.assertTrue(found113Warning);
         }
-        Mockito.verify(mockCache).createEntry(
+        Mockito.verify(mockCache).store(
                 Mockito.any(),
                 Mockito.any(),
                 Mockito.any(),

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestRequestProtocolCompliance.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestRequestProtocolCompliance.java
@@ -33,7 +33,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Collections;
 import java.util.List;
 
-import org.apache.hc.client5.http.cache.HeaderConstants;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.HttpVersion;
@@ -103,7 +102,7 @@ public class TestRequestProtocolCompliance {
 
     @Test
     public void testRequestWithMultipleIfMatchHeaders() {
-        final HttpRequest req = new BasicHttpRequest(HeaderConstants.PUT_METHOD, "http://example.com/");
+        final HttpRequest req = new BasicHttpRequest("PUT", "http://example.com/");
         req.addHeader(HttpHeaders.IF_MATCH, "W/\"weak1\"");
         req.addHeader(HttpHeaders.IF_MATCH, "W/\"weak2\"");
         assertEquals(1, impl.requestIsFatallyNonCompliant(req, false).size());
@@ -111,7 +110,7 @@ public class TestRequestProtocolCompliance {
 
     @Test
     public void testRequestWithMultipleIfNoneMatchHeaders() {
-        final HttpRequest req = new BasicHttpRequest(HeaderConstants.PUT_METHOD, "http://example.com/");
+        final HttpRequest req = new BasicHttpRequest("PUT", "http://example.com/");
         req.addHeader(HttpHeaders.IF_NONE_MATCH, "W/\"weak1\"");
         req.addHeader(HttpHeaders.IF_NONE_MATCH, "W/\"weak2\"");
         assertEquals(1, impl.requestIsFatallyNonCompliant(req, false).size());
@@ -119,7 +118,7 @@ public class TestRequestProtocolCompliance {
 
     @Test
     public void testRequestWithPreconditionFailed() {
-        final HttpRequest req = new BasicHttpRequest(HeaderConstants.GET_METHOD, "http://example.com/");
+        final HttpRequest req = new BasicHttpRequest("GET", "http://example.com/");
         req.addHeader(HttpHeaders.IF_MATCH, "W/\"weak1\"");
         req.addHeader(HttpHeaders.RANGE, "1");
         req.addHeader(HttpHeaders.IF_RANGE, "W/\"weak2\""); // ETag doesn't match with If-Match ETag
@@ -130,7 +129,7 @@ public class TestRequestProtocolCompliance {
 
     @Test
     public void testRequestWithValidIfRangeDate() {
-        final HttpRequest req = new BasicHttpRequest(HeaderConstants.GET_METHOD, "http://example.com/");
+        final HttpRequest req = new BasicHttpRequest("GET", "http://example.com/");
         req.addHeader(HttpHeaders.RANGE, "bytes=0-499");
         req.addHeader(HttpHeaders.LAST_MODIFIED, "Wed, 21 Oct 2023 07:28:00 GMT");
         req.addHeader(HttpHeaders.IF_RANGE, "Wed, 21 Oct 2023 07:28:00 GMT");
@@ -139,7 +138,7 @@ public class TestRequestProtocolCompliance {
 
     @Test
     public void testRequestWithInvalidDateFormat() {
-        final HttpRequest req = new BasicHttpRequest(HeaderConstants.GET_METHOD, "http://example.com/");
+        final HttpRequest req = new BasicHttpRequest("GET", "http://example.com/");
         req.addHeader(HttpHeaders.RANGE, "bytes=0-499");
         req.addHeader(HttpHeaders.LAST_MODIFIED, "Wed, 21 Oct 2023 07:28:00 GMT");
         req.addHeader(HttpHeaders.IF_RANGE, "20/10/2023");
@@ -148,7 +147,7 @@ public class TestRequestProtocolCompliance {
 
     @Test
     public void testRequestWithMissingIfRangeDate() {
-        final HttpRequest req = new BasicHttpRequest(HeaderConstants.GET_METHOD, "http://example.com/");
+        final HttpRequest req = new BasicHttpRequest("GET", "http://example.com/");
         req.addHeader(HttpHeaders.RANGE, "bytes=0-499");
         req.addHeader(HttpHeaders.LAST_MODIFIED, "Wed, 21 Oct 2023 07:28:00 GMT");
         assertTrue(impl.requestIsFatallyNonCompliant(req, false).isEmpty());
@@ -158,7 +157,7 @@ public class TestRequestProtocolCompliance {
     public void testRequestWithWeakETagAndRangeAndDAte() {
         // Setup request with GET method, Range header, If-Range header starting with "W/",
         // and a Last-Modified date that doesn't match the If-Range date
-        final HttpRequest req = new BasicHttpRequest(HeaderConstants.GET_METHOD, "http://example.com/");
+        final HttpRequest req = new BasicHttpRequest("GET", "http://example.com/");
         req.addHeader(HttpHeaders.RANGE, "bytes=0-499");
         req.addHeader(HttpHeaders.LAST_MODIFIED, "Fri, 20 Oct 2023 07:28:00 GMT");
         req.addHeader(HttpHeaders.IF_RANGE, "Wed, 18 Oct 2023 07:28:00 GMT");

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestResponseCachingPolicy.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestResponseCachingPolicy.java
@@ -512,7 +512,7 @@ public class TestResponseCachingPolicy {
 
         Assertions.assertFalse(policy.isResponseCacheable(responseCacheControl, "PUT", response));
 
-        Assertions.assertFalse(policy.isResponseCacheable(responseCacheControl, "get", response));
+        Assertions.assertFalse(policy.isResponseCacheable(responseCacheControl, "huh", response));
     }
 
     @Test


### PR DESCRIPTION
This is a complete redesign and re-write of the internal cache implementations intended
* to improve internal cache APIs
* to provide support for partial matches (no direct match but there are variants for the same root)
* to eliminate repetitive, redundant cache key calculations
* to eliminate unnecessary duplicate cache look-ups in the course of a single message exchange       

@arturobernalg Please review.