### PR TITLE
slf4j-api in httpcomponets-testing module is set to a wrong dependency scope.

### DIFF
--- a/httpclient5-testing/pom.xml
+++ b/httpclient5-testing/pom.xml
@@ -56,6 +56,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
# Problem Description
The slf4j-api is declared without assigning a dependency scope, leading to a default scope compile. But it's only used for testing with classes [org.slf4j.Logger, org.slf4j.LoggerFactory] in file “TypeAsyncResources.java" and "TestClientResources.java".
```
    <dependency>
      <groupId>org.slf4j</groupId>
      <artifactId>slf4j-api</artifactId>
    </dependency>
```

# Possible Outcome
This brings redundant compile time dependency for the module, increasing the probability of dependency conflict for downstream users.
# Solution
Changing the dependency scope to test can help. After changing the dependency scope to "test," I recompiled the module and executed the tests. Following these adjustments, the module compiled successfully, and all the tests passed.