### PR TITLE
HTTPCLIENT-2318 - Enhance PoolingHttpClientConnectionManager with isShutdown State Check.

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/BasicHttpClientConnectionManager.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/BasicHttpClientConnectionManager.java
@@ -711,8 +711,9 @@ public class BasicHttpClientConnectionManager implements HttpClientConnectionMan
      *
      * @return {@code true} if the connection manager has been shut down and is closed, otherwise
      * return {@code false}.
+     * @since 5.4
      */
-    boolean isClosed() {
+    public boolean isClosed() {
         return this.closed.get();
     }
 

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java
@@ -423,6 +423,11 @@ public class PoolingHttpClientConnectionManager
         if (LOG.isDebugEnabled()) {
             LOG.debug("{} releasing endpoint", ConnPoolSupport.getId(endpoint));
         }
+
+        if (this.isClosed()) {
+            return;
+        }
+
         final ManagedHttpClientConnection conn = entry.getConnection();
         if (conn != null && keepAlive == null) {
             conn.close(CloseMode.GRACEFUL);
@@ -522,11 +527,17 @@ public class PoolingHttpClientConnectionManager
         if (LOG.isDebugEnabled()) {
             LOG.debug("Closing connections idle longer than {}", idleTime);
         }
+        if (isClosed()) {
+            return;
+        }
         this.pool.closeIdle(idleTime);
     }
 
     @Override
     public void closeExpired() {
+        if (isClosed()) {
+            return;
+        }
         LOG.debug("Closing expired connections");
         this.pool.closeExpired();
     }
@@ -795,5 +806,18 @@ public class PoolingHttpClientConnectionManager
         }
 
     }
+
+    /**
+     * Method that can be called to determine whether the connection manager has been shut down and
+     * is closed or not.
+     *
+     * @return {@code true} if the connection manager has been shut down and is closed, otherwise
+     * return {@code false}.
+     * @since 5.4
+     */
+    public boolean isClosed() {
+        return this.closed.get();
+    }
+
 
 }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java
@@ -394,6 +394,9 @@ public class PoolingAsyncClientConnectionManager implements AsyncClientConnectio
         if (LOG.isDebugEnabled()) {
             LOG.debug("{} releasing endpoint", ConnPoolSupport.getId(endpoint));
         }
+        if (this.isClosed()) {
+            return;
+        }
         final ManagedAsyncClientConnection connection = entry.getConnection();
         boolean reusable = connection != null && connection.isOpen();
         try {
@@ -575,11 +578,17 @@ public class PoolingAsyncClientConnectionManager implements AsyncClientConnectio
 
     @Override
     public void closeIdle(final TimeValue idletime) {
+        if (isClosed()) {
+            return;
+        }
         pool.closeIdle(idletime);
     }
 
     @Override
     public void closeExpired() {
+        if (isClosed()) {
+            return;
+        }
         pool.closeExpired();
     }
 
@@ -773,8 +782,9 @@ public class PoolingAsyncClientConnectionManager implements AsyncClientConnectio
      *
      * @return {@code true} if the connection manager has been shut down and is closed, otherwise
      * return {@code false}.
+     * @since 5.4
      */
-    boolean isClosed() {
+    public boolean isClosed() {
         return this.closed.get();
     }
 


### PR DESCRIPTION
This PR addresses the issue described in [HTTPCLIENT-2318](https://issues.apache.org/jira/browse/HTTPCLIENT-2318) by enhancing the `PoolingHttpClientConnectionManager`. It introduces an isShutdown method for clear state checking and refines the close method for improved resource management, aiming to improve usability and reliability without affecting backward compatibility.