### PR TITLE
Improve debug logging around connections that cannot be reused

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java
@@ -409,7 +409,7 @@ public class PoolingHttpClientConnectionManager
                 }
             } else {
                 if (LOG.isDebugEnabled()) {
-                    LOG.debug("{} connection is not kept alive", ConnPoolSupport.getId(endpoint));
+                    LOG.debug("{} connection is not kept alive(isConsistent:{})", ConnPoolSupport.getId(endpoint), conn.isConsistent());
                 }
             }
         } catch (final RuntimeException ex) {


### PR DESCRIPTION
This commit is to improve debug logging around connections that are not reusable. This [previous commit ](https://github.com/apache/httpcomponents-client/commit/9cfdd54c94ab641a887e43ca1f4ae56beab5cd90) introduced usage of the [isConsistent](https://github.com/apache/httpcomponents-core/blob/d1c77bc7f7697548cd83d04ba87a1ec7105da308/httpcore5/src/main/java/org/apache/hc/core5/http/io/HttpClientConnection.java#L54) variable. 

Upon upgrading from v4.5 -> 5.x I witnessed increased latency between version due to connections being closed and it not being obvious why. I eventually pinpointed to this change, so improving the debug logging around this to hopefully help others in the future. 