### PR TITLE
HTTPCLIENT-2292: fix regression leading to invalid proxy

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/DefaultHttpClientConnectionOperator.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/DefaultHttpClientConnectionOperator.java
@@ -155,7 +155,7 @@ public class DefaultHttpClientConnectionOperator implements HttpClientConnection
             final InetAddress address = remoteAddresses[i];
             final boolean last = i == remoteAddresses.length - 1;
 
-            Socket sock = sf.createSocket(proxy, context);
+            Socket sock = proxy != null ? sf.createSocket(proxy, context) : sf.createSocket(context);
             if (soTimeout != null) {
                 sock.setSoTimeout(soTimeout.toMillisecondsIntBound());
             }


### PR DESCRIPTION
[This](https://issues.apache.org/jira/browse/HTTPCLIENT-2292) seems to have caused a regression in 5.2.2.

 
```java
java.lang.IllegalArgumentException: Invalid Proxy
    at java.base/java.net.Socket.<init>(Socket.java:216)
    at org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory.createSocket(SSLConnectionSocketFactory.java:208)
    at org.apache.hc.client5.http.impl.io.DefaultHttpClientConnectionOperator.connect(DefaultHttpClientConnectionOperator.java:158)
    at org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager.connect(PoolingHttpClientConnectionManager.java:447)
    at org.apache.hc.client5.http.impl.classic.InternalExecRuntime.connectEndpoint(InternalExecRuntime.java:162)
    at org.apache.hc.client5.http.impl.classic.InternalExecRuntime.connectEndpoint(InternalExecRuntime.java:172) 
```

When the proxy is undefined or set to null, DefaultHttpClientConnectionOperator does the following:

 
```java
Timeout soTimeout = socketConfig.getSoTimeout();
SocketAddress socksProxyAddress = socketConfig.getSocksProxyAddress();
Proxy proxy = socksProxyAddress != null ? new Proxy(Type.SOCKS, socksProxyAddress) : null; 
```

The proxy object above is then null, which means the following call:

```java
Socket sock = sf.createSocket(proxy, context); 
```

...will eventually pass down to SSLConnectionSocketFactory which does this:

```java
public Socket createSocket(Proxy proxy, HttpContext context) throws IOException {
    return new Socket(proxy); //this proxy cannot be null
} 
```

I should mention that in the above case,

No SOCKS proxy is ever configured via the PoolingHttpClientConnectionManagerBuilder. setDefaultSocketConfig() method 
No  SocketConfig.setSocksProxyAddress(socksaddr) exists and is always null.