### PR TITLE
HTTPCLIENT-751:  Support for RFC 2817 (Upgrading to TLS Within HTTP/1.1)

### DIFF
--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestClientRequestExecution.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestClientRequestExecution.java
@@ -57,6 +57,7 @@ import org.apache.hc.core5.http.URIScheme;
 import org.apache.hc.core5.http.impl.io.HttpRequestExecutor;
 import org.apache.hc.core5.http.io.HttpClientConnection;
 import org.apache.hc.core5.http.io.HttpRequestHandler;
+import org.apache.hc.core5.http.io.HttpResponseInformationCallback;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.io.entity.InputStreamEntity;
 import org.apache.hc.core5.http.io.entity.StringEntity;
@@ -137,8 +138,17 @@ public abstract class TestClientRequestExecution {
                 final ClassicHttpRequest request,
                 final HttpClientConnection conn,
                 final HttpContext context) throws IOException, HttpException {
+            return execute(request, conn, null, context);
+        }
 
-            final ClassicHttpResponse response = super.execute(request, conn, context);
+        @Override
+        public ClassicHttpResponse execute(
+                final ClassicHttpRequest request,
+                final HttpClientConnection conn,
+                final HttpResponseInformationCallback informationCallback,
+                final HttpContext context) throws IOException, HttpException {
+
+            final ClassicHttpResponse response = super.execute(request, conn, informationCallback, context);
             final Object marker = context.getAttribute(MARKER);
             if (marker == null) {
                 context.setAttribute(MARKER, Boolean.TRUE);

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/EndpointInfo.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/EndpointInfo.java
@@ -1,0 +1,64 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.client5.http;
+
+import javax.net.ssl.SSLSession;
+
+import org.apache.hc.core5.annotation.Internal;
+import org.apache.hc.core5.http.ProtocolVersion;
+
+/**
+ * @since 5.4
+ */
+public final class EndpointInfo {
+
+    private final ProtocolVersion protocol;
+    private final SSLSession sslSession;
+
+    @Internal
+    public EndpointInfo(final ProtocolVersion protocol, final SSLSession sslSession) {
+        this.protocol = protocol;
+        this.sslSession = sslSession;
+    }
+
+    public ProtocolVersion getProtocol() {
+        return protocol;
+    }
+
+    public SSLSession getSslSession() {
+        return sslSession;
+    }
+
+    @Override
+    public String toString() {
+        return "EndpointInfo{" +
+                "protocol=" + protocol +
+                ", sslSession=" + sslSession +
+                '}';
+    }
+
+}

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/async/AsyncExecRuntime.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/async/AsyncExecRuntime.java
@@ -27,6 +27,7 @@
 
 package org.apache.hc.client5.http.async;
 
+import org.apache.hc.client5.http.EndpointInfo;
 import org.apache.hc.client5.http.HttpRoute;
 import org.apache.hc.client5.http.protocol.HttpClientContext;
 import org.apache.hc.core5.annotation.Internal;
@@ -131,6 +132,13 @@ public interface AsyncExecRuntime {
         if (callback != null) {
             callback.completed(this);
         }
+    }
+
+    /**
+     * Returns information about the underlying endpoint when connected or {@code null} otherwise.
+     */
+    default EndpointInfo getEndpointInfo() {
+        return null;
     }
 
     /**

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/classic/ExecRuntime.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/classic/ExecRuntime.java
@@ -29,6 +29,7 @@ package org.apache.hc.client5.http.classic;
 
 import java.io.IOException;
 
+import org.apache.hc.client5.http.EndpointInfo;
 import org.apache.hc.client5.http.HttpRoute;
 import org.apache.hc.client5.http.protocol.HttpClientContext;
 import org.apache.hc.core5.annotation.Internal;
@@ -120,6 +121,13 @@ public interface ExecRuntime {
      * @param context the execution context.
      */
     void upgradeTls(HttpClientContext context) throws IOException;
+
+    /**
+     * Returns information about the underlying endpoint when connected or {@code null} otherwise.
+     */
+    default EndpointInfo getEndpointInfo() {
+        return null;
+    }
 
     /**
      * Executes HTTP request using the given context.

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/classic/ExecRuntime.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/classic/ExecRuntime.java
@@ -37,6 +37,7 @@ import org.apache.hc.core5.concurrent.CancellableDependency;
 import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.HttpException;
+import org.apache.hc.core5.http.io.HttpResponseInformationCallback;
 import org.apache.hc.core5.util.TimeValue;
 
 /**
@@ -140,6 +141,24 @@ public interface ExecRuntime {
             String id,
             ClassicHttpRequest request,
             HttpClientContext context) throws IOException, HttpException;
+
+    /**
+     * Executes HTTP request using the given context.
+     *
+     * @param id unique operation ID or {@code null}.
+     * @param request the request message.
+     * @param informationCallback information (1xx) response handler
+     * @param context the execution context.
+     *
+     * @since 5.4
+     */
+    default ClassicHttpResponse execute(
+            String id,
+            ClassicHttpRequest request,
+            HttpResponseInformationCallback informationCallback,
+            HttpClientContext context) throws IOException, HttpException {
+        return execute(id, request, context);
+    }
 
     /**
      * Determines of the connection is considered re-usable.

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/config/RequestConfig.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/config/RequestConfig.java
@@ -62,13 +62,14 @@ public class RequestConfig implements Cloneable {
     private final TimeValue connectionKeepAlive;
     private final boolean contentCompressionEnabled;
     private final boolean hardCancellationEnabled;
+    private final boolean protocolUpgradeEnabled;
 
     /**
      * Intended for CDI compatibility
     */
     protected RequestConfig() {
         this(false, null, null, false, false, 0, false, null, null,
-                DEFAULT_CONNECTION_REQUEST_TIMEOUT, null, null, DEFAULT_CONN_KEEP_ALIVE, false, false);
+                DEFAULT_CONNECTION_REQUEST_TIMEOUT, null, null, DEFAULT_CONN_KEEP_ALIVE, false, false, false);
     }
 
     RequestConfig(
@@ -86,7 +87,8 @@ public class RequestConfig implements Cloneable {
             final Timeout responseTimeout,
             final TimeValue connectionKeepAlive,
             final boolean contentCompressionEnabled,
-            final boolean hardCancellationEnabled) {
+            final boolean hardCancellationEnabled,
+            final boolean protocolUpgradeEnabled) {
         super();
         this.expectContinueEnabled = expectContinueEnabled;
         this.proxy = proxy;
@@ -103,6 +105,7 @@ public class RequestConfig implements Cloneable {
         this.connectionKeepAlive = connectionKeepAlive;
         this.contentCompressionEnabled = contentCompressionEnabled;
         this.hardCancellationEnabled = hardCancellationEnabled;
+        this.protocolUpgradeEnabled = protocolUpgradeEnabled;
     }
 
     /**
@@ -217,6 +220,13 @@ public class RequestConfig implements Cloneable {
         return hardCancellationEnabled;
     }
 
+    /**
+     * @see Builder#setProtocolUpgradeEnabled(boolean) (boolean)
+     */
+    public boolean isProtocolUpgradeEnabled() {
+        return protocolUpgradeEnabled;
+    }
+
     @Override
     protected RequestConfig clone() throws CloneNotSupportedException {
         return (RequestConfig) super.clone();
@@ -241,6 +251,7 @@ public class RequestConfig implements Cloneable {
         builder.append(", connectionKeepAlive=").append(connectionKeepAlive);
         builder.append(", contentCompressionEnabled=").append(contentCompressionEnabled);
         builder.append(", hardCancellationEnabled=").append(hardCancellationEnabled);
+        builder.append(", protocolUpgradeEnabled=").append(protocolUpgradeEnabled);
         builder.append("]");
         return builder.toString();
     }
@@ -265,7 +276,8 @@ public class RequestConfig implements Cloneable {
             .setResponseTimeout(config.getResponseTimeout())
             .setConnectionKeepAlive(config.getConnectionKeepAlive())
             .setContentCompressionEnabled(config.isContentCompressionEnabled())
-            .setHardCancellationEnabled(config.isHardCancellationEnabled());
+            .setHardCancellationEnabled(config.isHardCancellationEnabled())
+            .setProtocolUpgradeEnabled(config.isProtocolUpgradeEnabled());
     }
 
     public static class Builder {
@@ -285,6 +297,7 @@ public class RequestConfig implements Cloneable {
         private TimeValue connectionKeepAlive;
         private boolean contentCompressionEnabled;
         private boolean hardCancellationEnabled;
+        private boolean protocolUpgradeEnabled;
 
         Builder() {
             super();
@@ -294,6 +307,7 @@ public class RequestConfig implements Cloneable {
             this.connectionRequestTimeout = DEFAULT_CONNECTION_REQUEST_TIMEOUT;
             this.contentCompressionEnabled = true;
             this.hardCancellationEnabled = true;
+            this.protocolUpgradeEnabled = true;
         }
 
         /**
@@ -570,6 +584,23 @@ public class RequestConfig implements Cloneable {
             return this;
         }
 
+        /**
+         * Determines whether the client server should automatically attempt to upgrade
+         * to a safer or a newer version of the protocol, whenever possible.
+         * <p>
+         * Presently supported: HTTP/1.1 TLS upgrade
+         * </p>
+         * <p>
+         * Default: {@code true}
+         * </p>
+         *
+         * @since 5.4
+         */
+        public Builder setProtocolUpgradeEnabled(final boolean protocolUpgradeEnabled) {
+            this.protocolUpgradeEnabled = protocolUpgradeEnabled;
+            return this;
+        }
+
         public RequestConfig build() {
             return new RequestConfig(
                     expectContinueEnabled,
@@ -586,7 +617,8 @@ public class RequestConfig implements Cloneable {
                     responseTimeout,
                     connectionKeepAlive != null ? connectionKeepAlive : DEFAULT_CONN_KEEP_ALIVE,
                     contentCompressionEnabled,
-                    hardCancellationEnabled);
+                    hardCancellationEnabled,
+                    protocolUpgradeEnabled);
         }
 
     }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/ProtocolSwitchStrategy.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/ProtocolSwitchStrategy.java
@@ -1,0 +1,75 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.client5.http.impl;
+
+import java.util.Iterator;
+
+import org.apache.hc.core5.annotation.Internal;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.HttpMessage;
+import org.apache.hc.core5.http.ParseException;
+import org.apache.hc.core5.http.ProtocolException;
+import org.apache.hc.core5.http.ProtocolVersion;
+import org.apache.hc.core5.http.message.MessageSupport;
+import org.apache.hc.core5.http.ssl.TLS;
+
+/**
+ * Protocol switch handler.
+ *
+ * @since 5.4
+ */
+@Internal
+public final class ProtocolSwitchStrategy {
+
+    enum ProtocolSwitch { FAILURE, TLS }
+
+    public ProtocolVersion switchProtocol(final HttpMessage response) throws ProtocolException  {
+        final Iterator<String> it = MessageSupport.iterateTokens(response, HttpHeaders.UPGRADE);
+
+        ProtocolVersion tlsUpgrade = null;
+        while (it.hasNext()) {
+            final String token = it.next();
+            if (token.startsWith("TLS")) {
+                // TODO: Improve handling of HTTP protocol token once HttpVersion has a #parse method
+                try {
+                    tlsUpgrade = token.length() == 3 ? TLS.V_1_2.getVersion() : TLS.parse(token.replace("TLS/", "TLSv"));
+                } catch (final ParseException ex) {
+                    throw new ProtocolException("Invalid protocol: " + token);
+                }
+            } else if (token.equals("HTTP/1.1")) {
+                // TODO: Improve handling of HTTP protocol token once HttpVersion has a #parse method
+            } else {
+                throw new ProtocolException("Unsupported protocol: " + token);
+            }
+        }
+        if (tlsUpgrade == null) {
+            throw new ProtocolException("Invalid protocol switch response");
+        }
+        return tlsUpgrade;
+    }
+
+}

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncClientBuilder.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncClientBuilder.java
@@ -76,6 +76,7 @@ import org.apache.hc.client5.http.protocol.RedirectStrategy;
 import org.apache.hc.client5.http.protocol.RequestAddCookies;
 import org.apache.hc.client5.http.protocol.RequestDefaultHeaders;
 import org.apache.hc.client5.http.protocol.RequestExpectContinue;
+import org.apache.hc.client5.http.protocol.RequestUpgrade;
 import org.apache.hc.client5.http.protocol.RequestValidateTrace;
 import org.apache.hc.client5.http.protocol.ResponseProcessCookies;
 import org.apache.hc.client5.http.routing.HttpRoutePlanner;
@@ -843,7 +844,8 @@ public class HttpAsyncClientBuilder {
                 new H2RequestContent(),
                 new H2RequestConnControl(),
                 new RequestUserAgent(userAgentCopy),
-                new RequestExpectContinue());
+                new RequestExpectContinue(),
+                new RequestUpgrade());
         if (!cookieManagementDisabled) {
             b.add(RequestAddCookies.INSTANCE);
         }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalH2AsyncExecRuntime.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalH2AsyncExecRuntime.java
@@ -30,6 +30,7 @@ package org.apache.hc.client5.http.impl.async;
 import java.io.InterruptedIOException;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.apache.hc.client5.http.EndpointInfo;
 import org.apache.hc.client5.http.HttpRoute;
 import org.apache.hc.client5.http.async.AsyncExecRuntime;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -48,6 +49,8 @@ import org.apache.hc.core5.http.nio.command.RequestExecutionCommand;
 import org.apache.hc.core5.io.CloseMode;
 import org.apache.hc.core5.reactor.Command;
 import org.apache.hc.core5.reactor.IOSession;
+import org.apache.hc.core5.reactor.ssl.TlsDetails;
+import org.apache.hc.core5.reactor.ssl.TransportSecurityLayer;
 import org.apache.hc.core5.util.Identifiable;
 import org.apache.hc.core5.util.TimeValue;
 import org.apache.hc.core5.util.Timeout;
@@ -231,6 +234,17 @@ class InternalH2AsyncExecRuntime implements AsyncExecRuntime {
     @Override
     public void upgradeTls(final HttpClientContext context, final FutureCallback<AsyncExecRuntime> callback) {
         throw new UnsupportedOperationException();
+    }
+
+    public EndpointInfo getEndpointInfo() {
+        final Endpoint endpoint = sessionRef.get();
+        if (endpoint != null && endpoint.session.isOpen()) {
+            if (endpoint.session instanceof TransportSecurityLayer) {
+                final TlsDetails tlsDetails = ((TransportSecurityLayer) endpoint.session).getTlsDetails();
+                return new EndpointInfo(HttpVersion.HTTP_2, tlsDetails != null ? tlsDetails.getSSLSession() : null);
+            }
+        }
+        return null;
     }
 
     @Override

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalHttpAsyncExecRuntime.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalHttpAsyncExecRuntime.java
@@ -30,6 +30,7 @@ package org.apache.hc.client5.http.impl.async;
 import java.io.InterruptedIOException;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.apache.hc.client5.http.EndpointInfo;
 import org.apache.hc.client5.http.HttpRoute;
 import org.apache.hc.client5.http.async.AsyncExecRuntime;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -264,6 +265,11 @@ class InternalHttpAsyncExecRuntime implements AsyncExecRuntime {
             }
 
         });
+    }
+
+    public EndpointInfo getEndpointInfo() {
+        final AsyncConnectionEndpoint endpoint = endpointRef.get();
+        return endpoint != null ? endpoint.getInfo() : null;
     }
 
     @Override

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/ConnectExec.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/ConnectExec.java
@@ -30,6 +30,7 @@ package org.apache.hc.client5.http.impl.classic;
 import java.io.IOException;
 
 import org.apache.hc.client5.http.AuthenticationStrategy;
+import org.apache.hc.client5.http.EndpointInfo;
 import org.apache.hc.client5.http.HttpRoute;
 import org.apache.hc.client5.http.RouteTracker;
 import org.apache.hc.client5.http.SchemePortResolver;
@@ -62,6 +63,7 @@ import org.apache.hc.core5.http.Method;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.message.BasicClassicHttpRequest;
 import org.apache.hc.core5.http.message.StatusLine;
+import org.apache.hc.core5.http.protocol.HttpCoreContext;
 import org.apache.hc.core5.http.protocol.HttpProcessor;
 import org.apache.hc.core5.util.Args;
 import org.slf4j.Logger;
@@ -184,6 +186,11 @@ public final class ConnectExec implements ExecChainHandler {
                     }
 
                 } while (step > HttpRouteDirector.COMPLETE);
+            }
+            final EndpointInfo endpointInfo = execRuntime.getEndpointInfo();
+            if (endpointInfo != null) {
+                context.setProtocolVersion(endpointInfo.getProtocol());
+                context.setAttribute(HttpCoreContext.SSL_SESSION, endpointInfo.getSslSession());
             }
             return chain.proceed(request, scope);
 

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/HttpClientBuilder.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/HttpClientBuilder.java
@@ -80,6 +80,7 @@ import org.apache.hc.client5.http.protocol.RequestAddCookies;
 import org.apache.hc.client5.http.protocol.RequestClientConnControl;
 import org.apache.hc.client5.http.protocol.RequestDefaultHeaders;
 import org.apache.hc.client5.http.protocol.RequestExpectContinue;
+import org.apache.hc.client5.http.protocol.RequestUpgrade;
 import org.apache.hc.client5.http.protocol.RequestValidateTrace;
 import org.apache.hc.client5.http.protocol.ResponseProcessCookies;
 import org.apache.hc.client5.http.routing.HttpRoutePlanner;
@@ -824,7 +825,8 @@ public class HttpClientBuilder {
                 new RequestContent(),
                 new RequestClientConnControl(),
                 new RequestUserAgent(userAgentCopy),
-                new RequestExpectContinue());
+                new RequestExpectContinue(),
+                new RequestUpgrade());
         if (!cookieManagementDisabled) {
             b.add(RequestAddCookies.INSTANCE);
         }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/InternalExecRuntime.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/InternalExecRuntime.java
@@ -48,6 +48,7 @@ import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.ConnectionRequestTimeoutException;
 import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.impl.io.HttpRequestExecutor;
+import org.apache.hc.core5.http.io.HttpResponseInformationCallback;
 import org.apache.hc.core5.io.CloseMode;
 import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.TimeValue;
@@ -205,6 +206,15 @@ class InternalExecRuntime implements ExecRuntime, Cancellable {
             final String id,
             final ClassicHttpRequest request,
             final HttpClientContext context) throws IOException, HttpException {
+        return execute(id, request, null, context);
+    }
+
+    @Override
+    public ClassicHttpResponse execute(
+            final String id,
+            final ClassicHttpRequest request,
+            final HttpResponseInformationCallback informationCallback,
+            final HttpClientContext context) throws IOException, HttpException {
         final ConnectionEndpoint endpoint = ensureValid();
         if (!endpoint.isConnected()) {
             connectEndpoint(endpoint, context);
@@ -223,7 +233,7 @@ class InternalExecRuntime implements ExecRuntime, Cancellable {
         return endpoint.execute(
                 id,
                 request,
-                requestExecutor::execute,
+                (r, conn, c) -> requestExecutor.execute(r, conn, informationCallback, c),
                 context);
     }
 

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/InternalExecRuntime.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/InternalExecRuntime.java
@@ -32,6 +32,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.apache.hc.client5.http.EndpointInfo;
 import org.apache.hc.client5.http.HttpRoute;
 import org.apache.hc.client5.http.classic.ExecRuntime;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -191,6 +192,12 @@ class InternalExecRuntime implements ExecRuntime, Cancellable {
             log.debug("{} upgrading endpoint", ConnPoolSupport.getId(endpoint));
         }
         manager.upgrade(endpoint, context);
+    }
+
+    @Override
+    public EndpointInfo getEndpointInfo() {
+        final ConnectionEndpoint endpoint = endpointRef.get();
+        return endpoint != null ? endpoint.getInfo() : null;
     }
 
     @Override

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/MainClientExec.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/MainClientExec.java
@@ -113,7 +113,7 @@ public final class MainClientExec implements ExecChainHandler {
 
             httpProcessor.process(request, request.getEntity(), context);
 
-            final ClassicHttpResponse response = execRuntime.execute(exchangeId, request, context);
+            final ClassicHttpResponse response = execRuntime.execute(exchangeId, request, null, context);
 
             context.setAttribute(HttpCoreContext.HTTP_RESPONSE, response);
             httpProcessor.process(response, response.getEntity(), context);

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/BasicHttpClientConnectionManager.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/BasicHttpClientConnectionManager.java
@@ -38,6 +38,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 
 import org.apache.hc.client5.http.DnsResolver;
+import org.apache.hc.client5.http.EndpointInfo;
 import org.apache.hc.client5.http.HttpRoute;
 import org.apache.hc.client5.http.SchemePortResolver;
 import org.apache.hc.client5.http.config.ConnectionConfig;
@@ -682,6 +683,18 @@ public class BasicHttpClientConnectionManager implements HttpClientConnectionMan
                 LOG.debug("{} Executing exchange {}", id, exchangeId);
             }
             return requestExecutor.execute(request, getValidatedConnection(), context);
+        }
+
+        /**
+         * @since 5.4
+         */
+        @Override
+        public EndpointInfo getInfo() {
+            final ManagedHttpClientConnection connection = this.connRef.get();
+            if (connection != null && connection.isOpen()) {
+                return new EndpointInfo(connection.getProtocolVersion(), connection.getSSLSession());
+            }
+            return null;
         }
 
     }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/DefaultHttpClientConnectionOperator.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/DefaultHttpClientConnectionOperator.java
@@ -53,6 +53,7 @@ import org.apache.hc.core5.annotation.Internal;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.http.ConnectionClosedException;
 import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.URIScheme;
 import org.apache.hc.core5.http.config.Lookup;
 import org.apache.hc.core5.http.io.SocketConfig;
 import org.apache.hc.core5.http.protocol.HttpContext;
@@ -184,7 +185,7 @@ public class DefaultHttpClientConnectionOperator implements HttpClientConnection
         final Timeout soTimeout = socketConfig.getSoTimeout();
         final SocketAddress socksProxyAddress = socketConfig.getSocksProxyAddress();
         final Proxy socksProxy = socksProxyAddress != null ? new Proxy(Proxy.Type.SOCKS, socksProxyAddress) : null;
-        final int port = this.schemePortResolver.resolve(host);
+        final int port = this.schemePortResolver.resolve(host.getSchemeName(), host);
         for (int i = 0; i < remoteAddresses.length; i++) {
             final InetAddress address = remoteAddresses[i];
             final boolean last = i == remoteAddresses.length - 1;
@@ -269,13 +270,14 @@ public class DefaultHttpClientConnectionOperator implements HttpClientConnection
         if (socket == null) {
             throw new ConnectionClosedException("Connection is closed");
         }
-        final TlsSocketStrategy tlsSocketStrategy = tlsSocketStrategyLookup != null ? tlsSocketStrategyLookup.lookup(host.getSchemeName()) : null;
+        final String newProtocol = URIScheme.HTTP.same(host.getSchemeName()) ? URIScheme.HTTPS.id : host.getSchemeName();
+        final TlsSocketStrategy tlsSocketStrategy = tlsSocketStrategyLookup != null ? tlsSocketStrategyLookup.lookup(newProtocol) : null;
         if (tlsSocketStrategy != null) {
-            final int port = this.schemePortResolver.resolve(host);
+            final int port = this.schemePortResolver.resolve(newProtocol, host);
             final SSLSocket upgradedSocket = tlsSocketStrategy.upgrade(socket, host.getHostName(), port, attachment, context);
             conn.bind(upgradedSocket);
         } else {
-            throw new UnsupportedSchemeException(host.getSchemeName() + " protocol is not supported");
+            throw new UnsupportedSchemeException(newProtocol + " protocol is not supported");
         }
     }
 

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java
@@ -36,6 +36,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 
 import org.apache.hc.client5.http.DnsResolver;
+import org.apache.hc.client5.http.EndpointInfo;
 import org.apache.hc.client5.http.HttpRoute;
 import org.apache.hc.client5.http.SchemePortResolver;
 import org.apache.hc.client5.http.config.ConnectionConfig;
@@ -773,5 +774,21 @@ public class PoolingHttpClientConnectionManager
             return requestExecutor.execute(request, connection, context);
         }
 
+        /**
+         * @since 5.4
+         */
+        @Override
+        public EndpointInfo getInfo() {
+            final PoolEntry<HttpRoute, ManagedHttpClientConnection> poolEntry = poolEntryRef.get();
+            if (poolEntry != null) {
+                final ManagedHttpClientConnection connection = poolEntry.getConnection();
+                if (connection != null && connection.isOpen()) {
+                    return new EndpointInfo(connection.getProtocolVersion(), connection.getSSLSession());
+                }
+            }
+            return null;
+        }
+
     }
+
 }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java
@@ -505,10 +505,9 @@ public class PoolingHttpClientConnectionManager
         Args.notNull(endpoint, "Managed endpoint");
         final InternalConnectionEndpoint internalEndpoint = cast(endpoint);
         final PoolEntry<HttpRoute, ManagedHttpClientConnection> poolEntry = internalEndpoint.getValidatedPoolEntry();
-        final HttpRoute route = poolEntry.getRoute();
-        final HttpHost host = route.getProxyHost() != null ? route.getProxyHost() : route.getTargetHost();
-        final TlsConfig tlsConfig = resolveTlsConfig(host);
-        this.connectionOperator.upgrade(poolEntry.getConnection(), route.getTargetHost(), tlsConfig, context);
+        final HttpHost target = poolEntry.getRoute().getTargetHost();
+        final TlsConfig tlsConfig = resolveTlsConfig(target);
+        this.connectionOperator.upgrade(poolEntry.getConnection(), target, tlsConfig, context);
     }
 
     @Override

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java
@@ -37,6 +37,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.hc.client5.http.DnsResolver;
+import org.apache.hc.client5.http.EndpointInfo;
 import org.apache.hc.client5.http.HttpRoute;
 import org.apache.hc.client5.http.SchemePortResolver;
 import org.apache.hc.client5.http.config.ConnectionConfig;
@@ -750,6 +751,19 @@ public class PoolingAsyncClientConnectionManager implements AsyncClientConnectio
             connection.submitCommand(
                     new RequestExecutionCommand(exchangeHandler, pushHandlerFactory, context),
                     Command.Priority.NORMAL);
+        }
+
+        @Override
+        public EndpointInfo getInfo() {
+            final PoolEntry<HttpRoute, ManagedAsyncClientConnection> poolEntry = poolEntryRef.get();
+            if (poolEntry != null) {
+                final ManagedAsyncClientConnection connection = poolEntry.getConnection();
+                if (connection != null && connection.isOpen()) {
+                    final TlsDetails tlsDetails = connection.getTlsDetails();
+                    return new EndpointInfo(connection.getProtocolVersion(), tlsDetails != null ? tlsDetails.getSSLSession() : null);
+                }
+            }
+            return null;
         }
 
     }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/io/ConnectionEndpoint.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/io/ConnectionEndpoint.java
@@ -29,6 +29,7 @@ package org.apache.hc.client5.http.io;
 
 import java.io.IOException;
 
+import org.apache.hc.client5.http.EndpointInfo;
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.Internal;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
@@ -96,6 +97,15 @@ public abstract class ConnectionEndpoint implements ModalCloseable {
      * @param timeout timeout value
      */
     public abstract void setSocketTimeout(Timeout timeout);
+
+    /**
+     * Returns information about the endpoint or {@code null} when not connected.
+     *
+     * @since 5.4
+     */
+    public EndpointInfo getInfo() {
+        return null;
+    }
 
     /**
      * @since 5.4

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/nio/AsyncConnectionEndpoint.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/nio/AsyncConnectionEndpoint.java
@@ -30,6 +30,7 @@ package org.apache.hc.client5.http.nio;
 import java.io.IOException;
 import java.util.concurrent.Future;
 
+import org.apache.hc.client5.http.EndpointInfo;
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.concurrent.BasicFuture;
@@ -199,6 +200,15 @@ public abstract class AsyncConnectionEndpoint implements ModalCloseable {
             final AsyncResponseConsumer<T> responseConsumer,
             final FutureCallback<T> callback) {
         return execute(id, requestProducer, responseConsumer, null, null, callback);
+    }
+
+    /**
+     * Returns information about the endpoint or {@code null} when not connected.
+     *
+     * @since 5.4
+     */
+    public EndpointInfo getInfo() {
+        return null;
     }
 
 }

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/TestProtocolSwitchStrategy.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/TestProtocolSwitchStrategy.java
@@ -1,0 +1,98 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.client5.http.impl;
+
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.ProtocolException;
+import org.apache.hc.core5.http.message.BasicHttpResponse;
+import org.apache.hc.core5.http.ssl.TLS;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Simple tests for {@link DefaultAuthenticationStrategy}.
+ */
+public class TestProtocolSwitchStrategy {
+
+    ProtocolSwitchStrategy switchStrategy;
+
+    @BeforeEach
+    void setUp() {
+        switchStrategy = new ProtocolSwitchStrategy();
+    }
+
+    @Test
+    public void testSwitchToTLS() throws Exception {
+        final HttpResponse response1 = new BasicHttpResponse(HttpStatus.SC_SWITCHING_PROTOCOLS);
+        response1.addHeader(HttpHeaders.UPGRADE, "TLS");
+        Assertions.assertEquals(TLS.V_1_2.getVersion(), switchStrategy.switchProtocol(response1));
+
+        final HttpResponse response2 = new BasicHttpResponse(HttpStatus.SC_SWITCHING_PROTOCOLS);
+        response2.addHeader(HttpHeaders.UPGRADE, "TLS/1.3");
+        Assertions.assertEquals(TLS.V_1_3.getVersion(), switchStrategy.switchProtocol(response2));
+    }
+
+    @Test
+    public void testSwitchToHTTP11AndTLS() throws Exception {
+        final HttpResponse response1 = new BasicHttpResponse(HttpStatus.SC_SWITCHING_PROTOCOLS);
+        response1.addHeader(HttpHeaders.UPGRADE, "TLS, HTTP/1.1");
+        Assertions.assertEquals(TLS.V_1_2.getVersion(), switchStrategy.switchProtocol(response1));
+
+        final HttpResponse response2 = new BasicHttpResponse(HttpStatus.SC_SWITCHING_PROTOCOLS);
+        response2.addHeader(HttpHeaders.UPGRADE, ",, HTTP/1.1, TLS, ");
+        Assertions.assertEquals(TLS.V_1_2.getVersion(), switchStrategy.switchProtocol(response2));
+
+        final HttpResponse response3 = new BasicHttpResponse(HttpStatus.SC_SWITCHING_PROTOCOLS);
+        response3.addHeader(HttpHeaders.UPGRADE, "HTTP/1.1");
+        response3.addHeader(HttpHeaders.UPGRADE, "TLS/1.2");
+        Assertions.assertEquals(TLS.V_1_2.getVersion(), switchStrategy.switchProtocol(response3));
+
+        final HttpResponse response4 = new BasicHttpResponse(HttpStatus.SC_SWITCHING_PROTOCOLS);
+        response4.addHeader(HttpHeaders.UPGRADE, "HTTP/1.1");
+        response4.addHeader(HttpHeaders.UPGRADE, "TLS/1.2, TLS/1.3");
+        Assertions.assertEquals(TLS.V_1_3.getVersion(), switchStrategy.switchProtocol(response4));
+    }
+
+    @Test
+    public void testSwitchInvalid() throws Exception {
+        final HttpResponse response1 = new BasicHttpResponse(HttpStatus.SC_SWITCHING_PROTOCOLS);
+        response1.addHeader(HttpHeaders.UPGRADE, "Crap");
+        Assertions.assertThrows(ProtocolException.class, () -> switchStrategy.switchProtocol(response1));
+
+        final HttpResponse response2 = new BasicHttpResponse(HttpStatus.SC_SWITCHING_PROTOCOLS);
+        response2.addHeader(HttpHeaders.UPGRADE, "TLS, huh?");
+        Assertions.assertThrows(ProtocolException.class, () -> switchStrategy.switchProtocol(response2));
+
+        final HttpResponse response3 = new BasicHttpResponse(HttpStatus.SC_SWITCHING_PROTOCOLS);
+        response3.addHeader(HttpHeaders.UPGRADE, ",,,");
+        Assertions.assertThrows(ProtocolException.class, () -> switchStrategy.switchProtocol(response3));
+    }
+
+}

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/classic/TestMainClientExec.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/classic/TestMainClientExec.java
@@ -97,13 +97,14 @@ public class TestMainClientExec {
         Mockito.when(execRuntime.execute(
                 Mockito.anyString(),
                 Mockito.same(request),
+                Mockito.any(),
                 Mockito.any())).thenReturn(response);
 
         final ExecChain.Scope scope = new ExecChain.Scope("test", route, request, execRuntime, context);
         final ClassicHttpResponse finalResponse = mainClientExec.execute(request, scope, null);
 
         Mockito.verify(httpProcessor).process(request, null, context);
-        Mockito.verify(execRuntime).execute("test", request, context);
+        Mockito.verify(execRuntime).execute("test", request, null, context);
         Mockito.verify(httpProcessor).process(response, responseEntity, context);
 
         Assertions.assertEquals(route, context.getHttpRoute());
@@ -124,6 +125,7 @@ public class TestMainClientExec {
         Mockito.when(execRuntime.execute(
                 Mockito.anyString(),
                 Mockito.same(request),
+                Mockito.any(),
                 Mockito.any())).thenReturn(response);
         Mockito.when(reuseStrategy.keepAlive(
                 Mockito.same(request),
@@ -132,7 +134,7 @@ public class TestMainClientExec {
 
         final ExecChain.Scope scope = new ExecChain.Scope("test", route, request, execRuntime, context);
         final ClassicHttpResponse finalResponse = mainClientExec.execute(request, scope, null);
-        Mockito.verify(execRuntime).execute("test", request, context);
+        Mockito.verify(execRuntime).execute("test", request, null, context);
         Mockito.verify(execRuntime, Mockito.times(1)).markConnectionNonReusable();
         Mockito.verify(execRuntime, Mockito.never()).releaseEndpoint();
 
@@ -152,6 +154,7 @@ public class TestMainClientExec {
         Mockito.when(execRuntime.execute(
                 Mockito.anyString(),
                 Mockito.same(request),
+                Mockito.any(),
                 Mockito.any())).thenReturn(response);
         Mockito.when(reuseStrategy.keepAlive(
                 Mockito.same(request),
@@ -161,7 +164,7 @@ public class TestMainClientExec {
         final ExecChain.Scope scope = new ExecChain.Scope("test", route, request, execRuntime, context);
         final ClassicHttpResponse finalResponse = mainClientExec.execute(request, scope, null);
 
-        Mockito.verify(execRuntime).execute("test", request, context);
+        Mockito.verify(execRuntime).execute("test", request, null, context);
         Mockito.verify(execRuntime).markConnectionNonReusable();
         Mockito.verify(execRuntime).releaseEndpoint();
 
@@ -184,6 +187,7 @@ public class TestMainClientExec {
         Mockito.when(execRuntime.execute(
                 Mockito.anyString(),
                 Mockito.same(request),
+                Mockito.any(),
                 Mockito.any())).thenReturn(response);
         Mockito.when(reuseStrategy.keepAlive(
                 Mockito.same(request),
@@ -196,7 +200,7 @@ public class TestMainClientExec {
         final ExecChain.Scope scope = new ExecChain.Scope("test", route, request, execRuntime, context);
         final ClassicHttpResponse finalResponse = mainClientExec.execute(request, scope, null);
 
-        Mockito.verify(execRuntime).execute("test", request, context);
+        Mockito.verify(execRuntime).execute("test", request, null, context);
         Mockito.verify(execRuntime).markConnectionReusable(null, TimeValue.ofMilliseconds(678L));
         Mockito.verify(execRuntime, Mockito.never()).releaseEndpoint();
 
@@ -214,6 +218,7 @@ public class TestMainClientExec {
         Mockito.when(execRuntime.execute(
                 Mockito.anyString(),
                 Mockito.same(request),
+                Mockito.any(),
                 Mockito.any())).thenReturn(response);
         Mockito.when(reuseStrategy.keepAlive(
                 Mockito.same(request),
@@ -226,7 +231,7 @@ public class TestMainClientExec {
         final ExecChain.Scope scope = new ExecChain.Scope("test", route, request, execRuntime, context);
         final ClassicHttpResponse finalResponse = mainClientExec.execute(request, scope, null);
 
-        Mockito.verify(execRuntime).execute("test", request, context);
+        Mockito.verify(execRuntime).execute("test", request, null, context);
         Mockito.verify(execRuntime).releaseEndpoint();
 
         Assertions.assertNotNull(finalResponse);
@@ -247,6 +252,7 @@ public class TestMainClientExec {
         Mockito.when(execRuntime.execute(
                 Mockito.anyString(),
                 Mockito.same(request),
+                Mockito.any(),
                 Mockito.any())).thenReturn(response);
         Mockito.when(reuseStrategy.keepAlive(
                 Mockito.same(request),
@@ -255,7 +261,7 @@ public class TestMainClientExec {
 
         final ExecChain.Scope scope = new ExecChain.Scope("test", route, request, execRuntime, context);
         final ClassicHttpResponse finalResponse = mainClientExec.execute(request, scope, null);
-        Mockito.verify(execRuntime, Mockito.times(1)).execute("test", request, context);
+        Mockito.verify(execRuntime, Mockito.times(1)).execute("test", request, null, context);
         Mockito.verify(execRuntime, Mockito.never()).disconnectEndpoint();
         Mockito.verify(execRuntime, Mockito.never()).releaseEndpoint();
 
@@ -276,6 +282,7 @@ public class TestMainClientExec {
         Mockito.when(execRuntime.execute(
                 Mockito.anyString(),
                 Mockito.same(request),
+                Mockito.any(),
                 Mockito.any())).thenThrow(new ConnectionShutdownException());
 
         final ExecChain.Scope scope = new ExecChain.Scope("test", route, request, execRuntime, context);
@@ -293,6 +300,7 @@ public class TestMainClientExec {
         Mockito.when(execRuntime.execute(
                 Mockito.anyString(),
                 Mockito.same(request),
+                Mockito.any(),
                 Mockito.any())).thenThrow(new RuntimeException("Ka-boom"));
 
         final ExecChain.Scope scope = new ExecChain.Scope("test", route, request, execRuntime, context);
@@ -310,6 +318,7 @@ public class TestMainClientExec {
         Mockito.when(execRuntime.execute(
                 Mockito.anyString(),
                 Mockito.same(request),
+                Mockito.any(),
                 Mockito.any())).thenThrow(new HttpException("Ka-boom"));
 
         final ExecChain.Scope scope = new ExecChain.Scope("test", route, request, execRuntime, context);
@@ -327,6 +336,7 @@ public class TestMainClientExec {
         Mockito.when(execRuntime.execute(
                 Mockito.anyString(),
                 Mockito.same(request),
+                Mockito.any(),
                 Mockito.any())).thenThrow(new IOException("Ka-boom"));
 
         final ExecChain.Scope scope = new ExecChain.Scope("test", route, request, execRuntime, context);

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/classic/TestMainClientExec.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/classic/TestMainClientExec.java
@@ -56,7 +56,6 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
-@SuppressWarnings({"boxing","static-access"}) // test code
 public class TestMainClientExec {
 
     @Mock
@@ -104,7 +103,7 @@ public class TestMainClientExec {
         final ClassicHttpResponse finalResponse = mainClientExec.execute(request, scope, null);
 
         Mockito.verify(httpProcessor).process(request, null, context);
-        Mockito.verify(execRuntime).execute("test", request, null, context);
+        Mockito.verify(execRuntime).execute(Mockito.eq("test"), Mockito.same(request), Mockito.any(), Mockito.any());
         Mockito.verify(httpProcessor).process(response, responseEntity, context);
 
         Assertions.assertEquals(route, context.getHttpRoute());
@@ -134,7 +133,7 @@ public class TestMainClientExec {
 
         final ExecChain.Scope scope = new ExecChain.Scope("test", route, request, execRuntime, context);
         final ClassicHttpResponse finalResponse = mainClientExec.execute(request, scope, null);
-        Mockito.verify(execRuntime).execute("test", request, null, context);
+        Mockito.verify(execRuntime).execute(Mockito.eq("test"), Mockito.same(request), Mockito.any(), Mockito.any());
         Mockito.verify(execRuntime, Mockito.times(1)).markConnectionNonReusable();
         Mockito.verify(execRuntime, Mockito.never()).releaseEndpoint();
 
@@ -164,7 +163,7 @@ public class TestMainClientExec {
         final ExecChain.Scope scope = new ExecChain.Scope("test", route, request, execRuntime, context);
         final ClassicHttpResponse finalResponse = mainClientExec.execute(request, scope, null);
 
-        Mockito.verify(execRuntime).execute("test", request, null, context);
+        Mockito.verify(execRuntime).execute(Mockito.eq("test"), Mockito.same(request), Mockito.any(), Mockito.any());
         Mockito.verify(execRuntime).markConnectionNonReusable();
         Mockito.verify(execRuntime).releaseEndpoint();
 
@@ -200,7 +199,7 @@ public class TestMainClientExec {
         final ExecChain.Scope scope = new ExecChain.Scope("test", route, request, execRuntime, context);
         final ClassicHttpResponse finalResponse = mainClientExec.execute(request, scope, null);
 
-        Mockito.verify(execRuntime).execute("test", request, null, context);
+        Mockito.verify(execRuntime).execute(Mockito.eq("test"), Mockito.same(request), Mockito.any(), Mockito.any());
         Mockito.verify(execRuntime).markConnectionReusable(null, TimeValue.ofMilliseconds(678L));
         Mockito.verify(execRuntime, Mockito.never()).releaseEndpoint();
 
@@ -231,7 +230,7 @@ public class TestMainClientExec {
         final ExecChain.Scope scope = new ExecChain.Scope("test", route, request, execRuntime, context);
         final ClassicHttpResponse finalResponse = mainClientExec.execute(request, scope, null);
 
-        Mockito.verify(execRuntime).execute("test", request, null, context);
+        Mockito.verify(execRuntime).execute(Mockito.eq("test"), Mockito.same(request), Mockito.any(), Mockito.any());
         Mockito.verify(execRuntime).releaseEndpoint();
 
         Assertions.assertNotNull(finalResponse);
@@ -261,7 +260,7 @@ public class TestMainClientExec {
 
         final ExecChain.Scope scope = new ExecChain.Scope("test", route, request, execRuntime, context);
         final ClassicHttpResponse finalResponse = mainClientExec.execute(request, scope, null);
-        Mockito.verify(execRuntime, Mockito.times(1)).execute("test", request, null, context);
+        Mockito.verify(execRuntime, Mockito.times(1)).execute(Mockito.eq("test"), Mockito.same(request), Mockito.any(), Mockito.any());
         Mockito.verify(execRuntime, Mockito.never()).disconnectEndpoint();
         Mockito.verify(execRuntime, Mockito.never()).releaseEndpoint();
 

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/io/TestBasicHttpClientConnectionManager.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/io/TestBasicHttpClientConnectionManager.java
@@ -385,7 +385,7 @@ public class TestBasicHttpClientConnectionManager {
         mgr.setTlsConfig(tlsConfig);
 
         Mockito.when(dnsResolver.resolve("somehost")).thenReturn(new InetAddress[] {remote});
-        Mockito.when(schemePortResolver.resolve(target)).thenReturn(8443);
+        Mockito.when(schemePortResolver.resolve(target.getSchemeName(), target)).thenReturn(8443);
         Mockito.when(detachedSocketFactory.create(Mockito.any())).thenReturn(socket);
 
         Mockito.when(tlsSocketStrategyLookup.lookup("https")).thenReturn(tlsSocketStrategy);
@@ -399,7 +399,7 @@ public class TestBasicHttpClientConnectionManager {
         mgr.connect(endpoint1, null, context);
 
         Mockito.verify(dnsResolver, Mockito.times(1)).resolve("somehost");
-        Mockito.verify(schemePortResolver, Mockito.times(1)).resolve(target);
+        Mockito.verify(schemePortResolver, Mockito.times(1)).resolve(target.getSchemeName(), target);
         Mockito.verify(detachedSocketFactory, Mockito.times(1)).create(null);
         Mockito.verify(socket, Mockito.times(1)).connect(new InetSocketAddress(remote, 8443), 234);
         Mockito.verify(tlsSocketStrategy).upgrade(socket, "somehost", 8443, tlsConfig, context);
@@ -407,7 +407,7 @@ public class TestBasicHttpClientConnectionManager {
         mgr.connect(endpoint1, TimeValue.ofMilliseconds(123), context);
 
         Mockito.verify(dnsResolver, Mockito.times(2)).resolve("somehost");
-        Mockito.verify(schemePortResolver, Mockito.times(2)).resolve(target);
+        Mockito.verify(schemePortResolver, Mockito.times(2)).resolve(target.getSchemeName(), target);
         Mockito.verify(detachedSocketFactory, Mockito.times(2)).create(null);
         Mockito.verify(socket, Mockito.times(1)).connect(new InetSocketAddress(remote, 8443), 123);
         Mockito.verify(tlsSocketStrategy, Mockito.times(2)).upgrade(socket, "somehost", 8443, tlsConfig, context);
@@ -442,15 +442,15 @@ public class TestBasicHttpClientConnectionManager {
         mgr.setTlsConfig(tlsConfig);
 
         Mockito.when(dnsResolver.resolve("someproxy")).thenReturn(new InetAddress[] {remote});
-        Mockito.when(schemePortResolver.resolve(proxy)).thenReturn(8080);
-        Mockito.when(schemePortResolver.resolve(target)).thenReturn(8443);
+        Mockito.when(schemePortResolver.resolve(proxy.getSchemeName(), proxy)).thenReturn(8080);
+        Mockito.when(schemePortResolver.resolve(target.getSchemeName(), target)).thenReturn(8443);
         Mockito.when(tlsSocketStrategyLookup.lookup("https")).thenReturn(tlsSocketStrategy);
         Mockito.when(detachedSocketFactory.create(Mockito.any())).thenReturn(socket);
 
         mgr.connect(endpoint1, null, context);
 
         Mockito.verify(dnsResolver, Mockito.times(1)).resolve("someproxy");
-        Mockito.verify(schemePortResolver, Mockito.times(1)).resolve(proxy);
+        Mockito.verify(schemePortResolver, Mockito.times(1)).resolve(proxy.getSchemeName(), proxy);
         Mockito.verify(detachedSocketFactory, Mockito.times(1)).create(null);
         Mockito.verify(socket, Mockito.times(1)).connect(new InetSocketAddress(remote, 8080), 234);
 
@@ -458,7 +458,7 @@ public class TestBasicHttpClientConnectionManager {
 
         mgr.upgrade(endpoint1, context);
 
-        Mockito.verify(schemePortResolver, Mockito.times(1)).resolve(target);
+        Mockito.verify(schemePortResolver, Mockito.times(1)).resolve(target.getSchemeName(), target);
         Mockito.verify(tlsSocketStrategy, Mockito.times(1)).upgrade(
                 socket, "somehost", 8443, tlsConfig, context);
     }

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/io/TestHttpClientConnectionOperator.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/io/TestHttpClientConnectionOperator.java
@@ -91,7 +91,7 @@ public class TestHttpClientConnectionOperator {
         final InetAddress ip2 = InetAddress.getByAddress(new byte[] {127, 0, 0, 2});
 
         Mockito.when(dnsResolver.resolve("somehost")).thenReturn(new InetAddress[] { ip1, ip2 });
-        Mockito.when(schemePortResolver.resolve(host)).thenReturn(80);
+        Mockito.when(schemePortResolver.resolve(host.getSchemeName(), host)).thenReturn(80);
         Mockito.when(detachedSocketFactory.create(Mockito.any())).thenReturn(socket);
 
         final SocketConfig socketConfig = SocketConfig.custom()
@@ -129,7 +129,7 @@ public class TestHttpClientConnectionOperator {
                 .build();
 
         Mockito.when(dnsResolver.resolve("somehost")).thenReturn(new InetAddress[] { ip1, ip2 });
-        Mockito.when(schemePortResolver.resolve(host)).thenReturn(443);
+        Mockito.when(schemePortResolver.resolve(host.getSchemeName(), host)).thenReturn(443);
         Mockito.when(detachedSocketFactory.create(Mockito.any())).thenReturn(socket);
 
         Mockito.when(tlsSocketStrategyLookup.lookup("https")).thenReturn(tlsSocketStrategy);
@@ -194,7 +194,7 @@ public class TestHttpClientConnectionOperator {
         final InetAddress ip2 = InetAddress.getByAddress(new byte[] {10, 0, 0, 2});
 
         Mockito.when(dnsResolver.resolve("somehost")).thenReturn(new InetAddress[] { ip1, ip2 });
-        Mockito.when(schemePortResolver.resolve(host)).thenReturn(80);
+        Mockito.when(schemePortResolver.resolve(host.getSchemeName(), host)).thenReturn(80);
         Mockito.when(detachedSocketFactory.create(Mockito.any())).thenReturn(socket);
         Mockito.doThrow(new ConnectException()).when(socket).connect(
                 Mockito.eq(new InetSocketAddress(ip1, 80)),
@@ -219,7 +219,7 @@ public class TestHttpClientConnectionOperator {
         final InetAddress ip = InetAddress.getByAddress(new byte[] {127, 0, 0, 23});
         final HttpHost host = new HttpHost(ip);
 
-        Mockito.when(schemePortResolver.resolve(host)).thenReturn(80);
+        Mockito.when(schemePortResolver.resolve(host.getSchemeName(), host)).thenReturn(80);
         Mockito.when(detachedSocketFactory.create(Mockito.any())).thenReturn(socket);
 
         final InetSocketAddress localAddress = new InetSocketAddress(local, 0);
@@ -242,7 +242,7 @@ public class TestHttpClientConnectionOperator {
         Mockito.when(conn.isOpen()).thenReturn(true);
         Mockito.when(conn.getSocket()).thenReturn(socket);
         Mockito.when(tlsSocketStrategyLookup.lookup("https")).thenReturn(tlsSocketStrategy);
-        Mockito.when(schemePortResolver.resolve(host)).thenReturn(443);
+        Mockito.when(schemePortResolver.resolve(host.getSchemeName(), host)).thenReturn(443);
 
         final SSLSocket upgradedSocket = Mockito.mock(SSLSocket.class);
         Mockito.when(tlsSocketStrategy.upgrade(

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/io/TestPoolingHttpClientConnectionManager.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/io/TestPoolingHttpClientConnectionManager.java
@@ -263,7 +263,7 @@ public class TestPoolingHttpClientConnectionManager {
         mgr.setDefaultTlsConfig(tlsConfig);
 
         Mockito.when(dnsResolver.resolve("somehost")).thenReturn(new InetAddress[]{remote});
-        Mockito.when(schemePortResolver.resolve(target)).thenReturn(8443);
+        Mockito.when(schemePortResolver.resolve(target.getSchemeName(), target)).thenReturn(8443);
         Mockito.when(detachedSocketFactory.create(Mockito.any())).thenReturn(socket);
 
         Mockito.when(tlsSocketStrategyLookup.lookup("https")).thenReturn(tlsSocketStrategy);
@@ -277,7 +277,7 @@ public class TestPoolingHttpClientConnectionManager {
         mgr.connect(endpoint1, null, context);
 
         Mockito.verify(dnsResolver, Mockito.times(1)).resolve("somehost");
-        Mockito.verify(schemePortResolver, Mockito.times(1)).resolve(target);
+        Mockito.verify(schemePortResolver, Mockito.times(1)).resolve(target.getSchemeName(), target);
         Mockito.verify(detachedSocketFactory, Mockito.times(1)).create(null);
         Mockito.verify(socket, Mockito.times(1)).connect(new InetSocketAddress(remote, 8443), 234);
         Mockito.verify(tlsSocketStrategy).upgrade(socket, "somehost", 8443, tlsConfig, context);
@@ -285,7 +285,7 @@ public class TestPoolingHttpClientConnectionManager {
         mgr.connect(endpoint1, TimeValue.ofMilliseconds(123), context);
 
         Mockito.verify(dnsResolver, Mockito.times(2)).resolve("somehost");
-        Mockito.verify(schemePortResolver, Mockito.times(2)).resolve(target);
+        Mockito.verify(schemePortResolver, Mockito.times(2)).resolve(target.getSchemeName(), target);
         Mockito.verify(detachedSocketFactory, Mockito.times(2)).create(null);
         Mockito.verify(socket, Mockito.times(1)).connect(new InetSocketAddress(remote, 8443), 123);
         Mockito.verify(tlsSocketStrategy, Mockito.times(2)).upgrade(socket, "somehost", 8443, tlsConfig, context);
@@ -330,15 +330,15 @@ public class TestPoolingHttpClientConnectionManager {
         mgr.setDefaultTlsConfig(tlsConfig);
 
         Mockito.when(dnsResolver.resolve("someproxy")).thenReturn(new InetAddress[] {remote});
-        Mockito.when(schemePortResolver.resolve(proxy)).thenReturn(8080);
-        Mockito.when(schemePortResolver.resolve(target)).thenReturn(8443);
+        Mockito.when(schemePortResolver.resolve(proxy.getSchemeName(), proxy)).thenReturn(8080);
+        Mockito.when(schemePortResolver.resolve(target.getSchemeName(), target)).thenReturn(8443);
         Mockito.when(tlsSocketStrategyLookup.lookup("https")).thenReturn(tlsSocketStrategy);
         Mockito.when(detachedSocketFactory.create(Mockito.any())).thenReturn(socket);
 
         mgr.connect(endpoint1, null, context);
 
         Mockito.verify(dnsResolver, Mockito.times(1)).resolve("someproxy");
-        Mockito.verify(schemePortResolver, Mockito.times(1)).resolve(proxy);
+        Mockito.verify(schemePortResolver, Mockito.times(1)).resolve(proxy.getSchemeName(), proxy);
         Mockito.verify(detachedSocketFactory, Mockito.times(1)).create(null);
         Mockito.verify(socket, Mockito.times(1)).connect(new InetSocketAddress(remote, 8080), 234);
 
@@ -347,7 +347,7 @@ public class TestPoolingHttpClientConnectionManager {
 
         mgr.upgrade(endpoint1, context);
 
-        Mockito.verify(schemePortResolver, Mockito.times(1)).resolve(target);
+        Mockito.verify(schemePortResolver, Mockito.times(1)).resolve(target.getSchemeName(), target);
         Mockito.verify(tlsSocketStrategy, Mockito.times(1)).upgrade(
                 socket, "somehost", 8443, tlsConfig, context);
     }

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/protocol/TestRequestUpgrade.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/protocol/TestRequestUpgrade.java
@@ -1,0 +1,132 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.hc.client5.http.protocol;
+
+import javax.net.ssl.SSLSession;
+
+import org.apache.hc.client5.http.HeadersMatcher;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.HttpVersion;
+import org.apache.hc.core5.http.message.BasicHeader;
+import org.apache.hc.core5.http.message.BasicHttpRequest;
+import org.apache.hc.core5.http.protocol.HttpCoreContext;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class TestRequestUpgrade {
+
+    private RequestUpgrade interceptor;
+    private HttpClientContext context;
+
+    @BeforeEach
+    void setUp() {
+        interceptor = new RequestUpgrade();
+        context = HttpClientContext.create();
+    }
+
+    @Test
+    void testUpgrade() throws Exception {
+        final HttpRequest get = new BasicHttpRequest("GET", "/");
+        interceptor.process(get, null, context);
+        MatcherAssert.assertThat(get.getHeaders(),
+                HeadersMatcher.same(
+                        new BasicHeader(HttpHeaders.UPGRADE, "TLS/1.2"),
+                        new BasicHeader(HttpHeaders.CONNECTION, HttpHeaders.UPGRADE)));
+        final HttpRequest options = new BasicHttpRequest("OPTIONS", "/");
+        interceptor.process(options, null, context);
+        MatcherAssert.assertThat(options.getHeaders(),
+                HeadersMatcher.same(
+                        new BasicHeader(HttpHeaders.UPGRADE, "TLS/1.2"),
+                        new BasicHeader(HttpHeaders.CONNECTION, HttpHeaders.UPGRADE)));
+        final HttpRequest head = new BasicHttpRequest("HEAD", "/");
+        interceptor.process(head, null, context);
+        MatcherAssert.assertThat(head.getHeaders(),
+                HeadersMatcher.same(
+                        new BasicHeader(HttpHeaders.UPGRADE, "TLS/1.2"),
+                        new BasicHeader(HttpHeaders.CONNECTION, HttpHeaders.UPGRADE)));
+    }
+
+    @Test
+    void testUpgradeDisabled() throws Exception {
+        context.setRequestConfig(RequestConfig.custom()
+                .setProtocolUpgradeEnabled(false)
+                .build());
+        final HttpRequest get = new BasicHttpRequest("GET", "/");
+        interceptor.process(get, null, context);
+        Assertions.assertFalse(get.containsHeader(HttpHeaders.UPGRADE));
+    }
+
+    @Test
+    void testDoNotUpgradeHTTP2() throws Exception {
+        context.setProtocolVersion(HttpVersion.HTTP_2);
+        final HttpRequest get = new BasicHttpRequest("GET", "/");
+        interceptor.process(get, null, context);
+        Assertions.assertFalse(get.containsHeader(HttpHeaders.UPGRADE));
+    }
+
+    @Test
+    void testDoNotUpgradeHTTP10() throws Exception {
+        context.setProtocolVersion(HttpVersion.HTTP_1_0);
+        final HttpRequest get = new BasicHttpRequest("GET", "/");
+        interceptor.process(get, null, context);
+        Assertions.assertFalse(get.containsHeader(HttpHeaders.UPGRADE));
+    }
+
+    @Test
+    void testDoUpgradeIfAlreadyTLS() throws Exception {
+        context.setAttribute(HttpCoreContext.SSL_SESSION, Mockito.mock(SSLSession.class));
+        final HttpRequest get = new BasicHttpRequest("GET", "/");
+        interceptor.process(get, null, context);
+        Assertions.assertFalse(get.containsHeader(HttpHeaders.UPGRADE));
+    }
+
+    @Test
+    void testDoUpgradeNonSafeMethodsOrTrace() throws Exception {
+        final HttpRequest post = new BasicHttpRequest("POST", "/");
+        interceptor.process(post, null, context);
+        Assertions.assertFalse(post.containsHeader(HttpHeaders.UPGRADE));
+
+        final HttpRequest put = new BasicHttpRequest("PUT", "/");
+        interceptor.process(put, null, context);
+        Assertions.assertFalse(put.containsHeader(HttpHeaders.UPGRADE));
+
+        final HttpRequest patch = new BasicHttpRequest("PATCH", "/");
+        interceptor.process(patch, null, context);
+        Assertions.assertFalse(patch.containsHeader(HttpHeaders.UPGRADE));
+
+        final HttpRequest trace = new BasicHttpRequest("TRACE", "/");
+        interceptor.process(trace, null, context);
+        Assertions.assertFalse(trace.containsHeader(HttpHeaders.UPGRADE));
+    }
+
+}


### PR DESCRIPTION
This change-set adds support for an optional upgrade to TLS of HTTP/1.1 connections through `Upgrade` / `Switch-Protocol` handshake