### PR TITLE
HTTPCLIENT-2070: Auth cache to no longer rely on Java serialization for auth state caching

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/StateHolder.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/StateHolder.java
@@ -1,0 +1,41 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.client5.http.impl;
+
+import org.apache.hc.core5.annotation.Internal;
+
+/**
+ * @since 5.4
+ */
+@Internal
+public interface StateHolder<T> {
+
+    T store();
+
+    void restore(T state);
+
+}

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestBasicScheme.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestBasicScheme.java
@@ -26,10 +26,6 @@
  */
 package org.apache.hc.client5.http.impl.auth;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
@@ -153,34 +149,13 @@ public class TestBasicScheme {
         final BasicScheme basicScheme = new BasicScheme();
         basicScheme.processChallenge(authChallenge, null);
 
-        final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-        final ObjectOutputStream out = new ObjectOutputStream(buffer);
-        out.writeObject(basicScheme);
-        out.flush();
-        final byte[] raw = buffer.toByteArray();
-        final ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(raw));
-        final BasicScheme authScheme = (BasicScheme) in.readObject();
+        final BasicScheme.State state = basicScheme.store();
+        final BasicScheme cached = new BasicScheme();
+        cached.restore(state);
 
-        Assertions.assertEquals(basicScheme.getName(), authScheme.getName());
-        Assertions.assertEquals(basicScheme.getRealm(), authScheme.getRealm());
-        Assertions.assertEquals(basicScheme.isChallengeComplete(), authScheme.isChallengeComplete());
-    }
-
-    @Test
-    public void testSerializationUnchallenged() throws Exception {
-        final BasicScheme basicScheme = new BasicScheme();
-
-        final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-        final ObjectOutputStream out = new ObjectOutputStream(buffer);
-        out.writeObject(basicScheme);
-        out.flush();
-        final byte[] raw = buffer.toByteArray();
-        final ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(raw));
-        final BasicScheme authScheme = (BasicScheme) in.readObject();
-
-        Assertions.assertEquals(basicScheme.getName(), authScheme.getName());
-        Assertions.assertEquals(basicScheme.getRealm(), authScheme.getRealm());
-        Assertions.assertEquals(basicScheme.isChallengeComplete(), authScheme.isChallengeComplete());
+        Assertions.assertEquals(basicScheme.getName(), cached.getName());
+        Assertions.assertEquals(basicScheme.getRealm(), cached.getRealm());
+        Assertions.assertEquals(basicScheme.isChallengeComplete(), cached.isChallengeComplete());
     }
 
     @Test

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestBearerScheme.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestBearerScheme.java
@@ -26,11 +26,6 @@
  */
 package org.apache.hc.client5.http.impl.auth;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-
 import org.apache.hc.client5.http.auth.AuthChallenge;
 import org.apache.hc.client5.http.auth.AuthScheme;
 import org.apache.hc.client5.http.auth.AuthScope;
@@ -80,25 +75,21 @@ public class TestBearerScheme {
     }
 
     @Test
-    public void testSerialization() throws Exception {
+    public void testStateStorage() throws Exception {
         final AuthChallenge authChallenge = new AuthChallenge(ChallengeType.TARGET, "Bearer",
                 new BasicNameValuePair("realm", "test"),
                 new BasicNameValuePair("code", "read"));
 
-        final AuthScheme authscheme = new BearerScheme();
+        final BearerScheme authscheme = new BearerScheme();
         authscheme.processChallenge(authChallenge, null);
 
-        final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-        final ObjectOutputStream out = new ObjectOutputStream(buffer);
-        out.writeObject(authscheme);
-        out.flush();
-        final byte[] raw = buffer.toByteArray();
-        final ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(raw));
-        final BearerScheme authcheme2 = (BearerScheme) in.readObject();
+        final BearerScheme.State state = authscheme.store();
+        final BearerScheme cached = new BearerScheme();
+        cached.restore(state);
 
-        Assertions.assertEquals(authcheme2.getName(), authcheme2.getName());
-        Assertions.assertEquals(authcheme2.getRealm(), authcheme2.getRealm());
-        Assertions.assertEquals(authcheme2.isChallengeComplete(), authcheme2.isChallengeComplete());
+        Assertions.assertEquals(cached.getName(), cached.getName());
+        Assertions.assertEquals(cached.getRealm(), cached.getRealm());
+        Assertions.assertEquals(cached.isChallengeComplete(), cached.isChallengeComplete());
     }
 
 }


### PR DESCRIPTION
No more Java serialization in HttpClient