### PR TITLE
Fixed SOCKS proxy example

### DIFF
--- a/httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClientExecuteSOCKS.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClientExecuteSOCKS.java
@@ -27,25 +27,21 @@
 
 package org.apache.hc.client5.http.examples;
 
-import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.net.Proxy;
-import java.net.Socket;
-
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
-import org.apache.hc.client5.http.socket.ConnectionSocketFactory;
-import org.apache.hc.core5.http.HttpHost;
-import org.apache.hc.core5.http.config.Registry;
-import org.apache.hc.core5.http.config.RegistryBuilder;
-import org.apache.hc.core5.http.io.SocketConfig;
+import org.apache.hc.client5.http.ssl.HttpsSupport;
+import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.message.StatusLine;
 import org.apache.hc.core5.http.protocol.HttpContext;
-import org.apache.hc.core5.util.TimeValue;
+import org.apache.hc.core5.ssl.SSLContexts;
+
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.Socket;
 
 /**
  * How to send a request via SOCKS proxy.
@@ -55,63 +51,42 @@ import org.apache.hc.core5.util.TimeValue;
 public class ClientExecuteSOCKS {
 
     public static void main(final String[] args)throws Exception {
-        final Registry<ConnectionSocketFactory> reg = RegistryBuilder.<ConnectionSocketFactory>create()
-                .register("http", new MyConnectionSocketFactory())
-                .build();
-        final InetSocketAddress socksaddr = new InetSocketAddress("mysockshost", 1234);
+        final InetSocketAddress proxyAddress = new InetSocketAddress("mysockshost", 1234);
         final PoolingHttpClientConnectionManager cm = PoolingHttpClientConnectionManagerBuilder.create()
-                .setDefaultSocketConfig(SocketConfig.custom()
-                        .setSocksProxyAddress(socksaddr)
-                        .build())
+                .setSSLSocketFactory(new SocksProxySSLConnectionSocketFactory(proxyAddress))
                 .build();
+
+
         try (final CloseableHttpClient httpclient = HttpClients.custom()
                 .setConnectionManager(cm)
                 .build()) {
 
-            final HttpHost target = new HttpHost("http", "httpbin.org", 80);
-            final HttpGet request = new HttpGet("/get");
+            final HttpGet request = new HttpGet("https://ifconfig.me/ip");
 
             System.out.println("Executing request " + request.getMethod() + " " + request.getUri() +
-                    " via SOCKS proxy " + socksaddr);
-            httpclient.execute(target, request, response -> {
+                    " via SOCKS proxy " + proxyAddress);
+            httpclient.execute(request, response -> {
                 System.out.println("----------------------------------------");
                 System.out.println(request + "->" + new StatusLine(response));
-                EntityUtils.consume(response.getEntity());
+                System.out.println("IP: " + EntityUtils.toString(response.getEntity()));
                 return null;
             });
         }
     }
 
-    static class MyConnectionSocketFactory implements ConnectionSocketFactory {
+    private static class SocksProxySSLConnectionSocketFactory extends SSLConnectionSocketFactory {
 
-        @Override
-        public Socket createSocket(final HttpContext context) throws IOException {
-            final InetSocketAddress socksaddr = (InetSocketAddress) context.getAttribute("socks.address");
-            final Proxy proxy = new Proxy(Proxy.Type.SOCKS, socksaddr);
-            return new Socket(proxy);
+        private final InetSocketAddress proxyAddress;
+
+        public SocksProxySSLConnectionSocketFactory(InetSocketAddress proxyAddress) {
+            super(SSLContexts.createDefault(), HttpsSupport.getDefaultHostnameVerifier());
+            this.proxyAddress = proxyAddress;
         }
 
         @Override
-        public Socket connectSocket(
-                final TimeValue connectTimeout,
-                final Socket socket,
-                final HttpHost host,
-                final InetSocketAddress remoteAddress,
-                final InetSocketAddress localAddress,
-                final HttpContext context) throws IOException {
-            final Socket sock;
-            if (socket != null) {
-                sock = socket;
-            } else {
-                sock = createSocket(context);
-            }
-            if (localAddress != null) {
-                sock.bind(localAddress);
-            }
-            sock.connect(remoteAddress, connectTimeout != null ? connectTimeout.toMillisecondsIntBound() : 0);
-            return sock;
+        public Socket createSocket(HttpContext context) {
+            return new Socket(new Proxy(Proxy.Type.SOCKS, proxyAddress));
         }
-
     }
 
 }


### PR DESCRIPTION
Use a custom socket factory to create a proxied socket.

Original implementation sets the proxy address via default socket config assuming it would somehow propagate into the socket factory:
```java
PoolingHttpClientConnectionManagerBuilder.create()
                 .setDefaultSocketConfig(SocketConfig.custom().setSocksProxyAddress(socksaddr)
```
Unfortunatelly, the `SocketConfig.socksProxyAddress` is not used in the [`DefaultHttpClientConnectionOperator.connect()`](https://github.com/apache/httpcomponents-client/blob/223669659c295a01afe9047e0910768781c8f157/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/DefaultHttpClientConnectionOperator.java#L155) method, which creates the socket.

This solution extends `SSLConnectionSocketFactory` to create a proxied socket.

### Potential improvements

* This works only for HTTPS connections. The `PoolingHttpClientConnectionManagerBuilder` does not have API for setting a "plain socket factory", so making this work for a HTTP is slightly more complicated.
* To make the "default socket config" work, we may change implementation in the `DefaultHttpClientConnectionOperator.connect()` but that would probably lead to change of the "socket factory" APIs.
* There's also the `HttpClientBuilder.setProxy()` which does not support SOCKS proxy at the moment. This makes the API slightly awkward.