### PR TITLE
Prevent NullPointerException being thrown when constructing log message

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java
@@ -409,7 +409,8 @@ public class PoolingHttpClientConnectionManager
                 }
             } else {
                 if (LOG.isDebugEnabled()) {
-                    LOG.debug("{} connection is not kept alive(isConsistent:{})", ConnPoolSupport.getId(endpoint), conn.isConsistent());
+                    final String additionalInfo = conn == null ? "" : " (isConsistent:" + conn.isConsistent() + ")";
+                    LOG.debug("{} connection is not kept alive{}", ConnPoolSupport.getId(endpoint), additionalInfo);
                 }
             }
         } catch (final RuntimeException ex) {


### PR DESCRIPTION
https://github.com/apache/httpcomponents-client/pull/515 added additional logging information about the connection being released. However the log exists in a branch where the connection may be null, thus causing a NPE to be thrown under those circumstances.

This PR accounts for the potential for the connection to be null when constructing the log message.