### PR TITLE
Update MemcachedHttpCacheStorage.java

### DIFF
--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/memcached/MemcachedHttpCacheStorage.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/memcached/MemcachedHttpCacheStorage.java
@@ -208,8 +208,12 @@ public class MemcachedHttpCacheStorage extends AbstractBinaryCacheStorage<CASVal
     @Override
     protected boolean updateCAS(
             final String storageKey, final CASValue<Object> casValue, final byte[] storageObject) throws ResourceIOException {
-        final CASResponse casResult = client.cas(storageKey, casValue.getCas(), storageObject);
-        return casResult == CASResponse.OK;
+        try {    
+            final CASResponse casResult = client.cas(storageKey, casValue.getCas(), storageObject);
+            return casResult == CASResponse.OK;
+        } catch (final OperationTimeoutException ex) {
+            throw new MemcachedOperationTimeoutException(ex);
+        }
     }
 
     @Override


### PR DESCRIPTION
UpdateCAS does not catch timeout exceptions.

getUpdateCAS catches and throws ResourceIOException, but updateCas does not. Try and catch is important since BasicHttpCache would catch this.

https://github.com/apache/httpcomponents-client/blob/master/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/BasicHttpCache.java#L273-L286