### PR TITLE
HTTPCLIENT-2151: Support for JSSE in-built endpoint identification

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/ConscryptClientTlsStrategy.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/ConscryptClientTlsStrategy.java
@@ -54,6 +54,7 @@ public class ConscryptClientTlsStrategy extends AbstractClientTlsStrategy {
     public static TlsStrategy getDefault() {
         return new ConscryptClientTlsStrategy(
                 SSLContexts.createDefault(),
+                HostnameVerificationPolicy.BOTH,
                 HttpsSupport.getDefaultHostnameVerifier());
     }
 
@@ -63,6 +64,7 @@ public class ConscryptClientTlsStrategy extends AbstractClientTlsStrategy {
                 HttpsSupport.getSystemProtocols(),
                 HttpsSupport.getSystemCipherSuits(),
                 SSLBufferMode.STATIC,
+                HostnameVerificationPolicy.BOTH,
                 HttpsSupport.getDefaultHostnameVerifier());
     }
 
@@ -72,13 +74,36 @@ public class ConscryptClientTlsStrategy extends AbstractClientTlsStrategy {
             final String[] supportedCipherSuites,
             final SSLBufferMode sslBufferManagement,
             final HostnameVerifier hostnameVerifier) {
-        super(sslContext, supportedProtocols, supportedCipherSuites, sslBufferManagement, hostnameVerifier);
+        this(sslContext, supportedProtocols, supportedCipherSuites, sslBufferManagement, HostnameVerificationPolicy.CLIENT, hostnameVerifier);
+    }
+
+    /**
+     * @since 5.4
+     */
+    public ConscryptClientTlsStrategy(
+            final SSLContext sslContext,
+            final String[] supportedProtocols,
+            final String[] supportedCipherSuites,
+            final SSLBufferMode sslBufferManagement,
+            final HostnameVerificationPolicy hostnameVerificationPolicy,
+            final HostnameVerifier hostnameVerifier) {
+        super(sslContext, supportedProtocols, supportedCipherSuites, sslBufferManagement, hostnameVerificationPolicy, hostnameVerifier);
     }
 
     public ConscryptClientTlsStrategy(
             final SSLContext sslContext,
             final HostnameVerifier hostnameVerifier) {
         this(sslContext, null, null, SSLBufferMode.STATIC, hostnameVerifier);
+    }
+
+    /**
+     * @since 5.4
+     */
+    public ConscryptClientTlsStrategy(
+            final SSLContext sslContext,
+            final HostnameVerificationPolicy hostnameVerificationPolicy,
+            final HostnameVerifier hostnameVerifier) {
+        this(sslContext, null, null, SSLBufferMode.STATIC, hostnameVerificationPolicy, hostnameVerifier);
     }
 
     public ConscryptClientTlsStrategy(final SSLContext sslContext) {

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/DefaultClientTlsStrategy.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/DefaultClientTlsStrategy.java
@@ -54,6 +54,7 @@ public class DefaultClientTlsStrategy extends AbstractClientTlsStrategy {
     public static DefaultClientTlsStrategy createDefault() {
         return new DefaultClientTlsStrategy(
                 SSLContexts.createDefault(),
+                HostnameVerificationPolicy.BOTH,
                 HttpsSupport.getDefaultHostnameVerifier());
     }
 
@@ -66,6 +67,7 @@ public class DefaultClientTlsStrategy extends AbstractClientTlsStrategy {
                 HttpsSupport.getSystemProtocols(),
                 HttpsSupport.getSystemCipherSuits(),
                 SSLBufferMode.STATIC,
+                HostnameVerificationPolicy.BOTH,
                 HttpsSupport.getDefaultHostnameVerifier());
     }
 
@@ -102,8 +104,21 @@ public class DefaultClientTlsStrategy extends AbstractClientTlsStrategy {
             final SSLBufferMode sslBufferManagement,
             final HostnameVerifier hostnameVerifier,
             final Factory<SSLEngine, TlsDetails> tlsDetailsFactory) {
-        super(sslContext, supportedProtocols, supportedCipherSuites, sslBufferManagement, hostnameVerifier);
+        super(sslContext, supportedProtocols, supportedCipherSuites, sslBufferManagement, HostnameVerificationPolicy.CLIENT, hostnameVerifier);
         this.tlsDetailsFactory = tlsDetailsFactory;
+    }
+
+    /**
+     * @since 5.4
+     */
+    public DefaultClientTlsStrategy(
+            final SSLContext sslContext,
+            final String[] supportedProtocols,
+            final String[] supportedCipherSuites,
+            final SSLBufferMode sslBufferManagement,
+            final HostnameVerificationPolicy hostnameVerificationPolicy,
+            final HostnameVerifier hostnameVerifier) {
+        super(sslContext, supportedProtocols, supportedCipherSuites, sslBufferManagement, hostnameVerificationPolicy, hostnameVerifier);
     }
 
     public DefaultClientTlsStrategy(
@@ -112,13 +127,23 @@ public class DefaultClientTlsStrategy extends AbstractClientTlsStrategy {
             final String[] supportedCipherSuites,
             final SSLBufferMode sslBufferManagement,
             final HostnameVerifier hostnameVerifier) {
-        super(sslContext, supportedProtocols, supportedCipherSuites, sslBufferManagement, hostnameVerifier);
+        this(sslContext, supportedProtocols, supportedCipherSuites, sslBufferManagement, HostnameVerificationPolicy.CLIENT, hostnameVerifier);
     }
 
     public DefaultClientTlsStrategy(
             final SSLContext sslContext,
             final HostnameVerifier hostnameVerifier) {
         this(sslContext, null, null, SSLBufferMode.STATIC, hostnameVerifier);
+    }
+
+    /**
+     * @since 5.4
+     */
+    public DefaultClientTlsStrategy(
+            final SSLContext sslContext,
+            final HostnameVerificationPolicy hostnameVerificationPolicy,
+            final HostnameVerifier hostnameVerifier) {
+        this(sslContext, null, null, SSLBufferMode.STATIC, hostnameVerificationPolicy, hostnameVerifier);
     }
 
     public DefaultClientTlsStrategy(final SSLContext sslContext) {

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/HostnameVerificationPolicy.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/HostnameVerificationPolicy.java
@@ -1,0 +1,53 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.hc.client5.http.ssl;
+
+/**
+ * Hostname verification policy.
+ *
+ * @see javax.net.ssl.HostnameVerifier
+ * @see DefaultHostnameVerifier
+ *
+ * @since 5.4
+ */
+public enum HostnameVerificationPolicy {
+
+    /**
+     * Hostname verification is delegated to the JSSE provider, usually executed during the TLS handshake.
+     */
+    BUILTIN,
+    /**
+     * Hostname verification is executed by HttpClient post TLS handshake.
+     */
+    CLIENT,
+    /**
+     * Hostname verification is executed by the JSSE provider and by HttpClient post TLS handshake.
+     */
+    BOTH
+
+}


### PR DESCRIPTION
This change-set extends the public APIs with hostname verification options:
* `Built-In`: Hostname verification is delegated to the JSSE provider, usually executed during the TLS handshake 
* `Client`: Hostname verification is executed by HttpClient post TLS handshake
* `Both`: Hostname verification is executed by the JSSE provider and by HttpClient post TLS handshake

The `Both` option is used by default. It provides the benefit of backward compatibility with the behavior of previous versions of HttpClient, added security (hostnames get verified by the JSSE provider and by the client) and fail-early approach (invalid hostnames can get rejected during the TLS handshake). At the same some checks may get performed twice and result in certain (likely minor) performance hit. In the future HttpClient may switch to `Built-In` as the default.