### PR TITLE
HTTPCLIENT-2302: Add comment to TrustStrategy usage in examples

### DIFF
--- a/httpclient5/src/test/java/org/apache/hc/client5/http/examples/AsyncClientCustomSSL.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/examples/AsyncClientCustomSSL.java
@@ -59,6 +59,11 @@ public class AsyncClientCustomSSL {
     public static void main(final String[] args) throws Exception {
         // Trust standard CA and those trusted by our custom strategy
         final SSLContext sslContext = SSLContexts.custom()
+                // Specify a custom TrustStrategy
+                // Note that this is not needed when the certificate has been issued by a trusted CA,
+                // or when using a custom truststore which contains the certificate chain
+                // Warning: While this example is better than using TrustAllStrategy, it still allows
+                //          man-in-the-middle attacks
                 .loadTrustMaterial((chain, authType) -> {
                     final X509Certificate cert = chain[0];
                     return "CN=httpbin.org".equalsIgnoreCase(cert.getSubjectDN().getName());

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/examples/AsyncClientCustomSSL.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/examples/AsyncClientCustomSSL.java
@@ -60,10 +60,12 @@ public class AsyncClientCustomSSL {
         // Trust standard CA and those trusted by our custom strategy
         final SSLContext sslContext = SSLContexts.custom()
                 // Specify a custom TrustStrategy
-                // Note that this is not needed when the certificate has been issued by a trusted CA,
-                // or when using a custom truststore which contains the certificate chain
-                // Warning: While this example is better than using TrustAllStrategy, it still allows
-                //          man-in-the-middle attacks
+                // Custom TrustStrategy implementations are intended for verification of certificates
+                // whose CA is not trusted by the system, and where specifying a custom truststore
+                // containing the certificate chain is not an option.
+                // Validation of the server certificate without validation of the entire certificate chain
+                // is preferred to completely disabling trust verification, however this
+                // *still allows man-in-the-middle attacks*.
                 .loadTrustMaterial((chain, authType) -> {
                     final X509Certificate cert = chain[0];
                     return "CN=httpbin.org".equalsIgnoreCase(cert.getSubjectDN().getName());

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClientCustomSSL.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClientCustomSSL.java
@@ -56,10 +56,12 @@ public class ClientCustomSSL {
         // Trust standard CA and those trusted by our custom strategy
         final SSLContext sslContext = SSLContexts.custom()
                 // Specify a custom TrustStrategy
-                // Note that this is not needed when the certificate has been issued by a trusted CA,
-                // or when using a custom truststore which contains the certificate chain
-                // Warning: While this example is better than using TrustAllStrategy, it still allows
-                //          man-in-the-middle attacks
+                // Custom TrustStrategy implementations are intended for verification of certificates
+                // whose CA is not trusted by the system, and where specifying a custom truststore
+                // containing the certificate chain is not an option.
+                // Validation of the server certificate without validation of the entire certificate chain
+                // is preferred to completely disabling trust verification, however this
+                // *still allows man-in-the-middle attacks*.
                 .loadTrustMaterial((chain, authType) -> {
                     final X509Certificate cert = chain[0];
                     return "CN=httpbin.org".equalsIgnoreCase(cert.getSubjectDN().getName());

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClientCustomSSL.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClientCustomSSL.java
@@ -55,6 +55,11 @@ public class ClientCustomSSL {
     public final static void main(final String[] args) throws Exception {
         // Trust standard CA and those trusted by our custom strategy
         final SSLContext sslContext = SSLContexts.custom()
+                // Specify a custom TrustStrategy
+                // Note that this is not needed when the certificate has been issued by a trusted CA,
+                // or when using a custom truststore which contains the certificate chain
+                // Warning: While this example is better than using TrustAllStrategy, it still allows
+                //          man-in-the-middle attacks
                 .loadTrustMaterial((chain, authType) -> {
                     final X509Certificate cert = chain[0];
                     return "CN=httpbin.org".equalsIgnoreCase(cert.getSubjectDN().getName());


### PR DESCRIPTION
See also discussion in https://issues.apache.org/jira/browse/HTTPCLIENT-2302

This tries to make the user aware that:
- Usage of `TrustStrategy` is optional
- The specific usage in the examples does not prevent man-in-the-middle attacks

Feedback is appreciated!