### PR TITLE
HTTPCLIENT-2293: Via header improvements

### DIFF
--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/AsyncCachingExec.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/AsyncCachingExec.java
@@ -217,7 +217,6 @@ class AsyncCachingExec extends CachingExecBase implements AsyncExecChainHandler 
         final URIAuthority authority = request.getAuthority();
         final String scheme = request.getScheme();
         final HttpHost target = authority != null ? new HttpHost(scheme, authority) : route.getTargetHost();
-        final String via = generateViaHeader(request);
 
         // default response context
         setResponseStatus(context, CacheResponseStatus.CACHE_MISS);
@@ -227,8 +226,6 @@ class AsyncCachingExec extends CachingExecBase implements AsyncExecChainHandler 
             triggerResponse(SimpleHttpResponse.create(HttpStatus.SC_NOT_IMPLEMENTED), scope, asyncExecCallback);
             return;
         }
-
-        request.addHeader(HttpHeaders.VIA,via);
 
         final RequestCacheControl requestCacheControl = CacheControlHeaderParser.INSTANCE.parse(request);
 
@@ -296,8 +293,6 @@ class AsyncCachingExec extends CachingExecBase implements AsyncExecChainHandler 
                     final HttpResponse backendResponse,
                     final EntityDetails entityDetails) throws HttpException, IOException {
                 final Instant responseDate = getCurrentDate();
-                backendResponse.addHeader(HttpHeaders.VIA, generateViaHeader(backendResponse));
-
                 final AsyncExecCallback callback = new BackendResponseHandler(target, request, requestDate, responseDate, scope, asyncExecCallback);
                 callbackRef.set(callback);
                 return callback.handleResponse(backendResponse, entityDetails);
@@ -749,8 +744,6 @@ class AsyncCachingExec extends CachingExecBase implements AsyncExecChainHandler 
             }
 
             AsyncExecCallback evaluateResponse(final HttpResponse backendResponse, final Instant responseDate) {
-                backendResponse.addHeader(HttpHeaders.VIA, generateViaHeader(backendResponse));
-
                 final int statusCode = backendResponse.getCode();
                 if (statusCode == HttpStatus.SC_NOT_MODIFIED || statusCode == HttpStatus.SC_OK) {
                     recordCacheUpdate(scope.clientContext);
@@ -980,8 +973,6 @@ class AsyncCachingExec extends CachingExecBase implements AsyncExecChainHandler 
                     final HttpResponse backendResponse,
                     final EntityDetails entityDetails) throws HttpException, IOException {
                 final Instant responseDate = getCurrentDate();
-                backendResponse.addHeader(HttpHeaders.VIA, generateViaHeader(backendResponse));
-
                 final AsyncExecCallback callback;
                 // Handle 304 Not Modified responses
                 if (backendResponse.getCode() == HttpStatus.SC_NOT_MODIFIED) {

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingExecBase.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingExecBase.java
@@ -28,8 +28,6 @@ package org.apache.hc.client5.http.impl.cache;
 
 import java.io.IOException;
 import java.time.Instant;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
@@ -40,17 +38,12 @@ import org.apache.hc.client5.http.cache.ResourceIOException;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpHost;
-import org.apache.hc.core5.http.HttpMessage;
 import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.HttpStatus;
-import org.apache.hc.core5.http.HttpVersion;
 import org.apache.hc.core5.http.Method;
-import org.apache.hc.core5.http.ProtocolVersion;
-import org.apache.hc.core5.http.URIScheme;
 import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.util.TimeValue;
-import org.apache.hc.core5.util.VersionInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,7 +53,6 @@ public class CachingExecBase {
     final AtomicLong cacheMisses = new AtomicLong();
     final AtomicLong cacheUpdates = new AtomicLong();
 
-    final Map<ProtocolVersion, String> viaHeaders = new ConcurrentHashMap<>(4);
     final ResponseCachingPolicy responseCachingPolicy;
     final CacheValidityPolicy validityPolicy;
     final CachedHttpResponseGenerator responseGenerator;
@@ -228,35 +220,6 @@ public class CachingExecBase {
             return true;
         }
         return false;
-    }
-
-    String generateViaHeader(final HttpMessage msg) {
-
-        if (msg.getVersion() == null) {
-            msg.setVersion(HttpVersion.DEFAULT);
-        }
-        final ProtocolVersion pv = msg.getVersion();
-        final String existingEntry = viaHeaders.get(msg.getVersion());
-        if (existingEntry != null) {
-            return existingEntry;
-        }
-
-        final VersionInfo vi = VersionInfo.loadVersionInfo("org.apache.hc.client5", getClass().getClassLoader());
-        final String release = (vi != null) ? vi.getRelease() : VersionInfo.UNAVAILABLE;
-
-        final String value;
-        final int major = pv.getMajor();
-        final int minor = pv.getMinor();
-        if (URIScheme.HTTP.same(pv.getProtocol())) {
-            value = String.format("%d.%d localhost (Apache-HttpClient/%s (cache))", major, minor,
-                    release);
-        } else {
-            value = String.format("%s/%d.%d localhost (Apache-HttpClient/%s (cache))", pv.getProtocol(), major,
-                    minor, release);
-        }
-        viaHeaders.put(pv, value);
-
-        return value;
     }
 
     void setResponseStatus(final HttpContext context, final CacheResponseStatus value) {

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingH2AsyncClientBuilder.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingH2AsyncClientBuilder.java
@@ -65,7 +65,7 @@ public class CachingH2AsyncClientBuilder extends H2AsyncClientBuilder {
 
     protected CachingH2AsyncClientBuilder() {
         super();
-        addResponseInterceptorFirst(ResponseProtocolCompliance.INSTANCE);
+        addResponseInterceptorFirst(ResponseCacheConformance.INSTANCE);
         addResponseInterceptorLast(ResponseViaCache.INSTANCE);
         addRequestInterceptorLast(RequestViaCache.INSTANCE);
         this.deleteCache = true;

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingH2AsyncClientBuilder.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingH2AsyncClientBuilder.java
@@ -66,6 +66,8 @@ public class CachingH2AsyncClientBuilder extends H2AsyncClientBuilder {
     protected CachingH2AsyncClientBuilder() {
         super();
         addResponseInterceptorFirst(ResponseProtocolCompliance.INSTANCE);
+        addResponseInterceptorLast(ResponseViaCache.INSTANCE);
+        addRequestInterceptorLast(RequestViaCache.INSTANCE);
         this.deleteCache = true;
     }
 

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingHttpAsyncClientBuilder.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingHttpAsyncClientBuilder.java
@@ -65,7 +65,7 @@ public class CachingHttpAsyncClientBuilder extends HttpAsyncClientBuilder {
 
     protected CachingHttpAsyncClientBuilder() {
         super();
-        addResponseInterceptorFirst(ResponseProtocolCompliance.INSTANCE);
+        addResponseInterceptorFirst(ResponseCacheConformance.INSTANCE);
         addResponseInterceptorLast(ResponseViaCache.INSTANCE);
         addRequestInterceptorLast(RequestViaCache.INSTANCE);
         this.deleteCache = true;

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingHttpAsyncClientBuilder.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingHttpAsyncClientBuilder.java
@@ -66,6 +66,8 @@ public class CachingHttpAsyncClientBuilder extends HttpAsyncClientBuilder {
     protected CachingHttpAsyncClientBuilder() {
         super();
         addResponseInterceptorFirst(ResponseProtocolCompliance.INSTANCE);
+        addResponseInterceptorLast(ResponseViaCache.INSTANCE);
+        addRequestInterceptorLast(RequestViaCache.INSTANCE);
         this.deleteCache = true;
     }
 

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingHttpClientBuilder.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingHttpClientBuilder.java
@@ -61,7 +61,7 @@ public class CachingHttpClientBuilder extends HttpClientBuilder {
 
     protected CachingHttpClientBuilder() {
         super();
-        addResponseInterceptorFirst(ResponseProtocolCompliance.INSTANCE);
+        addResponseInterceptorFirst(ResponseCacheConformance.INSTANCE);
         addResponseInterceptorLast(ResponseViaCache.INSTANCE);
         addRequestInterceptorLast(RequestViaCache.INSTANCE);
         this.deleteCache = true;

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingHttpClientBuilder.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingHttpClientBuilder.java
@@ -62,6 +62,8 @@ public class CachingHttpClientBuilder extends HttpClientBuilder {
     protected CachingHttpClientBuilder() {
         super();
         addResponseInterceptorFirst(ResponseProtocolCompliance.INSTANCE);
+        addResponseInterceptorLast(ResponseViaCache.INSTANCE);
+        addRequestInterceptorLast(RequestViaCache.INSTANCE);
         this.deleteCache = true;
     }
 

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/RequestViaCache.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/RequestViaCache.java
@@ -1,0 +1,58 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.client5.http.impl.cache;
+
+import java.io.IOException;
+
+import org.apache.hc.core5.annotation.Contract;
+import org.apache.hc.core5.annotation.ThreadingBehavior;
+import org.apache.hc.core5.http.EntityDetails;
+import org.apache.hc.core5.http.HttpException;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.HttpRequestInterceptor;
+import org.apache.hc.core5.http.ProtocolVersion;
+import org.apache.hc.core5.http.protocol.HttpContext;
+
+/**
+ * This response interceptor adds {@literal VIA} header to all outgoing
+ * request messages dispatched through the caching layer.
+ */
+@Contract(threading = ThreadingBehavior.IMMUTABLE)
+class RequestViaCache implements HttpRequestInterceptor {
+
+    public static final RequestViaCache INSTANCE = new RequestViaCache();
+
+    @Override
+    public void process(final HttpRequest request,
+                        final EntityDetails entity,
+                        final HttpContext context) throws HttpException, IOException {
+        final ProtocolVersion protocolVersion = context.getProtocolVersion();
+        request.addHeader(HttpHeaders.VIA, ViaCacheGenerator.INSTANCE.lookup(protocolVersion));
+    }
+
+}

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/ResponseCacheConformance.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/ResponseCacheConformance.java
@@ -48,9 +48,9 @@ import org.apache.hc.core5.http.protocol.HttpContext;
  * header if it is not present in the response message..
  */
 @Contract(threading = ThreadingBehavior.IMMUTABLE)
-class ResponseProtocolCompliance implements HttpResponseInterceptor {
+class ResponseCacheConformance implements HttpResponseInterceptor {
 
-    public static final ResponseProtocolCompliance INSTANCE = new ResponseProtocolCompliance();
+    public static final ResponseCacheConformance INSTANCE = new ResponseCacheConformance();
 
     private final static String[] DISALLOWED_ENTITY_HEADERS = {
             HttpHeaders.CONTENT_ENCODING,

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/ResponseCachingPolicy.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/ResponseCachingPolicy.java
@@ -43,6 +43,7 @@ import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.http.HttpVersion;
 import org.apache.hc.core5.http.Method;
 import org.apache.hc.core5.http.ProtocolVersion;
+import org.apache.hc.core5.http.message.BasicTokenIterator;
 import org.apache.hc.core5.http.message.MessageSupport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -336,15 +337,10 @@ class ResponseCachingPolicy {
     }
 
     private boolean from1_0Origin(final HttpResponse response) {
-        final Iterator<HeaderElement> it = MessageSupport.iterate(response, HttpHeaders.VIA);
+        final Iterator<String> it = new BasicTokenIterator(response.headerIterator(HttpHeaders.VIA));
         if (it.hasNext()) {
-            final HeaderElement elt = it.next();
-            final String proto = elt.toString().split("\\s")[0];
-            if (proto.contains("/")) {
-                return proto.equals("HTTP/1.0");
-            } else {
-                return proto.equals("1.0");
-            }
+            final String token = it.next();
+            return token.startsWith("1.0 ") || token.startsWith("HTTP/1.0 ");
         }
         final ProtocolVersion version = response.getVersion() != null ? response.getVersion() : HttpVersion.DEFAULT;
         return HttpVersion.HTTP_1_0.equals(version);

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/ResponseViaCache.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/ResponseViaCache.java
@@ -1,0 +1,58 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.client5.http.impl.cache;
+
+import java.io.IOException;
+
+import org.apache.hc.core5.annotation.Contract;
+import org.apache.hc.core5.annotation.ThreadingBehavior;
+import org.apache.hc.core5.http.EntityDetails;
+import org.apache.hc.core5.http.HttpException;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.HttpResponseInterceptor;
+import org.apache.hc.core5.http.ProtocolVersion;
+import org.apache.hc.core5.http.protocol.HttpContext;
+
+/**
+ * This response interceptor adds {@literal VIA} header to all incoming
+ * response messages dispatched through the caching layer.
+ */
+@Contract(threading = ThreadingBehavior.IMMUTABLE)
+class ResponseViaCache implements HttpResponseInterceptor {
+
+    public static final ResponseViaCache INSTANCE = new ResponseViaCache();
+
+    @Override
+    public void process(final HttpResponse response,
+                        final EntityDetails entity,
+                        final HttpContext context) throws HttpException, IOException {
+        final ProtocolVersion protocolVersion = context.getProtocolVersion();
+        response.addHeader(HttpHeaders.VIA, ViaCacheGenerator.INSTANCE.lookup(protocolVersion));
+    }
+
+}

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/ViaCacheGenerator.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/ViaCacheGenerator.java
@@ -1,0 +1,62 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.client5.http.impl.cache;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.apache.hc.core5.http.ProtocolVersion;
+import org.apache.hc.core5.http.URIScheme;
+import org.apache.hc.core5.util.VersionInfo;
+
+final class ViaCacheGenerator {
+
+    final static ViaCacheGenerator INSTANCE = new ViaCacheGenerator();
+
+    final ConcurrentMap<ProtocolVersion, String> internalCache = new ConcurrentHashMap<>(4);
+
+    String generateViaHeader(final VersionInfo vi, final ProtocolVersion pv) {
+        final StringBuilder buf = new StringBuilder();
+        if (!URIScheme.HTTP.same(pv.getProtocol())) {
+            buf.append(pv.getProtocol()).append('/');
+        }
+        buf.append(pv.getMajor()).append('.').append(pv.getMinor());
+        buf.append(' ').append("localhost").append(' ');
+        buf.append("(Apache-HttpClient/");
+        final String release = (vi != null) ? vi.getRelease() : VersionInfo.UNAVAILABLE;
+        buf.append(release).append(" (cache))");
+        return buf.toString();
+    }
+
+    String lookup(final ProtocolVersion pv) {
+        return internalCache.computeIfAbsent(pv, (v) -> {
+            final VersionInfo vi = VersionInfo.loadVersionInfo("org.apache.hc.client5", getClass().getClassLoader());
+            return generateViaHeader(vi, v);
+        });
+    }
+
+}

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestResponseCacheConformance.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestResponseCacheConformance.java
@@ -37,13 +37,13 @@ import org.apache.hc.core5.http.support.BasicResponseBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class TestResponseProtocolCompliance {
+public class TestResponseCacheConformance {
 
-    private ResponseProtocolCompliance impl;
+    private ResponseCacheConformance impl;
 
     @BeforeEach
     public void setUp() {
-        impl = ResponseProtocolCompliance.INSTANCE;
+        impl = ResponseCacheConformance.INSTANCE;
     }
 
     private void shouldStripEntityHeaderFromOrigin304ResponseToStrongValidation(

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestViaCacheGenerator.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestViaCacheGenerator.java
@@ -1,0 +1,75 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.client5.http.impl.cache;
+
+
+import org.apache.hc.core5.http.HttpVersion;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class TestViaCacheGenerator {
+
+    private ViaCacheGenerator impl;
+
+    @BeforeEach
+    public void setUp() {
+        impl = new ViaCacheGenerator();
+    }
+
+    @Test
+    public void testViaValueGeneration() {
+        Assertions.assertEquals("1.1 localhost (Apache-HttpClient/UNAVAILABLE (cache))",
+                impl.generateViaHeader(null, HttpVersion.DEFAULT));
+        Assertions.assertEquals("2.0 localhost (Apache-HttpClient/UNAVAILABLE (cache))",
+                impl.generateViaHeader(null, HttpVersion.HTTP_2));
+    }
+
+    @Test
+    public void testViaValueLookup() {
+        MatcherAssert.assertThat(impl.lookup(HttpVersion.DEFAULT),
+                Matchers.startsWith("1.1 localhost (Apache-HttpClient/"));
+        MatcherAssert.assertThat(impl.lookup(HttpVersion.HTTP_1_0),
+                Matchers.startsWith("1.0 localhost (Apache-HttpClient/"));
+        MatcherAssert.assertThat(impl.lookup(HttpVersion.HTTP_1_1),
+                Matchers.startsWith("1.1 localhost (Apache-HttpClient/"));
+        MatcherAssert.assertThat(impl.lookup(HttpVersion.HTTP_2),
+                Matchers.startsWith("2.0 localhost (Apache-HttpClient/"));
+        MatcherAssert.assertThat(impl.lookup(HttpVersion.HTTP_2_0),
+                Matchers.startsWith("2.0 localhost (Apache-HttpClient/"));
+        MatcherAssert.assertThat(impl.lookup(HttpVersion.HTTP_1_0),
+                Matchers.startsWith("1.0 localhost (Apache-HttpClient/"));
+        MatcherAssert.assertThat(impl.lookup(HttpVersion.HTTP_1_1),
+                Matchers.startsWith("1.1 localhost (Apache-HttpClient/"));
+        MatcherAssert.assertThat(impl.lookup(HttpVersion.HTTP_2_0),
+                Matchers.startsWith("2.0 localhost (Apache-HttpClient/"));
+        Assertions.assertEquals(3, impl.internalCache.size());
+    }
+
+}


### PR DESCRIPTION
* `ResponseCachingPolicy` optimized to generate less intermediate garbage while paring `Via` headers
* `Via` request and response header generation moved from the caching exec interceptors into separate protocol interceptors 