### PR TITLE
Add validation to prevent both 'username' and 'username*' in DigestScheme headers.

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/DigestScheme.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/DigestScheme.java
@@ -223,6 +223,13 @@ public class DigestScheme implements AuthScheme, Serializable {
         if (this.paramMap.get("nonce") == null) {
             throw new AuthenticationException("missing nonce");
         }
+
+        final boolean hasUsername = this.paramMap.containsKey("username");
+        final boolean hasUsernameStar = this.paramMap.containsKey("username*");
+        if (hasUsername && hasUsernameStar) {
+            throw new AuthenticationException("Both 'username' and 'username*' cannot be present in the same header.");
+        }
+
         return createDigestResponse(request);
     }
 


### PR DESCRIPTION

This commit introduces a new validation check in the ´DigestScheme ´class to ensure that both 'username' and 'username*' are not present simultaneously in the same authentication header. According to [RFC 7616](https://datatracker.ietf.org/doc/html/rfc7616#section-3.4), having both of these fields in the same header should be treated as an error.