### PR TITLE
Check for timeToLive == 0

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java
@@ -322,8 +322,8 @@ public class PoolingHttpClientConnectionManager
                     if (poolEntry.hasConnection()) {
                         final TimeValue timeToLive = connectionConfig.getTimeToLive();
                         if (TimeValue.isNonNegative(timeToLive)) {
-                            final Deadline deadline = Deadline.calculate(poolEntry.getCreated(), timeToLive);
-                            if (deadline.isExpired()) {
+                            if (timeToLive.getDuration() == 0
+                                    || Deadline.calculate(poolEntry.getCreated(), timeToLive).isExpired()) {
                                 poolEntry.discardConnection(CloseMode.GRACEFUL);
                             }
                         }
@@ -331,8 +331,8 @@ public class PoolingHttpClientConnectionManager
                     if (poolEntry.hasConnection()) {
                         final TimeValue timeValue = resolveValidateAfterInactivity(connectionConfig);
                         if (TimeValue.isNonNegative(timeValue)) {
-                            final Deadline deadline = Deadline.calculate(poolEntry.getUpdated(), timeValue);
-                            if (deadline.isExpired()) {
+                            if (timeValue.getDuration() == 0
+                                    || Deadline.calculate(poolEntry.getUpdated(), timeValue).isExpired()) {
                                 final ManagedHttpClientConnection conn = poolEntry.getConnection();
                                 boolean stale;
                                 try {

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java
@@ -278,8 +278,8 @@ public class PoolingAsyncClientConnectionManager implements AsyncClientConnectio
                             if (poolEntry.hasConnection()) {
                                 final TimeValue timeToLive = connectionConfig.getTimeToLive();
                                 if (TimeValue.isNonNegative(timeToLive)) {
-                                    final Deadline deadline = Deadline.calculate(poolEntry.getCreated(), timeToLive);
-                                    if (deadline.isExpired()) {
+                                    if (timeToLive.getDuration() == 0
+                                            || Deadline.calculate(poolEntry.getCreated(), timeToLive).isExpired()) {
                                         poolEntry.discardConnection(CloseMode.GRACEFUL);
                                     }
                                 }
@@ -288,8 +288,8 @@ public class PoolingAsyncClientConnectionManager implements AsyncClientConnectio
                                 final ManagedAsyncClientConnection connection = poolEntry.getConnection();
                                 final TimeValue timeValue = connectionConfig.getValidateAfterInactivity();
                                 if (connection.isOpen() && TimeValue.isNonNegative(timeValue)) {
-                                    final Deadline deadline = Deadline.calculate(poolEntry.getUpdated(), timeValue);
-                                    if (deadline.isExpired()) {
+                                    if (timeValue.getDuration() == 0
+                                            || Deadline.calculate(poolEntry.getUpdated(), timeValue).isExpired()) {
                                         final ProtocolVersion protocolVersion = connection.getProtocolVersion();
                                         if (protocolVersion != null && protocolVersion.greaterEquals(HttpVersion.HTTP_2_0)) {
                                             connection.submitCommand(new PingCommand(new BasicPingHandler(result -> {


### PR DESCRIPTION
At the moment, when i pass validateAfterInactivity as Timeout.ZERO_MILLISECONDS, it has the effect of never validating the connection at all, because that is how Deadline.calculate works. However, the check for TimeValue.isNonNegative for validateAfterInactivity before the deadline check suggests this is not the intended behavior.

Furthermore, we are trying to communicate with a server that always closes a h2 connection after one request. Without a way to force revalidation every time, this runs into issues when a connection is taken from the pool.