### PR TITLE
Add security warning to TrustStrategy implementations documentation

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/TrustAllStrategy.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/TrustAllStrategy.java
@@ -34,9 +34,15 @@ import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.ssl.TrustStrategy;
 
 /**
- * A trust strategy that accepts all certificates as trusted. Verification of
- * all other certificates is done by the trust manager configured in the SSL
- * context.
+ * A trust strategy that accepts all certificates as trusted.
+ *
+ * <h2>Security Warning</h2>
+ * This trust strategy effectivels disables most security features of SSL / TLS,
+ * and allows man-in-the-middle attacks. If possible avoid this trust strategy
+ * and use more secure alternatives. For example, for self-signed certificates
+ * prefer specifying a keystore containing the certificate chain when calling
+ * the {@link org.apache.hc.core5.ssl.SSLContextBuilder} {@code loadTrustMaterial}
+ * methods.
  *
  * @since 4.5.4
  * @since 5.0

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/TrustAllStrategy.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/TrustAllStrategy.java
@@ -37,7 +37,7 @@ import org.apache.hc.core5.ssl.TrustStrategy;
  * A trust strategy that accepts all certificates as trusted.
  *
  * <h2>Security Warning</h2>
- * This trust strategy effectivels disables most security features of SSL / TLS,
+ * This trust strategy effectively disables trust verification of SSL / TLS,
  * and allows man-in-the-middle attacks. If possible avoid this trust strategy
  * and use more secure alternatives. For example, for self-signed certificates
  * prefer specifying a keystore containing the certificate chain when calling

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/TrustSelfSignedStrategy.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/TrustSelfSignedStrategy.java
@@ -42,8 +42,13 @@ import org.apache.hc.core5.ssl.TrustStrategy;
  * must have length 1. This means this trust strategy does not protect against man-in-the-middle
  * attacks. See the {@link TrustAllStrategy} for more information and more secure alternatives.
  *
+ * @deprecated
+ *      For self-signed certificates prefer specifying a keystore containing the certificate when
+ *      calling the {@link org.apache.hc.core5.ssl.SSLContextBuilder} {@code loadTrustMaterial}
+ *      methods.
  * @since 4.1
  */
+@Deprecated
 @Contract(threading = ThreadingBehavior.STATELESS)
 public class TrustSelfSignedStrategy implements TrustStrategy {
 

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/TrustSelfSignedStrategy.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/TrustSelfSignedStrategy.java
@@ -37,6 +37,11 @@ import org.apache.hc.core5.ssl.TrustStrategy;
  * A trust strategy that accepts self-signed certificates as trusted. Verification of all other
  * certificates is done by the trust manager configured in the SSL context.
  *
+ * <h2>Security Warning</h2>
+ * This acts like {@link TrustAllStrategy}, with the only restriction that the certificate chain
+ * must have length 1. This means this trust strategy does not protect against man-in-the-middle
+ * attacks. See the {@link TrustAllStrategy} for more information and more secure alternatives.
+ *
  * @since 4.1
  */
 @Contract(threading = ThreadingBehavior.STATELESS)


### PR DESCRIPTION
Tries to improve the documentation of `TrustAllStrategy` and `TrustSelfSignedStrategy` by mentioning their security implications and suggesting more secure alternatives.

For `TrustSelfSignedStrategy` it also documents what exactly the strategy does. Otherwise without looking at the implementation details users might erroneously think it is always necessary to use `TrustSelfSignedStrategy` when using self-signed certificates (even if they are also in the truststore), which is not the case.

Any feedback is appreciated!