### PR TITLE
HTTPCLIENT-2314: Handle gracefully a failure of DnsResolver to return a list of resolved addresses

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/SystemDefaultDnsResolver.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/SystemDefaultDnsResolver.java
@@ -42,7 +42,11 @@ public class SystemDefaultDnsResolver implements DnsResolver {
     public InetAddress[] resolve(final String host) throws UnknownHostException {
         try {
             // Try resolving using the default resolver
-            return InetAddress.getAllByName(host);
+            final InetAddress[] resolvedAddresses = InetAddress.getAllByName(host);
+            if (resolvedAddresses == null || resolvedAddresses.length == 0) {
+                throw new UnknownHostException(host);
+            }
+            return resolvedAddresses;
         } catch (final UnknownHostException e) {
             // If default resolver fails, try stripping the IPv6 zone ID and resolving again
             String strippedHost = null;

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/SystemDefaultDnsResolver.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/SystemDefaultDnsResolver.java
@@ -42,11 +42,7 @@ public class SystemDefaultDnsResolver implements DnsResolver {
     public InetAddress[] resolve(final String host) throws UnknownHostException {
         try {
             // Try resolving using the default resolver
-            final InetAddress[] resolvedAddresses = InetAddress.getAllByName(host);
-            if (resolvedAddresses == null || resolvedAddresses.length == 0) {
-                throw new UnknownHostException(host);
-            }
-            return resolvedAddresses;
+            return InetAddress.getAllByName(host);
         } catch (final UnknownHostException e) {
             // If default resolver fails, try stripping the IPv6 zone ID and resolving again
             String strippedHost = null;

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/InMemoryDnsResolver.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/InMemoryDnsResolver.java
@@ -90,7 +90,7 @@ public class InMemoryDnsResolver implements DnsResolver {
             LOG.info("Resolving {} to {}", host, Arrays.deepToString(resolvedAddresses));
         }
         if(resolvedAddresses == null){
-            throw new UnknownHostException(host + " cannot be resolved");
+            throw new UnknownHostException(host);
         }
         return resolvedAddresses;
     }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/DefaultHttpClientConnectionOperator.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/DefaultHttpClientConnectionOperator.java
@@ -32,6 +32,7 @@ import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.net.Socket;
 import java.net.SocketAddress;
+import java.net.UnknownHostException;
 import java.util.Arrays;
 
 import org.apache.hc.client5.http.ConnectExceptionSupport;
@@ -143,8 +144,12 @@ public class DefaultHttpClientConnectionOperator implements HttpClientConnection
             remoteAddresses = this.dnsResolver.resolve(host.getHostName());
 
             if (LOG.isDebugEnabled()) {
-                LOG.debug("{} resolved to {}", host.getHostName(), Arrays.asList(remoteAddresses));
+                LOG.debug("{} resolved to {}", host.getHostName(), remoteAddresses == null ? "null" : Arrays.asList(remoteAddresses));
             }
+            
+            if (remoteAddresses == null || remoteAddresses.length == 0) {
+              throw new UnknownHostException(host.getHostName());
+          }
         }
 
         final Timeout soTimeout = socketConfig.getSoTimeout();

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/DefaultHttpClientConnectionOperator.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/DefaultHttpClientConnectionOperator.java
@@ -146,7 +146,7 @@ public class DefaultHttpClientConnectionOperator implements HttpClientConnection
             if (LOG.isDebugEnabled()) {
                 LOG.debug("{} resolved to {}", host.getHostName(), remoteAddresses == null ? "null" : Arrays.asList(remoteAddresses));
             }
-            
+
             if (remoteAddresses == null || remoteAddresses.length == 0) {
               throw new UnknownHostException(host.getHostName());
           }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/MultihomeIOSessionRequester.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/MultihomeIOSessionRequester.java
@@ -111,6 +111,9 @@ final class MultihomeIOSessionRequester {
         final InetAddress[] remoteAddresses;
         try {
             remoteAddresses = dnsResolver.resolve(remoteEndpoint.getHostName());
+            if (remoteAddresses == null || remoteAddresses.length == 0) {
+              throw new UnknownHostException(remoteEndpoint.getHostName());
+            }
         } catch (final UnknownHostException ex) {
             future.failed(ex);
             return future;


### PR DESCRIPTION
Make sure an `UnknownHostException` is thrown, even if a custom `DnsResolver` implementation is used.
Fixes the issue of HTTPCLIENT-2314