### PR TITLE
Invalid Argument Exception thrown when null proxy passed to Socket contrctor

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/DefaultHttpClientConnectionOperator.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/DefaultHttpClientConnectionOperator.java
@@ -149,7 +149,7 @@ public class DefaultHttpClientConnectionOperator implements HttpClientConnection
 
         final Timeout soTimeout = socketConfig.getSoTimeout();
         final SocketAddress socksProxyAddress = socketConfig.getSocksProxyAddress();
-        final Proxy proxy = socksProxyAddress != null ? new Proxy(Proxy.Type.SOCKS, socksProxyAddress) : null;
+        final Proxy proxy = socksProxyAddress == null ? Proxy.NO_PROXY : new Proxy(Proxy.Type.SOCKS, socksProxyAddress);
         final int port = this.schemePortResolver.resolve(host);
         for (int i = 0; i < remoteAddresses.length; i++) {
             final InetAddress address = remoteAddresses[i];

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/io/TestBasicHttpClientConnectionManager.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/io/TestBasicHttpClientConnectionManager.java
@@ -29,6 +29,7 @@ package org.apache.hc.client5.http.impl.io;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.Proxy;
 import java.net.Socket;
 import java.util.concurrent.TimeUnit;
 
@@ -389,7 +390,7 @@ public class TestBasicHttpClientConnectionManager {
 
         Mockito.verify(dnsResolver, Mockito.times(1)).resolve("somehost");
         Mockito.verify(schemePortResolver, Mockito.times(1)).resolve(target);
-        Mockito.verify(plainSocketFactory, Mockito.times(1)).createSocket(null, context);
+        Mockito.verify(plainSocketFactory, Mockito.times(1)).createSocket(Proxy.NO_PROXY, context);
         Mockito.verify(plainSocketFactory, Mockito.times(1)).connectSocket(
                 socket,
                 target,
@@ -403,7 +404,7 @@ public class TestBasicHttpClientConnectionManager {
 
         Mockito.verify(dnsResolver, Mockito.times(2)).resolve("somehost");
         Mockito.verify(schemePortResolver, Mockito.times(2)).resolve(target);
-        Mockito.verify(plainSocketFactory, Mockito.times(2)).createSocket(null, context);
+        Mockito.verify(plainSocketFactory, Mockito.times(2)).createSocket(Proxy.NO_PROXY, context);
         Mockito.verify(plainSocketFactory, Mockito.times(1)).connectSocket(
                 socket,
                 target,
@@ -461,7 +462,7 @@ public class TestBasicHttpClientConnectionManager {
 
         Mockito.verify(dnsResolver, Mockito.times(1)).resolve("someproxy");
         Mockito.verify(schemePortResolver, Mockito.times(1)).resolve(proxy);
-        Mockito.verify(plainSocketFactory, Mockito.times(1)).createSocket(null, context);
+        Mockito.verify(plainSocketFactory, Mockito.times(1)).createSocket(Proxy.NO_PROXY, context);
         Mockito.verify(plainSocketFactory, Mockito.times(1)).connectSocket(
                 socket,
                 proxy,

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/io/TestPoolingHttpClientConnectionManager.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/io/TestPoolingHttpClientConnectionManager.java
@@ -29,6 +29,7 @@ package org.apache.hc.client5.http.impl.io;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.Proxy;
 import java.net.Socket;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -274,7 +275,7 @@ public class TestPoolingHttpClientConnectionManager {
 
         Mockito.verify(dnsResolver, Mockito.times(1)).resolve("somehost");
         Mockito.verify(schemePortResolver, Mockito.times(1)).resolve(target);
-        Mockito.verify(plainSocketFactory, Mockito.times(1)).createSocket(null, context);
+        Mockito.verify(plainSocketFactory, Mockito.times(1)).createSocket(Proxy.NO_PROXY, context);
         Mockito.verify(plainSocketFactory, Mockito.times(1)).connectSocket(
                 socket,
                 target,
@@ -288,7 +289,7 @@ public class TestPoolingHttpClientConnectionManager {
 
         Mockito.verify(dnsResolver, Mockito.times(2)).resolve("somehost");
         Mockito.verify(schemePortResolver, Mockito.times(2)).resolve(target);
-        Mockito.verify(plainSocketFactory, Mockito.times(2)).createSocket(null, context);
+        Mockito.verify(plainSocketFactory, Mockito.times(2)).createSocket(Proxy.NO_PROXY, context);
         Mockito.verify(plainSocketFactory, Mockito.times(1)).connectSocket(
                 socket,
                 target,
@@ -359,7 +360,7 @@ public class TestPoolingHttpClientConnectionManager {
 
         Mockito.verify(dnsResolver, Mockito.times(1)).resolve("someproxy");
         Mockito.verify(schemePortResolver, Mockito.times(1)).resolve(proxy);
-        Mockito.verify(plainsf, Mockito.times(1)).createSocket(null, context);
+        Mockito.verify(plainsf, Mockito.times(1)).createSocket(Proxy.NO_PROXY, context);
         Mockito.verify(plainsf, Mockito.times(1)).connectSocket(
                 mockSock,
                 proxy,


### PR DESCRIPTION
Setting the proxy to NO_PROXY when proxy if null instead.