### PR TITLE
HTTPCLIENT-2288 - Retry logic in DefaultHttpClientConnectionOperator doesn't handle SocketException

### DIFF
--- a/httpclient/src/main/java/org/apache/http/impl/conn/DefaultHttpClientConnectionOperator.java
+++ b/httpclient/src/main/java/org/apache/http/impl/conn/DefaultHttpClientConnectionOperator.java
@@ -30,7 +30,7 @@ import java.io.IOException;
 import java.net.ConnectException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.net.NoRouteToHostException;
+import java.net.SocketException;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
 
@@ -157,7 +157,7 @@ public class DefaultHttpClientConnectionOperator implements HttpClientConnection
                                     ? new ConnectTimeoutException(ex, host, addresses)
                                     : new HttpHostConnectException(ex, host, addresses);
                 }
-            } catch (final NoRouteToHostException ex) {
+            } catch (final SocketException ex) {
                 if (last) {
                     throw ex;
                 }

--- a/httpclient/src/test/java/org/apache/http/impl/client/integration/TestConnectionManagement.java
+++ b/httpclient/src/test/java/org/apache/http/impl/client/integration/TestConnectionManagement.java
@@ -28,6 +28,7 @@
 package org.apache.http.impl.client.integration;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketException;
@@ -446,7 +447,8 @@ public class TestConnectionManagement extends LocalServerTestBase {
 
         this.connManager.setMaxTotal(1);
 
-        final HttpHost target = start();
+        final HttpHost target = new HttpHost(
+                InetAddress.getByName("localhost"), "localhost", start().getPort(), this.scheme.name());
         final HttpRoute route = new HttpRoute(target, null, false);
         final HttpContext context = new BasicHttpContext();
 


### PR DESCRIPTION
This change is a partial backport of a change from 5.x, which fixes the issue described in https://issues.apache.org/jira/browse/HTTPCLIENT-2288.