### PR TITLE
Use MessageDigest.isEquals method when comparing signatures in NTLMEn…

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/NTLMEngineImpl.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/NTLMEngineImpl.java
@@ -926,7 +926,7 @@ final class NTLMEngineImpl implements NTLMEngine {
             //            log.info( "SSSSS validateSignature("+seqNumber+")\n"
             //                + "  received: " + DebugUtil.dump( signature ) + "\n"
             //                + "  computed: " + DebugUtil.dump( computedSignature ) );
-            return Arrays.equals( signature, computedSignature );
+            return MessageDigest.isEqual( signature, computedSignature );
         }
 
         public byte[] signAndEncryptMessage( final byte[] cleartextMessage ) throws NTLMEngineException


### PR DESCRIPTION
…gineImpl

Just a minor finding. It's true that timing attack is not applicable here, but it's a best practice to use MessageDigest.isEqual for this cases.