### PR TITLE
Implement Password Validation in BasicScheme.

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/BasicScheme.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/BasicScheme.java
@@ -184,12 +184,27 @@ public class BasicScheme implements AuthScheme, Serializable {
         }
     }
 
+    private void validatePassword() throws AuthenticationException {
+        if (credentials == null) {
+            throw new AuthenticationException("User credentials not set");
+        }
+        final char[] password = credentials.getUserPassword();
+        if (password != null) {
+            for (final char ch : password) {
+                if (Character.isISOControl(ch)) {
+                    throw new AuthenticationException("Password must not contain any control characters");
+                }
+            }
+        }
+    }
+
     @Override
     public String generateAuthResponse(
             final HttpHost host,
             final HttpRequest request,
             final HttpContext context) throws AuthenticationException {
         validateUsername();
+        validatePassword();
         if (this.buffer == null) {
             this.buffer = new ByteArrayBuilder(64);
         } else {

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestBasicScheme.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestBasicScheme.java
@@ -229,4 +229,18 @@ public class TestBasicScheme {
         Assertions.assertThrows(AuthenticationException.class, () -> authscheme.generateAuthResponse(host, request, null));
     }
 
+    @Test
+    public void testBasicAuthenticationPasswordWithControlCharacters() throws Exception {
+        final BasicScheme authscheme = new BasicScheme();
+        final HttpHost host = new HttpHost("somehost", 80);
+        final HttpRequest request = new BasicHttpRequest("GET", "/");
+
+        // Creating a password with a control character (ASCII code 0-31 or 127)
+        final char[] password = new char[]{'p', 'a', 's', 's', 0x1F, 'w', 'o', 'r', 'd'};
+        authscheme.initPreemptive(new UsernamePasswordCredentials("username", password));
+
+        // Expecting an AuthenticationException due to control character in password
+        Assertions.assertThrows(AuthenticationException.class, () -> authscheme.generateAuthResponse(host, request, null));
+    }
+
 }


### PR DESCRIPTION
Introduced a new method, `validatePassword`, in the `BasicScheme` class to enforce password validation in line with RFC 7617 standards. This method includes control character validation for passwords, ensuring they adhere to RFC 7617 by not containing any control characters.