### PR TITLE
Allow backwards-compatible createSocket calls

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/socket/PlainConnectionSocketFactory.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/socket/PlainConnectionSocketFactory.java
@@ -63,7 +63,7 @@ public class PlainConnectionSocketFactory implements ConnectionSocketFactory {
 
     @Override
     public Socket createSocket(final Proxy proxy, final HttpContext context) throws IOException {
-        return proxy != null ? new Socket(proxy) : new Socket();
+        return proxy != null ? new Socket(proxy) : createSocket(context);
     }
 
     @Override

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/SSLConnectionSocketFactory.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/SSLConnectionSocketFactory.java
@@ -206,7 +206,7 @@ public class SSLConnectionSocketFactory implements LayeredConnectionSocketFactor
 
     @Override
     public Socket createSocket(final Proxy proxy, final HttpContext context) throws IOException {
-        return proxy != null ? new Socket(proxy) : new Socket();
+        return proxy != null ? new Socket(proxy) : createSocket(context);
     }
 
     @Override


### PR DESCRIPTION
In order to allow for backwards-compatibility with projects that override/extend the existing plain and ssl connection factories, we'll specify the createSocket(Proxy, HttpContext) method to call the original createSocket method when proxy is null.