### PR TITLE
HTTPCLIENT-2290 - Refactor HttpClient synchronized sections for virtual threads

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/cookie/IgnoreCookieSpecFactory.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/cookie/IgnoreCookieSpecFactory.java
@@ -27,6 +27,8 @@
 
 package org.apache.hc.client5.http.impl.cookie;
 
+import java.util.concurrent.locks.ReentrantLock;
+
 import org.apache.hc.client5.http.cookie.CookieSpec;
 import org.apache.hc.client5.http.cookie.CookieSpecFactory;
 import org.apache.hc.core5.annotation.Contract;
@@ -43,17 +45,23 @@ public class IgnoreCookieSpecFactory implements CookieSpecFactory {
 
     private volatile CookieSpec cookieSpec;
 
+    private final ReentrantLock lock;
+
     public IgnoreCookieSpecFactory() {
         super();
+        this.lock = new ReentrantLock();
     }
 
     @Override
     public CookieSpec create(final HttpContext context) {
         if (cookieSpec == null) {
-            synchronized (this) {
+            lock.lock();
+            try {
                 if (cookieSpec == null) {
                     this.cookieSpec = IgnoreSpecSpec.INSTANCE;
                 }
+            } finally {
+                lock.unlock();
             }
         }
         return this.cookieSpec;


### PR DESCRIPTION
- Replaced `synchronized` blocks with `ReentrantLock` in `LeaseRequest` to better support virtual threads introduced in JDK 21.
- Ensured each `LeaseRequest` instance has its own unique lock for maintaining original synchronization semantics.
- Addressed potential performance and deadlock issues with virtual threads by using explicit lock primitives from `java.util.concurrent.locks`.