### PR TITLE
HTTPCLIENT-2284: Cache entry representation improvements

### DIFF
--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/AsyncCachingExec.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/AsyncCachingExec.java
@@ -703,6 +703,7 @@ class AsyncCachingExec extends CachingExecBase implements AsyncExecChainHandler 
                 recordCacheUpdate(scope.clientContext);
                 operation.setDependency(responseCache.update(
                         hit,
+                        target,
                         request,
                         backendResponse,
                         requestDate,
@@ -880,7 +881,7 @@ class AsyncCachingExec extends CachingExecBase implements AsyncExecChainHandler 
             triggerResponse(cacheResponse, scope, asyncExecCallback);
         }
 
-        if (partialMatch != null && partialMatch.entry.isVariantRoot()) {
+        if (partialMatch != null && partialMatch.entry.hasVariants()) {
             operation.setDependency(responseCache.getVariants(
                     partialMatch,
                     new FutureCallback<Collection<CacheHit>>() {
@@ -1016,6 +1017,7 @@ class AsyncCachingExec extends CachingExecBase implements AsyncExecChainHandler 
                                 }
                                 responseCache.update(
                                         hit,
+                                        target,
                                         request,
                                         backendResponse,
                                         requestDate,

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingExec.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingExec.java
@@ -339,7 +339,7 @@ class CachingExec extends CachingExecBase implements ExecChainHandler {
             }
 
             if (statusCode == HttpStatus.SC_NOT_MODIFIED) {
-                final CacheHit updated = responseCache.update(hit, request, backendResponse, requestDate, responseDate);
+                final CacheHit updated = responseCache.update(hit, target, request, backendResponse, requestDate, responseDate);
                 if (suitabilityChecker.isConditional(request)
                         && suitabilityChecker.allConditionalsMatch(request, updated.entry, Instant.now())) {
                     return convert(responseGenerator.generateNotModifiedResponse(updated.entry), scope);
@@ -399,6 +399,7 @@ class CachingExec extends CachingExecBase implements ExecChainHandler {
             if (hit != null) {
                 final CacheHit updated = responseCache.update(
                         hit,
+                        target,
                         request,
                         backendResponse,
                         requestSent,
@@ -458,7 +459,7 @@ class CachingExec extends CachingExecBase implements ExecChainHandler {
         if (!mayCallBackend(requestCacheControl)) {
             return new BasicClassicHttpResponse(HttpStatus.SC_GATEWAY_TIMEOUT, "Gateway Timeout");
         }
-        if (partialMatch != null && partialMatch.entry.isVariantRoot()) {
+        if (partialMatch != null && partialMatch.entry.hasVariants()) {
             final List<CacheHit> variants = responseCache.getVariants(partialMatch);
             if (variants != null && !variants.isEmpty()) {
                 return negotiateResponseFromVariants(target, request, scope, chain, variants);

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/HttpAsyncCache.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/HttpAsyncCache.java
@@ -69,6 +69,7 @@ interface HttpAsyncCache {
      */
     Cancellable update(
             CacheHit stale,
+            HttpHost host,
             HttpRequest request,
             HttpResponse originResponse,
             Instant requestSent,

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/HttpCache.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/HttpCache.java
@@ -65,6 +65,7 @@ interface HttpCache {
      */
     CacheHit update(
             CacheHit stale,
+            HttpHost host,
             HttpRequest request,
             HttpResponse originResponse,
             Instant requestSent,

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/HttpCacheEntryMatcher.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/HttpCacheEntryMatcher.java
@@ -30,8 +30,8 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Iterator;
-import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import org.apache.hc.client5.http.cache.HttpCacheEntry;
 import org.apache.hc.client5.http.cache.Resource;
@@ -55,7 +55,7 @@ public class HttpCacheEntryMatcher extends BaseMatcher<HttpCacheEntry> {
             try {
                 final HttpCacheEntry otherValue = (HttpCacheEntry) item;
 
-                if (!mapEqual(expectedValue.getVariantMap(), otherValue.getVariantMap())) {
+                if (!setEqual(expectedValue.getVariants(), otherValue.getVariants())) {
                     return false;
                 }
                 if (!Objects.equals(expectedValue.getRequestMethod(), otherValue.getRequestMethod())) {
@@ -114,12 +114,11 @@ public class HttpCacheEntryMatcher extends BaseMatcher<HttpCacheEntry> {
         return true;
     }
 
-    private static boolean mapEqual(final Map<?, ?> expected, final Map<?, ?> actual) {
+    private static boolean setEqual(final Set<?> expected, final Set<?> actual) {
         if (expected.size() != actual.size()) {
             return false;
         }
-        return expected.entrySet().stream()
-                .allMatch(e -> Objects.equals(e.getValue(), actual.get(e.getKey())));
+        return actual.containsAll(expected);
     }
 
     @Override

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/HttpTestUtils.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/HttpTestUtils.java
@@ -29,7 +29,7 @@ package org.apache.hc.client5.http.impl.cache;
 import java.io.InputStream;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Map;
+import java.util.Collection;
 import java.util.Objects;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
@@ -229,14 +229,14 @@ public class HttpTestUtils {
                                                 final Header[] requestHeaders,
                                                 final int status,
                                                 final Header[] responseHeaders,
-                                                final Map<String, String> variantMap) {
+                                                final Collection<String> variants) {
         return new HttpCacheEntry(
                 requestDate,
                 responseDate,
                 method.name(), requestUri, headers(requestHeaders),
                 status, headers(responseHeaders),
                 null,
-                variantMap);
+                variants);
     }
 
     public static HttpCacheEntry makeCacheEntry(final Instant requestDate,
@@ -260,13 +260,13 @@ public class HttpTestUtils {
                                                 final Instant responseDate,
                                                 final int status,
                                                 final Header[] responseHeaders,
-                                                final Map<String, String> variantMap) {
+                                                final Collection<String> variants) {
         return makeCacheEntry(
                 requestDate,
                 responseDate,
                 Method.GET, "/", null,
                 status, responseHeaders,
-                variantMap);
+                variants);
     }
 
     public static HttpCacheEntry makeCacheEntry(final Instant requestDate,
@@ -311,13 +311,13 @@ public class HttpTestUtils {
     public static HttpCacheEntry makeCacheEntry(final Instant requestDate,
                                                 final Instant responseDate,
                                                 final Header[] headers,
-                                                final Map<String,String> variantMap) {
-        return makeCacheEntry(requestDate, responseDate, Method.GET, "/", null, HttpStatus.SC_OK, headers, variantMap);
+                                                final Collection<String> variants) {
+        return makeCacheEntry(requestDate, responseDate, Method.GET, "/", null, HttpStatus.SC_OK, headers, variants);
     }
 
-    public static HttpCacheEntry makeCacheEntry(final Map<String, String> variantMap) {
+    public static HttpCacheEntry makeCacheEntry(final Collection<String> variants) {
         final Instant now = Instant.now();
-        return makeCacheEntry(now, now, new Header[] {}, variantMap);
+        return makeCacheEntry(now, now, new Header[] {}, variants);
     }
 
     public static HttpCacheEntry makeCacheEntry(final Header[] headers, final byte[] bytes) {

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestBasicHttpAsyncCache.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestBasicHttpAsyncCache.java
@@ -31,8 +31,8 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import java.net.URI;
 import java.time.Instant;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 
 import org.apache.hc.client5.http.utils.DateUtils;
@@ -111,15 +111,15 @@ public class TestBasicHttpAsyncCache {
     public void testInvalidatesUnsafeRequestsWithVariants() throws Exception {
         final HttpRequest request = new BasicHttpRequest("POST", "/path");
         final String rootKey = CacheKeyGenerator.INSTANCE.generateKey(host, request);
+        final Set<String> variants = new HashSet<>();
+        variants.add("{var1}");
+        variants.add("{var2}");
         final String variantKey1 = "{var1}" + rootKey;
         final String variantKey2 = "{var2}" + rootKey;
-        final Map<String, String> variantMap = new HashMap<>();
-        variantMap.put("{var1}", variantKey1);
-        variantMap.put("{var2}", variantKey2);
 
         final HttpResponse response = HttpTestUtils.make200Response();
 
-        mockStorage.putEntry(rootKey, HttpTestUtils.makeCacheEntry(variantMap));
+        mockStorage.putEntry(rootKey, HttpTestUtils.makeCacheEntry(variants));
         mockStorage.putEntry(variantKey1, HttpTestUtils.makeCacheEntry());
         mockStorage.putEntry(variantKey2, HttpTestUtils.makeCacheEntry());
 

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestByteArrayCacheEntrySerializer.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestByteArrayCacheEntrySerializer.java
@@ -38,8 +38,8 @@ import java.io.ObjectOutputStream;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.apache.hc.client5.http.cache.HttpCacheEntry;
 import org.apache.hc.client5.http.cache.HttpCacheStorageEntry;
@@ -274,15 +274,15 @@ public class TestByteArrayCacheEntrySerializer {
         for (int i = 0; i < headers.length; i++) {
             headers[i] = new BasicHeader("header" + i, "value" + i);
         }
-        final Map<String,String> variantMap = new HashMap<>();
-        variantMap.put("test variant 1","true");
-        variantMap.put("test variant 2","true");
+        final Set<String> variants = new HashSet<>();
+        variants.add("test variant 1");
+        variants.add("test variant 2");
         final HttpCacheEntry cacheEntry = HttpTestUtils.makeCacheEntry(
                 Instant.now(),
                 Instant.now(),
                 HttpStatus.SC_OK,
                 headers,
-                variantMap);
+                variants);
 
         return new HttpCacheStorageEntry(key, cacheEntry);
     }
@@ -292,15 +292,15 @@ public class TestByteArrayCacheEntrySerializer {
         for (int i = 0; i < headers.length; i++) {
             headers[i] = new BasicHeader("header" + i, "value" + i);
         }
-        final Map<String,String> variantMap = new HashMap<>();
-        variantMap.put("test variant 1","true");
-        variantMap.put("test variant 2","true");
+        final Set<String> variants = new HashSet<>();
+        variants.add("test variant 1");
+        variants.add("test variant 2");
         final HttpCacheEntry cacheEntry = HttpTestUtils.makeCacheEntry(
                 Instant.now(),
                 Instant.now(),
                 HttpStatus.SC_OK,
                 headers,
-                variantMap);
+                variants);
 
         return new HttpCacheStorageEntry(key, cacheEntry);
     }

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestCachingExecChain.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestCachingExecChain.java
@@ -1432,7 +1432,7 @@ public class TestCachingExecChain {
                 headers,
                 new HeapResource(body.getBytes(StandardCharsets.UTF_8)));
 
-        Mockito.when(mockCache.update(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+        Mockito.when(mockCache.update(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
                 .thenReturn(new CacheHit("key", cacheEntry));
 
         // Call cacheAndReturnResponse with 304 Not Modified response
@@ -1441,6 +1441,7 @@ public class TestCachingExecChain {
         // Verify cache entry is updated
         Mockito.verify(mockCache).update(
                 Mockito.any(),
+                Mockito.same(host),
                 Mockito.same(request),
                 Mockito.same(backendResponse),
                 Mockito.eq(requestSent),

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestHttpByteArrayCacheEntrySerializer.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestHttpByteArrayCacheEntrySerializer.java
@@ -32,8 +32,8 @@ import java.io.InputStream;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.apache.hc.client5.http.cache.HttpCacheEntry;
 import org.apache.hc.client5.http.cache.HttpCacheEntrySerializer;
@@ -378,14 +378,14 @@ public class TestHttpByteArrayCacheEntrySerializer {
     public void testSimpleVariantMap() throws Exception {
         final String content = "Hello World";
         final ContentType contentType = ContentType.TEXT_PLAIN.withCharset(StandardCharsets.UTF_8);
-        final Map<String, String> variantMap = new HashMap<>();
-        variantMap.put("{Accept-Encoding=gzip}","{Accept-Encoding=gzip}https://example.com:1234/foo");
-        variantMap.put("{Accept-Encoding=compress}","{Accept-Encoding=compress}https://example.com:1234/foo");
+        final Set<String> variants = new HashSet<>();
+        variants.add("{Accept-Encoding=gzip}");
+        variants.add("{Accept-Encoding=compress}");
         final HttpCacheEntry cacheEntry = new HttpCacheEntry(Instant.now(), Instant.now(),
                 "GET", "/stuff", HttpTestUtils.headers(),
                 HttpStatus.SC_OK, HttpTestUtils.headers(new BasicHeader(HttpHeaders.CONTENT_TYPE, contentType.toString())),
                 new HeapResource(content.getBytes(contentType.getCharset())),
-                variantMap);
+                variants);
         final HttpCacheStorageEntry storageEntry = new HttpCacheStorageEntry("unique-cache-key", cacheEntry);
         final byte[] serialized = httpCacheEntrySerializer.serialize(storageEntry);
 

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestProtocolRequirements.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestProtocolRequirements.java
@@ -1723,6 +1723,7 @@ public class TestProtocolRequirements {
                         Mockito.any(),
                         Mockito.any(),
                         Mockito.any(),
+                        Mockito.any(),
                         Mockito.any()))
                 .thenReturn(new CacheHit("key", HttpTestUtils.makeCacheEntry()));
 
@@ -1730,6 +1731,7 @@ public class TestProtocolRequirements {
 
         Mockito.verify(mockCache).update(
                 Mockito.any(),
+                Mockito.eq(host),
                 RequestEquivalent.eq(request),
                 ResponseEquivalent.eq(notModified),
                 Mockito.any(),


### PR DESCRIPTION
* request URI stored in cache is now normalized and is presently expected to be the same as the root key
* removed references to variant cache keys from the cache entry
* Variants in root entries are now represented as a set, not as a map