### PR TITLE
Enforce Support for UTF-8 Encoding Scheme in Digest Authentication as per RFC 7616

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/DigestScheme.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/DigestScheme.java
@@ -122,13 +122,20 @@ public class DigestScheme implements AuthScheme, Serializable {
     private UsernamePasswordCredentials credentials;
 
     public DigestScheme() {
-        this(StandardCharsets.ISO_8859_1);
-    }
-
-    public DigestScheme(final Charset charset) {
-        this.defaultCharset = charset != null ? charset : StandardCharsets.ISO_8859_1;
+        this.defaultCharset =  StandardCharsets.UTF_8;
         this.paramMap = new HashMap<>();
         this.complete = false;
+    }
+
+    /**
+     * @deprecated This constructor is deprecated to enforce the use of {@link StandardCharsets#UTF_8} encoding
+     * in compliance with RFC 7616 for HTTP Digest Access Authentication. Use the default constructor {@link #DigestScheme()} instead.
+     *
+     * @param charset the {@link Charset} set to be used for encoding credentials. This parameter is ignored as UTF-8 is always used.
+     */
+    @Deprecated
+    public DigestScheme(final Charset charset) {
+        this();
     }
 
     public void initPreemptive(final Credentials credentials, final String cnonce, final String realm) {

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/DigestSchemeFactory.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/DigestSchemeFactory.java
@@ -28,6 +28,7 @@
 package org.apache.hc.client5.http.impl.auth;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.hc.client5.http.auth.AuthScheme;
 import org.apache.hc.client5.http.auth.AuthSchemeFactory;
@@ -49,22 +50,24 @@ public class DigestSchemeFactory implements AuthSchemeFactory {
      */
     public static final DigestSchemeFactory INSTANCE = new DigestSchemeFactory();
 
-    private final Charset charset;
 
     /**
-     * @since 5.1
+     * @param charset the {@link Charset} set to be used for encoding credentials. This parameter is ignored as UTF-8 is always used.
+     * @deprecated This constructor is deprecated to enforce the use of {@link StandardCharsets#UTF_8} encoding
+     * in compliance with RFC 7616 for HTTP Digest Access Authentication. Use the default constructor {@link #DigestSchemeFactory()} instead.
      */
+    @Deprecated
     public DigestSchemeFactory(final Charset charset) {
-        this.charset = charset;
+        super();
     }
 
     public DigestSchemeFactory() {
-        this(null);
+
     }
 
     @Override
     public AuthScheme create(final HttpContext context) {
-        return new DigestScheme(charset);
+        return new DigestScheme();
     }
 
 }


### PR DESCRIPTION
This commit enforces the use of the 'UTF-8' encoding scheme as the sole allowed value for character encoding in Digest Authentication, in alignment with the guidelines specified in RFC 7616.