### PR TITLE
SNI support improvements

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/RouteInfo.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/RouteInfo.java
@@ -30,6 +30,7 @@ package org.apache.hc.client5.http;
 import java.net.InetAddress;
 
 import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.net.NamedEndpoint;
 
 /**
  * Connection route information.
@@ -70,6 +71,15 @@ public interface RouteInfo {
      * @return the target host
      */
     HttpHost getTargetHost();
+
+    /**
+     * Obtains the target name, if different from the target host, {@code null} otherwise.
+     *
+     * @since 5.4
+     */
+    default NamedEndpoint getTargetName() {
+        return null;
+    }
 
     /**
      * Obtains the local address to connect from.

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalAbstractHttpAsyncClient.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalAbstractHttpAsyncClient.java
@@ -184,7 +184,7 @@ abstract class InternalAbstractHttpAsyncClient extends AbstractHttpAsyncClientBa
 
     abstract AsyncExecRuntime createAsyncExecRuntime(HandlerFactory<AsyncPushConsumer> pushHandlerFactory);
 
-    abstract HttpRoute determineRoute(HttpHost httpHost, HttpClientContext clientContext) throws HttpException;
+    abstract HttpRoute determineRoute(HttpHost httpHost, HttpRequest request, HttpClientContext clientContext) throws HttpException;
 
     @Override
     protected <T> Future<T> doExecute(
@@ -214,6 +214,7 @@ abstract class InternalAbstractHttpAsyncClient extends AbstractHttpAsyncClientBa
 
                 final HttpRoute route = determineRoute(
                         httpHost != null ? httpHost : RoutingSupport.determineHost(request),
+                        request,
                         clientContext);
                 final String exchangeId = ExecSupport.getNextExchangeId();
                 clientContext.setExchangeId(exchangeId);

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalH2AsyncClient.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalH2AsyncClient.java
@@ -44,6 +44,7 @@ import org.apache.hc.core5.annotation.Internal;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.config.Lookup;
 import org.apache.hc.core5.http.nio.AsyncPushConsumer;
 import org.apache.hc.core5.http.nio.HandlerFactory;
@@ -94,8 +95,8 @@ public final class InternalH2AsyncClient extends InternalAbstractHttpAsyncClient
     }
 
     @Override
-    HttpRoute determineRoute(final HttpHost httpHost, final HttpClientContext clientContext) throws HttpException {
-        final HttpRoute route = routePlanner.determineRoute(httpHost, clientContext);
+    HttpRoute determineRoute(final HttpHost httpHost, final HttpRequest request, final HttpClientContext clientContext) throws HttpException {
+        final HttpRoute route = routePlanner.determineRoute(httpHost, request, clientContext);
         if (route.isTunnelled()) {
             throw new HttpException("HTTP/2 tunneling not supported");
         }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalH2AsyncExecRuntime.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalH2AsyncExecRuntime.java
@@ -95,12 +95,12 @@ class InternalH2AsyncExecRuntime implements AsyncExecRuntime {
             if (log.isDebugEnabled()) {
                 log.debug("{} acquiring endpoint ({})", id, connectTimeout);
             }
-            return Operations.cancellable(connPool.getSession(target, connectTimeout,
+            return Operations.cancellable(connPool.getSession(route, connectTimeout,
                     new FutureCallback<IOSession>() {
 
                         @Override
                         public void completed(final IOSession ioSession) {
-                            sessionRef.set(new Endpoint(target, ioSession));
+                            sessionRef.set(new Endpoint(route, ioSession));
                             reusable = true;
                             if (log.isDebugEnabled()) {
                                 log.debug("{} acquired endpoint", id);
@@ -184,19 +184,19 @@ class InternalH2AsyncExecRuntime implements AsyncExecRuntime {
             callback.completed(this);
             return Operations.nonCancellable();
         }
-        final HttpHost target = endpoint.target;
+        final HttpRoute route = endpoint.route;
         final RequestConfig requestConfig = context.getRequestConfig();
         @SuppressWarnings("deprecation")
         final Timeout connectTimeout = requestConfig.getConnectTimeout();
         if (log.isDebugEnabled()) {
             log.debug("{} connecting endpoint ({})", ConnPoolSupport.getId(endpoint), connectTimeout);
         }
-        return Operations.cancellable(connPool.getSession(target, connectTimeout,
+        return Operations.cancellable(connPool.getSession(route, connectTimeout,
             new FutureCallback<IOSession>() {
 
             @Override
             public void completed(final IOSession ioSession) {
-                sessionRef.set(new Endpoint(target, ioSession));
+                sessionRef.set(new Endpoint(route, ioSession));
                 reusable = true;
                 if (log.isDebugEnabled()) {
                     log.debug("{} endpoint connected", ConnPoolSupport.getId(endpoint));
@@ -263,15 +263,15 @@ class InternalH2AsyncExecRuntime implements AsyncExecRuntime {
                     new RequestExecutionCommand(exchangeHandler, pushHandlerFactory, complexCancellable, context),
                     Command.Priority.NORMAL);
         } else {
-            final HttpHost target = endpoint.target;
+            final HttpRoute route = endpoint.route;
             final RequestConfig requestConfig = context.getRequestConfig();
             @SuppressWarnings("deprecation")
             final Timeout connectTimeout = requestConfig.getConnectTimeout();
-            connPool.getSession(target, connectTimeout, new FutureCallback<IOSession>() {
+            connPool.getSession(route, connectTimeout, new FutureCallback<IOSession>() {
 
                 @Override
                 public void completed(final IOSession ioSession) {
-                    sessionRef.set(new Endpoint(target, ioSession));
+                    sessionRef.set(new Endpoint(route, ioSession));
                     reusable = true;
                     if (log.isDebugEnabled()) {
                         log.debug("{} start execution {}", ConnPoolSupport.getId(endpoint), id);
@@ -309,11 +309,11 @@ class InternalH2AsyncExecRuntime implements AsyncExecRuntime {
 
     static class Endpoint implements Identifiable {
 
-        final HttpHost target;
+        final HttpRoute route;
         final IOSession session;
 
-        Endpoint(final HttpHost target, final IOSession session) {
-            this.target = target;
+        Endpoint(final HttpRoute route, final IOSession session) {
+            this.route = route;
             this.session = session;
         }
 

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalH2ConnPool.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalH2ConnPool.java
@@ -29,40 +29,49 @@ package org.apache.hc.client5.http.impl.async;
 import java.net.InetSocketAddress;
 import java.util.concurrent.Future;
 
+import org.apache.hc.client5.http.HttpRoute;
 import org.apache.hc.client5.http.config.ConnectionConfig;
 import org.apache.hc.core5.concurrent.CallbackContribution;
 import org.apache.hc.core5.concurrent.FutureCallback;
+import org.apache.hc.core5.function.Callback;
 import org.apache.hc.core5.function.Resolver;
 import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.URIScheme;
+import org.apache.hc.core5.http.nio.command.ShutdownCommand;
 import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
-import org.apache.hc.core5.http2.nio.pool.H2ConnPool;
+import org.apache.hc.core5.http2.nio.command.PingCommand;
+import org.apache.hc.core5.http2.nio.support.BasicPingHandler;
 import org.apache.hc.core5.io.CloseMode;
 import org.apache.hc.core5.io.ModalCloseable;
+import org.apache.hc.core5.net.NamedEndpoint;
+import org.apache.hc.core5.reactor.AbstractIOSessionPool;
+import org.apache.hc.core5.reactor.Command;
 import org.apache.hc.core5.reactor.ConnectionInitiator;
 import org.apache.hc.core5.reactor.IOSession;
+import org.apache.hc.core5.reactor.ssl.TransportSecurityLayer;
 import org.apache.hc.core5.util.TimeValue;
 import org.apache.hc.core5.util.Timeout;
 
 class InternalH2ConnPool implements ModalCloseable {
 
-    private final H2ConnPool connPool;
+    private final SessionPool sessionPool;
 
     private volatile Resolver<HttpHost, ConnectionConfig> connectionConfigResolver;
 
     InternalH2ConnPool(final ConnectionInitiator connectionInitiator,
                        final Resolver<HttpHost, InetSocketAddress> addressResolver,
                        final TlsStrategy tlsStrategy) {
-        this.connPool = new H2ConnPool(connectionInitiator, addressResolver, tlsStrategy);
+        this.sessionPool = new SessionPool(connectionInitiator, addressResolver, tlsStrategy);
     }
 
     @Override
     public void close(final CloseMode closeMode) {
-        connPool.close(closeMode);
+        sessionPool.close(closeMode);
     }
 
     @Override
     public void close() {
-        connPool.close();
+        sessionPool.close();
     }
 
     private ConnectionConfig resolveConnectionConfig(final HttpHost httpHost) {
@@ -72,12 +81,12 @@ class InternalH2ConnPool implements ModalCloseable {
     }
 
     public Future<IOSession> getSession(
-            final HttpHost endpoint,
+            final HttpRoute route,
             final Timeout connectTimeout,
             final FutureCallback<IOSession> callback) {
-        final ConnectionConfig connectionConfig = resolveConnectionConfig(endpoint);
-        return connPool.getSession(
-                endpoint,
+        final ConnectionConfig connectionConfig = resolveConnectionConfig(route.getTargetHost());
+        return sessionPool.getSession(
+                route,
                 connectTimeout != null ? connectTimeout : connectionConfig.getConnectTimeout(),
                 new CallbackContribution<IOSession>(callback) {
 
@@ -94,11 +103,113 @@ class InternalH2ConnPool implements ModalCloseable {
     }
 
     public void closeIdle(final TimeValue idleTime) {
-        connPool.closeIdle(idleTime);
+        sessionPool.closeIdle(idleTime);
     }
 
     public void setConnectionConfigResolver(final Resolver<HttpHost, ConnectionConfig> connectionConfigResolver) {
         this.connectionConfigResolver = connectionConfigResolver;
+    }
+
+    public TimeValue getValidateAfterInactivity() {
+        return sessionPool.validateAfterInactivity;
+    }
+
+    public void setValidateAfterInactivity(final TimeValue timeValue) {
+        sessionPool.validateAfterInactivity = timeValue;
+    }
+
+
+    static class SessionPool extends AbstractIOSessionPool<HttpRoute> {
+
+        private final ConnectionInitiator connectionInitiator;
+        private final Resolver<HttpHost, InetSocketAddress> addressResolver;
+        private final TlsStrategy tlsStrategy;
+
+        private volatile TimeValue validateAfterInactivity = TimeValue.NEG_ONE_MILLISECOND;
+
+        SessionPool(final ConnectionInitiator connectionInitiator,
+                    final Resolver<HttpHost, InetSocketAddress> addressResolver,
+                    final TlsStrategy tlsStrategy) {
+            this.connectionInitiator = connectionInitiator;
+            this.addressResolver = addressResolver;
+            this.tlsStrategy = tlsStrategy;
+        }
+
+        @Override
+        protected Future<IOSession> connectSession(final HttpRoute route,
+                                                   final Timeout connectTimeout,
+                                                   final FutureCallback<IOSession> callback) {
+            final HttpHost target = route.getTargetHost();
+            final InetSocketAddress localAddress = route.getLocalSocketAddress();
+            final InetSocketAddress remoteAddress = addressResolver.resolve(target);
+            return connectionInitiator.connect(
+                    target,
+                    remoteAddress,
+                    localAddress,
+                    connectTimeout,
+                    null,
+                    new CallbackContribution<IOSession>(callback) {
+
+                        @Override
+                        public void completed(final IOSession ioSession) {
+                            if (tlsStrategy != null
+                                    && URIScheme.HTTPS.same(target.getSchemeName())
+                                    && ioSession instanceof TransportSecurityLayer) {
+                                final NamedEndpoint tlsName = route.getTargetName() != null ? route.getTargetName() : target;
+                                tlsStrategy.upgrade(
+                                        (TransportSecurityLayer) ioSession,
+                                        tlsName,
+                                        null,
+                                        connectTimeout,
+                                        new CallbackContribution<TransportSecurityLayer>(callback) {
+
+                                            @Override
+                                            public void completed(final TransportSecurityLayer transportSecurityLayer) {
+                                                callback.completed(ioSession);
+                                            }
+
+                                        });
+                                ioSession.setSocketTimeout(connectTimeout);
+                            } else {
+                                callback.completed(ioSession);
+                            }
+                        }
+
+                    });
+        }
+
+        @Override
+        protected void validateSession(final IOSession ioSession,
+                                       final Callback<Boolean> callback) {
+            if (ioSession.isOpen()) {
+                final TimeValue timeValue = validateAfterInactivity;
+                if (TimeValue.isNonNegative(timeValue)) {
+                    final long lastAccessTime = Math.min(ioSession.getLastReadTime(), ioSession.getLastWriteTime());
+                    final long deadline = lastAccessTime + timeValue.toMilliseconds();
+                    if (deadline <= System.currentTimeMillis()) {
+                        final Timeout socketTimeoutMillis = ioSession.getSocketTimeout();
+                        ioSession.enqueue(new PingCommand(new BasicPingHandler(result -> {
+                            ioSession.setSocketTimeout(socketTimeoutMillis);
+                            callback.execute(result);
+                        })), Command.Priority.NORMAL);
+                        return;
+                    }
+                }
+                callback.execute(true);
+            } else {
+                callback.execute(false);
+            }
+        }
+
+        @Override
+        protected void closeSession(final IOSession ioSession,
+                                    final CloseMode closeMode) {
+            if (closeMode == CloseMode.GRACEFUL) {
+                ioSession.enqueue(ShutdownCommand.GRACEFUL, Command.Priority.NORMAL);
+            } else {
+                ioSession.close(closeMode);
+            }
+        }
     }
 
 }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalHttpAsyncClient.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalHttpAsyncClient.java
@@ -46,6 +46,7 @@ import org.apache.hc.core5.annotation.Internal;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.config.Lookup;
 import org.apache.hc.core5.http.nio.AsyncPushConsumer;
 import org.apache.hc.core5.http.nio.HandlerFactory;
@@ -100,8 +101,8 @@ public final class InternalHttpAsyncClient extends InternalAbstractHttpAsyncClie
     }
 
     @Override
-    HttpRoute determineRoute(final HttpHost httpHost, final HttpClientContext clientContext) throws HttpException {
-        return routePlanner.determineRoute(httpHost, clientContext);
+    HttpRoute determineRoute(final HttpHost httpHost, final HttpRequest request, final HttpClientContext clientContext) throws HttpException {
+        return routePlanner.determineRoute(httpHost, request, clientContext);
     }
 
 }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/MinimalH2AsyncClient.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/MinimalH2AsyncClient.java
@@ -34,6 +34,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ThreadFactory;
 
 import org.apache.hc.client5.http.DnsResolver;
+import org.apache.hc.client5.http.HttpRoute;
 import org.apache.hc.client5.http.config.Configurable;
 import org.apache.hc.client5.http.config.ConnectionConfig;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -141,7 +142,7 @@ public final class MinimalH2AsyncClient extends AbstractMinimalHttpAsyncClientBa
                 final Timeout connectTimeout = requestConfig.getConnectTimeout();
                 final HttpHost target = new HttpHost(request.getScheme(), request.getAuthority());
 
-                final Future<IOSession> sessionFuture = connPool.getSession(target, connectTimeout,
+                final Future<IOSession> sessionFuture = connPool.getSession(new HttpRoute(target), connectTimeout,
                     new FutureCallback<IOSession>() {
 
                     @Override

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/InternalHttpClient.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/InternalHttpClient.java
@@ -55,6 +55,7 @@ import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.config.Lookup;
 import org.apache.hc.core5.http.impl.io.HttpRequestExecutor;
 import org.apache.hc.core5.http.io.support.ClassicRequestBuilder;
@@ -116,8 +117,8 @@ class InternalHttpClient extends CloseableHttpClient implements Configurable {
         this.closeables = closeables != null ?  new ConcurrentLinkedQueue<>(closeables) : null;
     }
 
-    private HttpRoute determineRoute(final HttpHost target, final HttpContext context) throws HttpException {
-        return this.routePlanner.determineRoute(target, context);
+    private HttpRoute determineRoute(final HttpHost target, final HttpRequest request, final HttpContext context) throws HttpException {
+        return this.routePlanner.determineRoute(target, request, context);
     }
 
     private void setupContext(final HttpClientContext context) {
@@ -157,6 +158,7 @@ class InternalHttpClient extends CloseableHttpClient implements Configurable {
             setupContext(localcontext);
             final HttpRoute route = determineRoute(
                     target != null ? target : RoutingSupport.determineHost(request),
+                    request,
                     localcontext);
             final String exchangeId = ExecSupport.getNextExchangeId();
             localcontext.setExchangeId(exchangeId);

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/BasicHttpClientConnectionManager.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/BasicHttpClientConnectionManager.java
@@ -476,24 +476,20 @@ public class BasicHttpClientConnectionManager implements HttpClientConnectionMan
                 return;
             }
             final HttpRoute route = internalEndpoint.getRoute();
-            final HttpHost host;
-            if (route.getProxyHost() != null) {
-                host = route.getProxyHost();
-            } else {
-                host = route.getTargetHost();
-            }
+            final HttpHost firstHop = route.getProxyHost() != null ? route.getProxyHost() : route.getTargetHost();
             final Timeout connectTimeout = timeout != null ? Timeout.of(timeout.getDuration(), timeout.getTimeUnit()) : connectionConfig.getConnectTimeout();
             final ManagedHttpClientConnection connection = internalEndpoint.getConnection();
             if (LOG.isDebugEnabled()) {
-                LOG.debug("{} connecting endpoint to {} ({})", ConnPoolSupport.getId(endpoint), host, connectTimeout);
+                LOG.debug("{} connecting endpoint to {} ({})", ConnPoolSupport.getId(endpoint), firstHop, connectTimeout);
             }
             this.connectionOperator.connect(
                     connection,
-                    host,
+                    firstHop,
+                    route.getTargetName(),
                     route.getLocalSocketAddress(),
                     connectTimeout,
                     socketConfig,
-                    tlsConfig,
+                    route.isTunnelled() ? null : tlsConfig,
                     context);
             if (LOG.isDebugEnabled()) {
                 LOG.debug("{} connected {}", ConnPoolSupport.getId(endpoint), ConnPoolSupport.getId(conn));
@@ -516,9 +512,11 @@ public class BasicHttpClientConnectionManager implements HttpClientConnectionMan
             Args.notNull(endpoint, "Endpoint");
             Args.notNull(route, "HTTP route");
             final InternalConnectionEndpoint internalEndpoint = cast(endpoint);
+            final HttpRoute route = internalEndpoint.getRoute();
             this.connectionOperator.upgrade(
                     internalEndpoint.getConnection(),
-                    internalEndpoint.getRoute().getTargetHost(),
+                    route.getTargetHost(),
+                    route.getTargetName(),
                     tlsConfig,
                     context);
         } finally {

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/io/HttpClientConnectionOperator.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/io/HttpClientConnectionOperator.java
@@ -36,6 +36,7 @@ import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.io.SocketConfig;
 import org.apache.hc.core5.http.protocol.HttpContext;
+import org.apache.hc.core5.net.NamedEndpoint;
 import org.apache.hc.core5.util.TimeValue;
 import org.apache.hc.core5.util.Timeout;
 
@@ -70,24 +71,27 @@ public interface HttpClientConnectionOperator {
      * Connect the given managed connection to the remote endpoint.
      *
      * @param conn the managed connection.
-     * @param host the address of the opposite endpoint.
+     * @param endpointHost the address of the remote endpoint.
+     * @param endpointName the name of the remote endpoint, if different from the endpoint host name,
+     *                   {@code null} otherwise. Usually taken from the request URU authority.
      * @param localAddress the address of the local endpoint.
      * @param connectTimeout the timeout of the connect operation.
      * @param socketConfig the socket configuration.
      * @param attachment connect request attachment.
      * @param context the execution context.
      *
-     * @since 5.2
+     * @since 5.4
      */
     default void connect(
             ManagedHttpClientConnection conn,
-            HttpHost host,
+            HttpHost endpointHost,
+            NamedEndpoint endpointName,
             InetSocketAddress localAddress,
             Timeout connectTimeout,
             SocketConfig socketConfig,
             Object attachment,
             HttpContext context) throws IOException {
-        connect(conn, host, localAddress, connectTimeout, socketConfig, context);
+        connect(conn, endpointHost, localAddress, connectTimeout, socketConfig, context);
     }
 
     /**
@@ -108,7 +112,9 @@ public interface HttpClientConnectionOperator {
      * by using the TLS security protocol.
      *
      * @param conn the managed connection.
-     * @param host the address of the opposite endpoint with TLS security.
+     * @param endpointHost the address of the remote endpoint.
+     * @param endpointName the name of the remote endpoint, if different from the endpoint host name,
+     *                   {@code null} otherwise. Usually taken from the request URU authority.
      * @param attachment connect request attachment.
      * @param context the execution context.
      *
@@ -116,10 +122,11 @@ public interface HttpClientConnectionOperator {
      */
     default void upgrade(
             ManagedHttpClientConnection conn,
-            HttpHost host,
+            HttpHost endpointHost,
+            NamedEndpoint endpointName,
             Object attachment,
             HttpContext context) throws IOException {
-        upgrade(conn, host, context);
+        upgrade(conn, endpointHost, context);
     }
 
 }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/nio/AsyncClientConnectionOperator.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/nio/AsyncClientConnectionOperator.java
@@ -36,6 +36,7 @@ import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.concurrent.FutureCallback;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.protocol.HttpContext;
+import org.apache.hc.core5.net.NamedEndpoint;
 import org.apache.hc.core5.reactor.ConnectionInitiator;
 import org.apache.hc.core5.util.Timeout;
 
@@ -73,24 +74,27 @@ public interface AsyncClientConnectionOperator {
      * the provided {@link ConnectionInitiator}.
      *
      * @param connectionInitiator the connection initiator.
-     * @param host the address of the opposite endpoint.
+     * @param endpointHost the address of the remote endpoint.
+     * @param endpointName the name of the remote endpoint, if different from the endpoint host name,
+     *                   {@code null} otherwise. Usually taken from the request URU authority.
      * @param localAddress the address of the local endpoint.
      * @param connectTimeout the timeout of the connect operation.
      * @param attachment the attachment, which can be any object representing custom parameter
      *                    of the operation.
      * @param context the execution context.
      * @param callback the future result callback.
-     * @since 5.2
+     * @since 5.4
      */
     default Future<ManagedAsyncClientConnection> connect(
             ConnectionInitiator connectionInitiator,
-            HttpHost host,
+            HttpHost endpointHost,
+            NamedEndpoint endpointName,
             SocketAddress localAddress,
             Timeout connectTimeout,
             Object attachment,
             HttpContext context,
             FutureCallback<ManagedAsyncClientConnection> callback) {
-        return connect(connectionInitiator, host, localAddress, connectTimeout,
+        return connect(connectionInitiator, endpointHost, localAddress, connectTimeout,
             attachment, callback);
     }
 
@@ -110,38 +114,26 @@ public interface AsyncClientConnectionOperator {
      * by using the TLS security protocol.
      *
      * @param conn the managed connection.
-     * @param host the address of the opposite endpoint with TLS security.
+     * @param endpointHost the address of the remote endpoint.
+     * @param endpointName the name of the remote endpoint, if different from the endpoint host name,
+     *                   {@code null} otherwise. Usually taken from the request URU authority.
      * @param attachment the attachment, which can be any object representing custom parameter
      *                    of the operation.
      * @param context the execution context.
      * @param callback the future result callback.
-     * @since 5.2
+     * @since 5.4
      */
     default void upgrade(
             ManagedAsyncClientConnection conn,
-            HttpHost host,
+            HttpHost endpointHost,
+            NamedEndpoint endpointName,
             Object attachment,
             HttpContext context,
             FutureCallback<ManagedAsyncClientConnection> callback) {
-        upgrade(conn, host, attachment, context);
+        upgrade(conn, endpointHost, attachment);
         if (callback != null) {
             callback.completed(conn);
         }
-    }
-
-    /**
-     * Upgrades transport security of the given managed connection
-     * by using the TLS security protocol.
-     *
-     * @param conn the managed connection.
-     * @param host the address of the opposite endpoint with TLS security.
-     * @param attachment the attachment, which can be any object representing custom parameter
-     *                    of the operation.
-     * @param context the execution context.
-     * @since 5.2
-     */
-    default void upgrade(ManagedAsyncClientConnection conn, HttpHost host, Object attachment, HttpContext context) {
-        upgrade(conn, host, attachment);
     }
 
 }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/routing/HttpRoutePlanner.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/routing/HttpRoutePlanner.java
@@ -32,6 +32,7 @@ import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.protocol.HttpContext;
 
 /**
@@ -61,5 +62,21 @@ public interface HttpRoutePlanner {
      * @throws HttpException    in case of a problem
      */
     HttpRoute determineRoute(HttpHost target, HttpContext context) throws HttpException;
+
+    /**
+     * Determines the route for the given host.
+     *
+     * @param target    the target host for the request.
+     * @param request   the request message. Can be {@code null} if not given / known.
+     * @param context   the context to use for the subsequent execution.
+     *                  Implementations may accept {@code null}.
+     *
+     * @return  the route that the request should take
+     *
+     * @since 5.4
+     */
+    default HttpRoute determineRoute(HttpHost target, HttpRequest request, HttpContext context) throws HttpException {
+        return determineRoute(target, context);
+    }
 
 }

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/TestHttpRoute.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/TestHttpRoute.java
@@ -25,16 +25,16 @@
  *
  */
 
-package org.apache.hc.client5.http.routing;
+package org.apache.hc.client5.http;
 
 import java.net.InetAddress;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.hc.client5.http.HttpRoute;
 import org.apache.hc.client5.http.RouteInfo.LayerType;
 import org.apache.hc.client5.http.RouteInfo.TunnelType;
 import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.net.URIAuthority;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -171,45 +171,8 @@ public class TestHttpRoute {
         Assertions.assertTrue (routettt.isSecure(), "routettt.secure");
         Assertions.assertTrue (routettt.isTunnelled(), "routettt.tunnel");
         Assertions.assertTrue (routettt.isLayered(), "routettt.layer");
-
-
-        final Set<HttpRoute> routes = new HashSet<>();
-        routes.add(routefff);
-        routes.add(routefft);
-        routes.add(routeftf);
-        routes.add(routeftt);
-        routes.add(routetff);
-        routes.add(routetft);
-        routes.add(routettf);
-        routes.add(routettt);
-        Assertions.assertEquals(8, routes.size(), "some flagged routes are equal");
-
-        // we can't test hashCode in general due to its dependency
-        // on InetAddress and HttpHost, but we can check for the flags
-        final Set<Integer> routecodes = new HashSet<>();
-        routecodes.add(routefff.hashCode());
-        routecodes.add(routefft.hashCode());
-        routecodes.add(routeftf.hashCode());
-        routecodes.add(routeftt.hashCode());
-        routecodes.add(routetff.hashCode());
-        routecodes.add(routetft.hashCode());
-        routecodes.add(routettf.hashCode());
-        routecodes.add(routettt.hashCode());
-        Assertions.assertEquals(8, routecodes.size(), "some flagged routes have same hashCode");
-
-        final Set<String> routestrings = new HashSet<>();
-        routestrings.add(routefff.toString());
-        routestrings.add(routefft.toString());
-        routestrings.add(routeftf.toString());
-        routestrings.add(routeftt.toString());
-        routestrings.add(routetff.toString());
-        routestrings.add(routetft.toString());
-        routestrings.add(routettf.toString());
-        routestrings.add(routettt.toString());
-        Assertions.assertEquals(8, routestrings.size(), "some flagged route.toString() are equal");
     }
 
-    @SuppressWarnings("unused")
     @Test
     public void testInvalidArguments() {
         final HttpHost[] chain1 = { PROXY1 };
@@ -291,6 +254,9 @@ public class TestHttpRoute {
                                         TunnelType.TUNNELLED, LayerType.PLAIN);
         final HttpRoute route2k = new HttpRoute(TARGET1, LOCAL41, chain3, false,
                                           TunnelType.PLAIN, LayerType.LAYERED);
+        final HttpRoute route2m = new HttpRoute(TARGET2,
+                new URIAuthority(TARGET2.getHostName(), TARGET2.getPort()), LOCAL41, chain3, false,
+                TunnelType.PLAIN, LayerType.PLAIN);
 
         // check a special case first: 2f should be the same as 2e
         Assertions.assertEquals(route2e, route2f, "2e 2f");
@@ -308,6 +274,7 @@ public class TestHttpRoute {
         Assertions.assertNotEquals(route1a, route2i, "1a 2i");
         Assertions.assertNotEquals(route1a, route2j, "1a 2j");
         Assertions.assertNotEquals(route1a, route2k, "1a 2k");
+        Assertions.assertNotEquals(route1a, route2m, "1a 2k");
 
         // repeat the checks in the other direction
         // there could be problems with detecting null attributes
@@ -323,6 +290,7 @@ public class TestHttpRoute {
         Assertions.assertNotEquals(route2i, route1a, "2i 1a");
         Assertions.assertNotEquals(route2j, route1a, "2j 1a");
         Assertions.assertNotEquals(route2k, route1a, "2k 1a");
+        Assertions.assertNotEquals(route2m, route1a, "2k 1a");
 
         // don't check hashCode, it's not guaranteed to be different
 
@@ -337,6 +305,7 @@ public class TestHttpRoute {
         Assertions.assertNotEquals(route1a.toString(), route2i.toString(), "toString 1a 2i");
         Assertions.assertNotEquals(route1a.toString(), route2j.toString(), "toString 1a 2j");
         Assertions.assertNotEquals(route1a.toString(), route2k.toString(), "toString 1a 2k");
+        Assertions.assertNotEquals(route1a.toString(), route2m.toString(), "toString 1a 2k");
 
         // now check that all of the routes are different from eachother
         // except for those that aren't :-)
@@ -353,7 +322,7 @@ public class TestHttpRoute {
         routes.add(route2i);
         routes.add(route2j);
         routes.add(route2k);
-        Assertions.assertEquals(11, routes.size(), "some routes are equal");
+        routes.add(route2m);
 
         // and a run of cloning over the set
         for (final HttpRoute origin : routes) {
@@ -361,22 +330,6 @@ public class TestHttpRoute {
             Assertions.assertEquals(origin, cloned, "clone of " + origin);
             Assertions.assertTrue(routes.contains(cloned), "clone of " + origin);
         }
-
-        // and don't forget toString
-        final Set<String> routestrings = new HashSet<>();
-        routestrings.add(route1a.toString());
-        routestrings.add(route2a.toString());
-        routestrings.add(route2b.toString());
-        routestrings.add(route2c.toString());
-        routestrings.add(route2d.toString());
-        routestrings.add(route2e.toString());
-        //routestrings.add(route2f.toString()); // 2f is the same as 2e
-        routestrings.add(route2g.toString());
-        routestrings.add(route2h.toString());
-        routestrings.add(route2i.toString());
-        routestrings.add(route2j.toString());
-        routestrings.add(route2k.toString());
-        Assertions.assertEquals(11, routestrings.size(), "some route.toString() are equal");
 
         // finally, compare with nonsense
         Assertions.assertNotEquals(null, route1a, "route equals null");

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/examples/AsyncClientSNI.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/examples/AsyncClientSNI.java
@@ -1,0 +1,106 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.client5.http.examples;
+
+import java.util.concurrent.Future;
+
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+
+import org.apache.hc.client5.http.async.methods.SimpleHttpRequest;
+import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
+import org.apache.hc.client5.http.async.methods.SimpleRequestBuilder;
+import org.apache.hc.client5.http.async.methods.SimpleRequestProducer;
+import org.apache.hc.client5.http.async.methods.SimpleResponseConsumer;
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.client5.http.impl.async.HttpAsyncClients;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
+import org.apache.hc.core5.concurrent.FutureCallback;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.message.StatusLine;
+import org.apache.hc.core5.io.CloseMode;
+
+/**
+ * This example demonstrates how to use SNI to send requests to a virtual HTTPS
+ * endpoint using the async I/O.
+ */
+public class AsyncClientSNI {
+
+    public static void main(final String[] args) throws Exception {
+        try (final CloseableHttpAsyncClient client = HttpAsyncClients.createSystem()) {
+
+            client.start();
+
+            final HttpHost target = new HttpHost("https", "www.google.com");
+            final SimpleHttpRequest request = SimpleRequestBuilder.get()
+                    .setUri("https://www.google.ch/")
+                    .build();
+
+            final HttpClientContext clientContext = HttpClientContext.create();
+
+            System.out.println("Executing request " + request);
+            final Future<SimpleHttpResponse> future = client.execute(
+                    target,
+                    SimpleRequestProducer.create(request),
+                    SimpleResponseConsumer.create(),
+                    null,
+                    clientContext,
+                    new FutureCallback<SimpleHttpResponse>() {
+
+                        @Override
+                        public void completed(final SimpleHttpResponse response) {
+                            System.out.println(request + "->" + new StatusLine(response));
+                            final SSLSession sslSession = clientContext.getSSLSession();
+                            if (sslSession != null) {
+                                try {
+                                    System.out.println("Peer: " + sslSession.getPeerPrincipal());
+                                    System.out.println("TLS protocol: " + sslSession.getProtocol());
+                                    System.out.println("TLS cipher suite: " + sslSession.getCipherSuite());
+                                } catch (final SSLPeerUnverifiedException ignore) {
+                                }
+                            }
+                        }
+
+                        @Override
+                        public void failed(final Exception ex) {
+                            System.out.println(request + "->" + ex);
+                        }
+
+                        @Override
+                        public void cancelled() {
+                            System.out.println(request + " cancelled");
+                        }
+
+                    });
+            future.get();
+
+            System.out.println("Shutting down");
+            client.close(CloseMode.GRACEFUL);
+        }
+    }
+
+}

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClientSNI.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClientSNI.java
@@ -1,0 +1,73 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.client5.http.examples;
+
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.message.StatusLine;
+
+/**
+ * This example demonstrates how to use SNI to send requests to a virtual HTTPS
+ * endpoint using the classic I/O.
+ */
+public class ClientSNI {
+
+    public final static void main(final String[] args) throws Exception {
+        try (CloseableHttpClient httpclient = HttpClients.createSystem()) {
+
+            final HttpHost target = new HttpHost("https", "www.google.com");
+            final HttpGet httpget = new HttpGet("https://www.google.ch/");
+
+            System.out.println("Executing request " + httpget.getMethod() + " " + httpget.getUri());
+
+            final HttpClientContext clientContext = HttpClientContext.create();
+            httpclient.execute(target, httpget, clientContext, response -> {
+                System.out.println("----------------------------------------");
+                System.out.println(httpget + "->" + new StatusLine(response));
+                EntityUtils.consume(response.getEntity());
+                final SSLSession sslSession = clientContext.getSSLSession();
+                if (sslSession != null) {
+                    try {
+                        System.out.println("Peer: " + sslSession.getPeerPrincipal());
+                        System.out.println("TLS protocol: " + sslSession.getProtocol());
+                        System.out.println("TLS cipher suite: " + sslSession.getCipherSuite());
+                    } catch (final SSLPeerUnverifiedException ignore) {
+                    }
+                }
+                return null;
+            });
+        }
+    }
+
+}

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/classic/TestInternalHttpClient.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/classic/TestInternalHttpClient.java
@@ -57,7 +57,6 @@ import org.mockito.MockitoAnnotations;
 /**
  *  Simple tests for {@link InternalHttpClient}.
  */
-@SuppressWarnings({"static-access"}) // test code
 public class TestInternalHttpClient {
 
     @Mock
@@ -101,6 +100,7 @@ public class TestInternalHttpClient {
 
         Mockito.when(routePlanner.determineRoute(
                 Mockito.eq(new HttpHost("somehost")),
+                Mockito.any(),
                 Mockito.<HttpClientContext>any())).thenReturn(route);
         Mockito.when(execChain.execute(
                 Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(
@@ -121,6 +121,7 @@ public class TestInternalHttpClient {
 
         Mockito.when(routePlanner.determineRoute(
                 Mockito.eq(new HttpHost("somehost")),
+                Mockito.any(),
                 Mockito.<HttpClientContext>any())).thenReturn(route);
         Mockito.when(execChain.execute(
                 Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(
@@ -141,6 +142,7 @@ public class TestInternalHttpClient {
 
         Mockito.when(routePlanner.determineRoute(
                 Mockito.eq(new HttpHost("somehost")),
+                Mockito.any(),
                 Mockito.<HttpClientContext>any())).thenReturn(route);
         Mockito.when(execChain.execute(
                 Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(
@@ -163,6 +165,7 @@ public class TestInternalHttpClient {
 
         Mockito.when(routePlanner.determineRoute(
                 Mockito.eq(new HttpHost("somehost")),
+                Mockito.any(),
                 Mockito.<HttpClientContext>any())).thenReturn(route);
         Mockito.when(execChain.execute(
                 Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(
@@ -183,6 +186,7 @@ public class TestInternalHttpClient {
 
         Mockito.when(routePlanner.determineRoute(
                 Mockito.eq(new HttpHost("somehost")),
+                Mockito.any(),
                 Mockito.<HttpClientContext>any())).thenReturn(route);
         Mockito.when(execChain.execute(
                 Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/io/TestBasicHttpClientConnectionManager.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/io/TestBasicHttpClientConnectionManager.java
@@ -402,7 +402,7 @@ public class TestBasicHttpClientConnectionManager {
         Mockito.verify(schemePortResolver, Mockito.times(1)).resolve(target.getSchemeName(), target);
         Mockito.verify(detachedSocketFactory, Mockito.times(1)).create(null);
         Mockito.verify(socket, Mockito.times(1)).connect(new InetSocketAddress(remote, 8443), 234);
-        Mockito.verify(tlsSocketStrategy).upgrade(socket, "somehost", 8443, tlsConfig, context);
+        Mockito.verify(tlsSocketStrategy).upgrade(socket, "somehost", 443, tlsConfig, context);
 
         mgr.connect(endpoint1, TimeValue.ofMilliseconds(123), context);
 
@@ -410,7 +410,7 @@ public class TestBasicHttpClientConnectionManager {
         Mockito.verify(schemePortResolver, Mockito.times(2)).resolve(target.getSchemeName(), target);
         Mockito.verify(detachedSocketFactory, Mockito.times(2)).create(null);
         Mockito.verify(socket, Mockito.times(1)).connect(new InetSocketAddress(remote, 8443), 123);
-        Mockito.verify(tlsSocketStrategy, Mockito.times(2)).upgrade(socket, "somehost", 8443, tlsConfig, context);
+        Mockito.verify(tlsSocketStrategy, Mockito.times(2)).upgrade(socket, "somehost", 443, tlsConfig, context);
     }
 
     @Test
@@ -458,9 +458,8 @@ public class TestBasicHttpClientConnectionManager {
 
         mgr.upgrade(endpoint1, context);
 
-        Mockito.verify(schemePortResolver, Mockito.times(1)).resolve(target.getSchemeName(), target);
         Mockito.verify(tlsSocketStrategy, Mockito.times(1)).upgrade(
-                socket, "somehost", 8443, tlsConfig, context);
+                socket, "somehost", 443, tlsConfig, context);
     }
 
 

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/io/TestHttpClientConnectionOperator.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/io/TestHttpClientConnectionOperator.java
@@ -102,7 +102,7 @@ public class TestHttpClientConnectionOperator {
             .setSoLinger(50, TimeUnit.MILLISECONDS)
             .build();
         final InetSocketAddress localAddress = new InetSocketAddress(local, 0);
-        connectionOperator.connect(conn, host, localAddress, Timeout.ofMilliseconds(123), socketConfig, null, context);
+        connectionOperator.connect(conn, host, null, localAddress, Timeout.ofMilliseconds(123), socketConfig, null, context);
 
         Mockito.verify(socket).setKeepAlive(true);
         Mockito.verify(socket).setReuseAddress(true);
@@ -137,17 +137,17 @@ public class TestHttpClientConnectionOperator {
         Mockito.when(tlsSocketStrategy.upgrade(
                 Mockito.same(socket),
                 Mockito.eq("somehost"),
-                Mockito.eq(443),
+                Mockito.anyInt(),
                 Mockito.any(),
                 Mockito.any())).thenReturn(upgradedSocket);
 
         final InetSocketAddress localAddress = new InetSocketAddress(local, 0);
-        connectionOperator.connect(conn, host, localAddress,
+        connectionOperator.connect(conn, host, null, localAddress,
                 Timeout.ofMilliseconds(123), SocketConfig.DEFAULT, tlsConfig, context);
 
         Mockito.verify(socket).connect(new InetSocketAddress(ip1, 443), 123);
         Mockito.verify(conn, Mockito.times(2)).bind(socket);
-        Mockito.verify(tlsSocketStrategy).upgrade(socket, "somehost", 443, tlsConfig, context);
+        Mockito.verify(tlsSocketStrategy).upgrade(socket, "somehost", -1, tlsConfig, context);
         Mockito.verify(conn, Mockito.times(1)).bind(upgradedSocket);
     }
 
@@ -203,7 +203,7 @@ public class TestHttpClientConnectionOperator {
         final InetSocketAddress localAddress = new InetSocketAddress(local, 0);
         final TlsConfig tlsConfig = TlsConfig.custom()
                 .build();
-        connectionOperator.connect(conn, host, localAddress,
+        connectionOperator.connect(conn, host, null, localAddress,
                 Timeout.ofMilliseconds(123), SocketConfig.DEFAULT, tlsConfig, context);
 
         Mockito.verify(socket, Mockito.times(2)).bind(localAddress);
@@ -225,7 +225,7 @@ public class TestHttpClientConnectionOperator {
         final InetSocketAddress localAddress = new InetSocketAddress(local, 0);
         final TlsConfig tlsConfig = TlsConfig.custom()
                 .build();
-        connectionOperator.connect(conn, host, localAddress,
+        connectionOperator.connect(conn, host, null, localAddress,
                 Timeout.ofMilliseconds(123), SocketConfig.DEFAULT, tlsConfig, context);
 
         Mockito.verify(socket).bind(localAddress);
@@ -242,17 +242,16 @@ public class TestHttpClientConnectionOperator {
         Mockito.when(conn.isOpen()).thenReturn(true);
         Mockito.when(conn.getSocket()).thenReturn(socket);
         Mockito.when(tlsSocketStrategyLookup.lookup("https")).thenReturn(tlsSocketStrategy);
-        Mockito.when(schemePortResolver.resolve(host.getSchemeName(), host)).thenReturn(443);
 
         final SSLSocket upgradedSocket = Mockito.mock(SSLSocket.class);
         Mockito.when(tlsSocketStrategy.upgrade(
                 Mockito.any(),
                 Mockito.eq("somehost"),
-                Mockito.eq(443),
+                Mockito.anyInt(),
                 Mockito.eq(Timeout.ofMilliseconds(345)),
                 Mockito.any())).thenReturn(upgradedSocket);
 
-        connectionOperator.upgrade(conn, host, Timeout.ofMilliseconds(345), context);
+        connectionOperator.upgrade(conn, host, null, Timeout.ofMilliseconds(345), context);
 
         Mockito.verify(conn).bind(upgradedSocket);
     }

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/io/TestPoolingHttpClientConnectionManager.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/io/TestPoolingHttpClientConnectionManager.java
@@ -270,7 +270,7 @@ public class TestPoolingHttpClientConnectionManager {
         Mockito.when(tlsSocketStrategy.upgrade(
                 Mockito.same(socket),
                 Mockito.eq("somehost"),
-                Mockito.eq(8443),
+                Mockito.anyInt(),
                 Mockito.any(),
                 Mockito.any())).thenReturn(upgradedSocket);
 
@@ -280,7 +280,7 @@ public class TestPoolingHttpClientConnectionManager {
         Mockito.verify(schemePortResolver, Mockito.times(1)).resolve(target.getSchemeName(), target);
         Mockito.verify(detachedSocketFactory, Mockito.times(1)).create(null);
         Mockito.verify(socket, Mockito.times(1)).connect(new InetSocketAddress(remote, 8443), 234);
-        Mockito.verify(tlsSocketStrategy).upgrade(socket, "somehost", 8443, tlsConfig, context);
+        Mockito.verify(tlsSocketStrategy).upgrade(socket, "somehost", 443, tlsConfig, context);
 
         mgr.connect(endpoint1, TimeValue.ofMilliseconds(123), context);
 
@@ -288,7 +288,7 @@ public class TestPoolingHttpClientConnectionManager {
         Mockito.verify(schemePortResolver, Mockito.times(2)).resolve(target.getSchemeName(), target);
         Mockito.verify(detachedSocketFactory, Mockito.times(2)).create(null);
         Mockito.verify(socket, Mockito.times(1)).connect(new InetSocketAddress(remote, 8443), 123);
-        Mockito.verify(tlsSocketStrategy, Mockito.times(2)).upgrade(socket, "somehost", 8443, tlsConfig, context);
+        Mockito.verify(tlsSocketStrategy, Mockito.times(2)).upgrade(socket, "somehost", 443, tlsConfig, context);
     }
 
     @Test
@@ -347,9 +347,8 @@ public class TestPoolingHttpClientConnectionManager {
 
         mgr.upgrade(endpoint1, context);
 
-        Mockito.verify(schemePortResolver, Mockito.times(1)).resolve(target.getSchemeName(), target);
         Mockito.verify(tlsSocketStrategy, Mockito.times(1)).upgrade(
-                socket, "somehost", 8443, tlsConfig, context);
+                socket, "somehost", 443, tlsConfig, context);
     }
 
 }


### PR DESCRIPTION
* Connection route info now request URI authority
* The default route planner and connections managers now take request URI authority when calculating the connection route and when pooling and re-using connections