### PR TITLE
HTTPCLIENT-2277: internal cache API and cache update redesign

### DIFF
--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/cache/HttpCacheEntryFactory.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/cache/HttpCacheEntryFactory.java
@@ -173,38 +173,24 @@ public class HttpCacheEntryFactory {
     /**
      * Creates a new root {@link HttpCacheEntry} (parent of multiple variants).
      *
-     * @param requestInstant   Date/time when the request was made (Used for age calculations)
-     * @param responseInstant  Date/time that the response came back (Used for age calculations)
-     * @param host             Target host
-     * @param request          Original client request (a deep copy of this object is made)
+     * @param latestVariant    The most recently created variant entry
      * @param variants         describing cache entries that are variants of this parent entry; this
      *                         maps a "variant key" (derived from the varying request headers) to a
      *                         "cache key" (where in the cache storage the particular variant is
      *                         located)
      */
-    public HttpCacheEntry createRoot(final Instant requestInstant,
-                                     final Instant responseInstant,
-                                     final HttpHost host,
-                                     final HttpRequest request,
-                                     final HttpResponse response,
+    public HttpCacheEntry createRoot(final HttpCacheEntry latestVariant,
                                      final Collection<String> variants) {
-        Args.notNull(requestInstant, "Request instant");
-        Args.notNull(responseInstant, "Response instant");
-        Args.notNull(host, "Host");
-        Args.notNull(request, "Request");
-        Args.notNull(response, "Origin response");
-        final String requestUri = normalizeRequestUri(host, request);
-        final HeaderGroup requestHeaders = filterHopByHopHeaders(request);
-        final HeaderGroup responseHeaders = filterHopByHopHeaders(response);
-        ensureDate(responseHeaders, responseInstant);
+        Args.notNull(latestVariant, "Request");
+        Args.notNull(variants, "Variants");
         return new HttpCacheEntry(
-                requestInstant,
-                responseInstant,
-                request.getMethod(),
-                requestUri,
-                requestHeaders,
-                response.getCode(),
-                responseHeaders,
+                latestVariant.getRequestInstant(),
+                latestVariant.getResponseInstant(),
+                latestVariant.getRequestMethod(),
+                latestVariant.getRequestURI(),
+                headers(latestVariant.requestHeaderIterator()),
+                latestVariant.getStatus(),
+                headers(latestVariant.headerIterator()),
                 null,
                 variants);
     }

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/BasicHttpCache.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/BasicHttpCache.java
@@ -179,9 +179,10 @@ class BasicHttpCache implements HttpCache {
         if (root != null && root.hasVariants()) {
             final List<CacheHit> variants = new ArrayList<>();
             for (final String variantKey : root.getVariants()) {
-                final HttpCacheEntry variant = getInternal(variantKey + rootKey);
+                final String variantCacheKey = variantKey + rootKey;
+                final HttpCacheEntry variant = getInternal(variantCacheKey);
                 if (variant != null) {
-                    variants.add(new CacheHit(hit.rootKey, variantKey, variant));
+                    variants.add(new CacheHit(rootKey, variantCacheKey, variant));
                 }
             }
             return variants;

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CacheKeyGenerator.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CacheKeyGenerator.java
@@ -157,6 +157,23 @@ public class CacheKeyGenerator implements Resolver<URI, String> {
     }
 
     /**
+     * Computes a "variant key" from the headers of the given request if the given
+     * cache entry can have variants ({@code Vary} header is present).
+     *
+     * @param request originating request
+     * @param entry cache entry
+     * @return variant key if the given cache entry can have variants, {@code null} otherwise.
+     */
+    public String generateVariantKey(final HttpRequest request, final HttpCacheEntry entry) {
+        if (entry.containsHeader(HttpHeaders.VARY)) {
+            final List<String> variantNames = variantNames(entry);
+            return generateVariantKey(request, variantNames);
+        } else {
+            return null;
+        }
+    }
+
+    /**
      * Computes a key for the given {@link HttpHost} and {@link HttpRequest}
      * that can be used as a unique identifier for cached resources. if the request has a
      * {@literal VARY} header the identifier will also include variant key.
@@ -177,22 +194,6 @@ public class CacheKeyGenerator implements Resolver<URI, String> {
         } else {
             return generateVariantKey(request, variantNames) + rootKey;
         }
-    }
-
-    /**
-     * Computes a "variant key" from the headers of a given request that are
-     * covered by the Vary header of a given cache entry. Any request whose
-     * varying headers match those of this request should have the same
-     * variant key.
-     * @param req originating request
-     * @param entry cache entry in question that has variants
-     * @return variant key
-     *
-     * @deprecated Use {@link #generateVariantKey(HttpRequest, Collection)}.
-     */
-    @Deprecated
-    public String generateVariantKey(final HttpRequest req, final HttpCacheEntry entry) {
-        return generateVariantKey(req, variantNames(entry));
     }
 
 }

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingExec.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingExec.java
@@ -520,13 +520,12 @@ class CachingExec extends CachingExecBase implements ExecChainHandler {
 
             recordCacheUpdate(scope.clientContext);
 
-            final CacheHit hit = responseCache.update(match, backendResponse, requestDate, responseDate);
+            final CacheHit hit = responseCache.storeFromNegotiated(match, target, request, backendResponse, requestDate, responseDate);
             if (shouldSendNotModifiedResponse(request, hit.entry)) {
                 return convert(responseGenerator.generateNotModifiedResponse(hit.entry), scope);
+            } else {
+                return convert(responseGenerator.generateResponse(request, hit.entry), scope);
             }
-            final SimpleHttpResponse response = responseGenerator.generateResponse(request, hit.entry);
-            responseCache.storeReusing(hit, target, request, backendResponse, requestDate, responseDate);
-            return convert(response, scope);
         } catch (final IOException | RuntimeException ex) {
             backendResponse.close();
             throw ex;

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/HttpAsyncCache.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/HttpAsyncCache.java
@@ -77,21 +77,11 @@ interface HttpAsyncCache {
             FutureCallback<CacheHit> callback);
 
     /**
-     * Updates {@link HttpCacheEntry} using details from a 304 {@link HttpResponse}.
-     */
-    Cancellable update(
-            CacheHit stale,
-            HttpResponse originResponse,
-            Instant requestSent,
-            Instant responseReceived,
-            FutureCallback<CacheHit> callback);
-
-    /**
      * Stores {@link HttpRequest} / {@link HttpResponse} exchange details in the cache
-     * re-using the resource of the existing {@link HttpCacheEntry}.
+     * from the negotiated {@link HttpCacheEntry}.
      */
-    Cancellable storeReusing(
-            CacheHit hit,
+    Cancellable storeFromNegotiated(
+            CacheHit negotiated,
             HttpHost host,
             HttpRequest request,
             HttpResponse originResponse,

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/HttpCache.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/HttpCache.java
@@ -72,20 +72,11 @@ interface HttpCache {
             Instant responseReceived);
 
     /**
-     * Updates {@link HttpCacheEntry} using details from a 304 {@link HttpResponse}.
-     */
-    CacheHit update(
-            CacheHit stale,
-            HttpResponse originResponse,
-            Instant requestSent,
-            Instant responseReceived);
-
-    /**
      * Stores {@link HttpRequest} / {@link HttpResponse} exchange details in the cache
-     * re-using the resource of the existing {@link HttpCacheEntry}.
+     * from the negotiated {@link HttpCacheEntry}.
      */
-    CacheHit storeReusing(
-            CacheHit hit,
+    CacheHit storeFromNegotiated(
+            CacheHit negotiated,
             HttpHost host,
             HttpRequest request,
             HttpResponse originResponse,

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/cache/TestHttpCacheEntryFactory.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/cache/TestHttpCacheEntryFactory.java
@@ -233,14 +233,16 @@ public class TestHttpCacheEntryFactory {
                 new BasicHeader("X-custom", "my stuff")
         );
 
+        final HttpCacheEntry newEntry = impl.create(tenSecondsAgo, oneSecondAgo, host, request, response, HttpTestUtils.makeRandomResource(1024));
+
         final Set<String> variants = new HashSet<>();
         variants.add("variant1");
         variants.add("variant2");
         variants.add("variant3");
 
-        final HttpCacheEntry newEntry = impl.createRoot(tenSecondsAgo, oneSecondAgo, host, request, response, variants);
+        final HttpCacheEntry newRoot = impl.createRoot(newEntry, variants);
 
-        MatcherAssert.assertThat(newEntry, HttpCacheEntryMatcher.equivalent(
+        MatcherAssert.assertThat(newRoot, HttpCacheEntryMatcher.equivalent(
                 HttpTestUtils.makeCacheEntry(
                         tenSecondsAgo,
                         oneSecondAgo,
@@ -261,8 +263,8 @@ public class TestHttpCacheEntryFactory {
                         variants
                         )));
 
-        Assertions.assertTrue(newEntry.hasVariants());
-        Assertions.assertNull(newEntry.getResource());
+        Assertions.assertTrue(newRoot.hasVariants());
+        Assertions.assertNull(newRoot.getResource());
     }
 
     @Test

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/HttpTestUtils.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/HttpTestUtils.java
@@ -33,6 +33,7 @@ import java.util.Collection;
 import java.util.Objects;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
+import java.util.function.Consumer;
 
 import org.apache.hc.client5.http.cache.HttpCacheEntry;
 import org.apache.hc.client5.http.cache.HttpCacheEntryFactory;
@@ -372,11 +373,14 @@ public class HttpTestUtils {
         return new BasicClassicHttpResponse(HttpStatus.SC_INTERNAL_SERVER_ERROR, "Internal Server Error");
     }
 
-    public static <T> FutureCallback<T> countDown(final CountDownLatch latch) {
+    public static <T> FutureCallback<T> countDown(final CountDownLatch latch, final Consumer<T> consumer) {
         return new FutureCallback<T>() {
 
             @Override
             public void completed(final T result) {
+                if (consumer != null) {
+                    consumer.accept(result);
+                }
                 latch.countDown();
             }
 
@@ -394,6 +398,10 @@ public class HttpTestUtils {
 
         };
 
+    }
+
+    public static <T> FutureCallback<T> countDown(final CountDownLatch latch) {
+        return countDown(latch, null);
     }
 
 }

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestBasicHttpCache.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestBasicHttpCache.java
@@ -261,8 +261,10 @@ public class TestBasicHttpCache {
 
         assertNotNull(variantMap);
         assertEquals(2, variantMap.size());
-        MatcherAssert.assertThat(variantMap.get("{accept-encoding=gzip}"), HttpCacheEntryMatcher.equivalent(hit1.entry));
-        MatcherAssert.assertThat(variantMap.get("{accept-encoding=identity}"), HttpCacheEntryMatcher.equivalent(hit2.entry));
+        MatcherAssert.assertThat(variantMap.get("{accept-encoding=gzip}" + rootKey),
+                HttpCacheEntryMatcher.equivalent(hit1.entry));
+        MatcherAssert.assertThat(variantMap.get("{accept-encoding=identity}" + rootKey),
+                HttpCacheEntryMatcher.equivalent(hit2.entry));
     }
 
     @Test


### PR DESCRIPTION
Changes:
* improved and simplified internal cache API
* corrected cache update logic after a variant negotiation
* more tests
* fixed regression