### PR TITLE
Redesign of client HTTP context APIs

### DIFF
--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/cache/CacheResponseStatus.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/cache/CacheResponseStatus.java
@@ -28,10 +28,7 @@ package org.apache.hc.client5.http.cache;
 
 /**
  * This enumeration represents the various ways a response can be generated
- * by the caching {@link org.apache.hc.client5.http.classic.HttpClient};
- * if a request is executed with an {@link HttpCacheContext}
- * then a parameter with one of these values will be registered in the
- * context under the key  {@link HttpCacheContext#CACHE_RESPONSE_STATUS}.
+ * by an HTTP cache.
  */
 public enum CacheResponseStatus {
 

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/cache/HttpCacheContext.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/cache/HttpCacheContext.java
@@ -26,50 +26,102 @@
  */
 package org.apache.hc.client5.http.cache;
 
+import java.util.Map;
+
+import javax.net.ssl.SSLSession;
+
+import org.apache.hc.client5.http.HttpRoute;
+import org.apache.hc.client5.http.RouteInfo;
+import org.apache.hc.client5.http.auth.AuthCache;
+import org.apache.hc.client5.http.auth.AuthExchange;
+import org.apache.hc.client5.http.auth.AuthScheme;
+import org.apache.hc.client5.http.auth.AuthSchemeFactory;
+import org.apache.hc.client5.http.auth.CredentialsProvider;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.cookie.CookieOrigin;
+import org.apache.hc.client5.http.cookie.CookieSpec;
+import org.apache.hc.client5.http.cookie.CookieSpecFactory;
+import org.apache.hc.client5.http.cookie.CookieStore;
 import org.apache.hc.client5.http.protocol.HttpClientContext;
+import org.apache.hc.client5.http.protocol.RedirectLocations;
+import org.apache.hc.core5.annotation.Internal;
+import org.apache.hc.core5.http.EndpointDetails;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.ProtocolVersion;
+import org.apache.hc.core5.http.config.Lookup;
 import org.apache.hc.core5.http.protocol.HttpContext;
 
 /**
- * Adaptor class that provides convenience type safe setters and getters
- * for caching {@link HttpContext} attributes.
+ * Cache execution {@link HttpContext}. This class can be re-used for
+ * multiple consecutive logically related request executions that represent
+ * a single communication session. This context may not be used concurrently.
+ * <p>
+ * IMPORTANT: This class is NOT thread-safe and MUST NOT be used concurrently by
+ * multiple message exchanges.
  *
  * @since 4.3
  */
 public class HttpCacheContext extends HttpClientContext {
 
     /**
-     * This is the name under which the {@link CacheResponseStatus} of a request
-     * (for example, whether it resulted in a cache hit) will be recorded if an
-     * {@link HttpContext} is provided during execution.
+     * @deprecated Use getter methods
      */
+    @Deprecated
     public static final String CACHE_RESPONSE_STATUS = "http.cache.response.status";
+    static final String REQUEST_CACHE_CONTROL = "http.cache.request-control";
+    static final String RESPONSE_CACHE_CONTROL = "http.cache.response-control";
+    static final String CACHE_ENTRY = "http.cache.entry";
 
     /**
-     * @since 5.4
+     * @deprecated Use {@link #castOrCreate(HttpContext)}.
      */
-    public static final String CACHE_ENTRY = "http.cache.entry";
-
-    /**
-     * @since 5.4
-     */
-    public static final String CACHE_REQUEST_CONTROL = "http.cache.request.control";
-
-    /**
-     * @since 5.4
-     */
-    public static final String CACHE_RESPONSE_CONTROL = "http.cache.response.control";
-
+    @Deprecated
     public static HttpCacheContext adapt(final HttpContext context) {
         if (context instanceof HttpCacheContext) {
             return (HttpCacheContext) context;
-        } else {
-            return new HttpCacheContext(context);
         }
+        return new Delegate(HttpClientContext.castOrCreate(context));
+    }
+
+    /**
+     * Casts the given generic {@link HttpContext} as {@link HttpCacheContext} or
+     * throws an {@link IllegalStateException} if the given context is not suitable.
+     *
+     * @since 5.4
+     */
+    public static HttpCacheContext cast(final HttpContext context) {
+        if (context == null) {
+            return null;
+        }
+        if (context instanceof HttpCacheContext) {
+            return (HttpCacheContext) context;
+        } else if (context instanceof HttpClientContext) {
+            return new Delegate((HttpClientContext) context);
+        } else {
+            return new Delegate(HttpClientContext.cast(context));
+        }
+    }
+
+    /**
+     * Casts the given generic {@link HttpContext} as {@link HttpCacheContext} or
+     * creates new {@link HttpCacheContext} if the given context is null..
+     *
+     * @since 5.4
+     */
+    public static HttpCacheContext castOrCreate(final HttpContext context) {
+        return context != null ? cast(context) : create();
     }
 
     public static HttpCacheContext create() {
         return new HttpCacheContext();
     }
+
+    private CacheResponseStatus responseStatus;
+    private RequestCacheControl requestCacheControl;
+    private ResponseCacheControl responseCacheControl;
+    private HttpCacheEntry cacheEntry;
 
     public HttpCacheContext(final HttpContext context) {
         super(context);
@@ -79,59 +131,377 @@ public class HttpCacheContext extends HttpClientContext {
         super();
     }
 
+    /**
+     * Represents an outcome of the cache operation and the way the response has been
+     * generated.
+     * <p>
+     * This context attribute is expected to be populated by the protocol handler.
+     */
     public CacheResponseStatus getCacheResponseStatus() {
-        return getAttribute(CACHE_RESPONSE_STATUS, CacheResponseStatus.class);
+        return responseStatus;
     }
 
     /**
      * @since 5.4
      */
-    public void setCacheResponseStatus(final CacheResponseStatus status) {
-        setAttribute(CACHE_RESPONSE_STATUS, status);
+    @Internal
+    public void setCacheResponseStatus(final CacheResponseStatus responseStatus) {
+        this.responseStatus = responseStatus;
     }
 
     /**
+     * Represents cache control requested by the client.
+     * <p>
+     * This context attribute is expected to be set by the caller.
+     *
      * @since 5.4
      */
     public RequestCacheControl getRequestCacheControl() {
-        final RequestCacheControl cacheControl = getAttribute(CACHE_REQUEST_CONTROL, RequestCacheControl.class);
+        return requestCacheControl;
+    }
+
+    /**
+     * Returns cache control requested by the client or {@link RequestCacheControl#DEFAULT}
+     * if not explicitly set in the context.
+     *
+     * @since 5.4
+     */
+    public final RequestCacheControl getRequestCacheControlOrDefault() {
+        final RequestCacheControl cacheControl = getRequestCacheControl();
         return cacheControl != null ? cacheControl : RequestCacheControl.DEFAULT;
     }
 
     /**
      * @since 5.4
      */
+    @Internal
     public void setRequestCacheControl(final RequestCacheControl requestCacheControl) {
-        setAttribute(CACHE_REQUEST_CONTROL, requestCacheControl);
+        this.requestCacheControl = requestCacheControl;
     }
 
     /**
+     * Represents cache control enforced by the server.
+     * <p>
+     * This context attribute is expected to be populated by the protocol handler.
+     *
      * @since 5.4
      */
     public ResponseCacheControl getResponseCacheControl() {
-        final ResponseCacheControl cacheControl = getAttribute(CACHE_RESPONSE_CONTROL, ResponseCacheControl.class);
+        return responseCacheControl;
+    }
+
+    /**
+     * Represents cache control enforced by the server or {@link ResponseCacheControl#DEFAULT}
+     * if not explicitly set in the context.
+     *
+     * @since 5.4
+     */
+    public final ResponseCacheControl getResponseCacheControlOrDefault() {
+        final ResponseCacheControl cacheControl = getResponseCacheControl();
         return cacheControl != null ? cacheControl : ResponseCacheControl.DEFAULT;
     }
 
     /**
      * @since 5.4
      */
+    @Internal
     public void setResponseCacheControl(final ResponseCacheControl responseCacheControl) {
-        setAttribute(CACHE_RESPONSE_CONTROL, responseCacheControl);
+        this.responseCacheControl = responseCacheControl;
     }
 
     /**
+     * Represents the cache entry the resource of which has been used to generate the response.
+     * <p>
+     * This context attribute is expected to be populated by the protocol handler.
+     *
      * @since 5.4
      */
     public HttpCacheEntry getCacheEntry() {
-        return getAttribute(CACHE_ENTRY, HttpCacheEntry.class);
+        return cacheEntry;
     }
 
     /**
      * @since 5.4
      */
-    public void setCacheEntry(final HttpCacheEntry entry) {
-        setAttribute(CACHE_ENTRY, entry);
+    @Internal
+    public void setCacheEntry(final HttpCacheEntry cacheEntry) {
+        this.cacheEntry = cacheEntry;
+    }
+
+    /**
+     * Internal adaptor class that delegates all its method calls to {@link HttpClientContext}.
+     * To be removed in the future.
+     */
+    @SuppressWarnings("deprecation")
+    @Internal
+    static class Delegate extends HttpCacheContext {
+
+        private final HttpClientContext clientContext;
+
+        Delegate(final HttpClientContext clientContext) {
+            super(null);
+            this.clientContext = clientContext;
+        }
+
+        @Override
+        public CacheResponseStatus getCacheResponseStatus() {
+            return clientContext.getAttribute(CACHE_RESPONSE_STATUS, CacheResponseStatus.class);
+        }
+
+        @Override
+        public void setCacheResponseStatus(final CacheResponseStatus responseStatus) {
+            clientContext.setAttribute(CACHE_RESPONSE_STATUS, responseStatus);
+        }
+
+        @Override
+        public RequestCacheControl getRequestCacheControl() {
+            return clientContext.getAttribute(REQUEST_CACHE_CONTROL, RequestCacheControl.class);
+        }
+
+        @Override
+        public void setRequestCacheControl(final RequestCacheControl requestCacheControl) {
+            clientContext.setAttribute(REQUEST_CACHE_CONTROL, requestCacheControl);
+        }
+
+        @Override
+        public ResponseCacheControl getResponseCacheControl() {
+            return clientContext.getAttribute(RESPONSE_CACHE_CONTROL, ResponseCacheControl.class);
+        }
+
+        @Override
+        public void setResponseCacheControl(final ResponseCacheControl responseCacheControl) {
+            clientContext.setAttribute(RESPONSE_CACHE_CONTROL, responseCacheControl);
+        }
+
+        @Override
+        public HttpCacheEntry getCacheEntry() {
+            return clientContext.getAttribute(CACHE_ENTRY, HttpCacheEntry.class);
+        }
+
+        @Override
+        public void setCacheEntry(final HttpCacheEntry cacheEntry) {
+            clientContext.setAttribute(CACHE_ENTRY, cacheEntry);
+        }
+
+        @Override
+        public RouteInfo getHttpRoute() {
+            return clientContext.getHttpRoute();
+        }
+
+        @Override
+        @Internal
+        public void setRoute(final HttpRoute route) {
+            clientContext.setRoute(route);
+        }
+
+        @Override
+        public RedirectLocations getRedirectLocations() {
+            return clientContext.getRedirectLocations();
+        }
+
+        @Override
+        @Internal
+        public void setRedirectLocations(final RedirectLocations redirectLocations) {
+            clientContext.setRedirectLocations(redirectLocations);
+        }
+
+        @Override
+        public CookieStore getCookieStore() {
+            return clientContext.getCookieStore();
+        }
+
+        @Override
+        public void setCookieStore(final CookieStore cookieStore) {
+            clientContext.setCookieStore(cookieStore);
+        }
+
+        @Override
+        public CookieSpec getCookieSpec() {
+            return clientContext.getCookieSpec();
+        }
+
+        @Override
+        @Internal
+        public void setCookieSpec(final CookieSpec cookieSpec) {
+            clientContext.setCookieSpec(cookieSpec);
+        }
+
+        @Override
+        public CookieOrigin getCookieOrigin() {
+            return clientContext.getCookieOrigin();
+        }
+
+        @Override
+        @Internal
+        public void setCookieOrigin(final CookieOrigin cookieOrigin) {
+            clientContext.setCookieOrigin(cookieOrigin);
+        }
+
+        @Override
+        public Lookup<CookieSpecFactory> getCookieSpecRegistry() {
+            return clientContext.getCookieSpecRegistry();
+        }
+
+        @Override
+        public void setCookieSpecRegistry(final Lookup<CookieSpecFactory> lookup) {
+            clientContext.setCookieSpecRegistry(lookup);
+        }
+
+        @Override
+        public Lookup<AuthSchemeFactory> getAuthSchemeRegistry() {
+            return clientContext.getAuthSchemeRegistry();
+        }
+
+        @Override
+        public void setAuthSchemeRegistry(final Lookup<AuthSchemeFactory> lookup) {
+            clientContext.setAuthSchemeRegistry(lookup);
+        }
+
+        @Override
+        public CredentialsProvider getCredentialsProvider() {
+            return clientContext.getCredentialsProvider();
+        }
+
+        @Override
+        public void setCredentialsProvider(final CredentialsProvider credentialsProvider) {
+            clientContext.setCredentialsProvider(credentialsProvider);
+        }
+
+        @Override
+        public AuthCache getAuthCache() {
+            return clientContext.getAuthCache();
+        }
+
+        @Override
+        public void setAuthCache(final AuthCache authCache) {
+            clientContext.setAuthCache(authCache);
+        }
+
+        @Override
+        public Map<HttpHost, AuthExchange> getAuthExchanges() {
+            return clientContext.getAuthExchanges();
+        }
+
+        @Override
+        public AuthExchange getAuthExchange(final HttpHost host) {
+            return clientContext.getAuthExchange(host);
+        }
+
+        @Override
+        public void setAuthExchange(final HttpHost host, final AuthExchange authExchange) {
+            clientContext.setAuthExchange(host, authExchange);
+        }
+
+        @Override
+        public void resetAuthExchange(final HttpHost host, final AuthScheme authScheme) {
+            clientContext.resetAuthExchange(host, authScheme);
+        }
+
+        @Override
+        public Object getUserToken() {
+            return clientContext.getUserToken();
+        }
+
+        @Override
+        public void setUserToken(final Object userToken) {
+            clientContext.setUserToken(userToken);
+        }
+
+        @Override
+        public RequestConfig getRequestConfig() {
+            return clientContext.getRequestConfig();
+        }
+
+        @Override
+        public void setRequestConfig(final RequestConfig requestConfig) {
+            clientContext.setRequestConfig(requestConfig);
+        }
+
+        @Override
+        public String getExchangeId() {
+            return clientContext.getExchangeId();
+        }
+
+        @Override
+        public void setExchangeId(final String exchangeId) {
+            clientContext.setExchangeId(exchangeId);
+        }
+
+        @Override
+        public HttpRequest getRequest() {
+            return clientContext.getRequest();
+        }
+
+        @Override
+        public void setRequest(final HttpRequest request) {
+            clientContext.setRequest(request);
+        }
+
+        @Override
+        public HttpResponse getResponse() {
+            return clientContext.getResponse();
+        }
+
+        @Override
+        public void setResponse(final HttpResponse response) {
+            clientContext.setResponse(response);
+        }
+
+        @Override
+        public EndpointDetails getEndpointDetails() {
+            return clientContext.getEndpointDetails();
+        }
+
+        @Override
+        public void setEndpointDetails(final EndpointDetails endpointDetails) {
+            clientContext.setEndpointDetails(endpointDetails);
+        }
+
+        @Override
+        public SSLSession getSSLSession() {
+            return clientContext.getSSLSession();
+        }
+
+        @Override
+        public void setSSLSession(final SSLSession sslSession) {
+            clientContext.setSSLSession(sslSession);
+        }
+
+        @Override
+        public ProtocolVersion getProtocolVersion() {
+            return clientContext.getProtocolVersion();
+        }
+
+        @Override
+        public void setProtocolVersion(final ProtocolVersion version) {
+            clientContext.setProtocolVersion(version);
+        }
+
+        @Override
+        public Object getAttribute(final String id) {
+            return clientContext.getAttribute(id);
+        }
+
+        @Override
+        public Object setAttribute(final String id, final Object obj) {
+            return clientContext.setAttribute(id, obj);
+        }
+
+        @Override
+        public Object removeAttribute(final String id) {
+            return clientContext.removeAttribute(id);
+        }
+
+        @Override
+        public <T> T getAttribute(final String id, final Class<T> clazz) {
+            return clientContext.getAttribute(id, clazz);
+        }
+
+        @Override
+        public String toString() {
+            return clientContext.toString();
+        }
+
     }
 
 }

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/cache/HttpCacheContext.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/cache/HttpCacheContext.java
@@ -68,7 +68,7 @@ public class HttpCacheContext extends HttpClientContext {
     }
 
     public static HttpCacheContext create() {
-        return new HttpCacheContext(new HttpClientContext());
+        return new HttpCacheContext();
     }
 
     public HttpCacheContext(final HttpContext context) {

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/AsyncCachingExec.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/AsyncCachingExec.java
@@ -804,7 +804,7 @@ class AsyncCachingExec extends CachingExecBase implements AsyncExecChainHandler 
                                 scope.route,
                                 scope.originalRequest,
                                 new ComplexFuture<>(null),
-                                HttpClientContext.create(),
+                                HttpCacheContext.create(),
                                 scope.execRuntime.fork(),
                                 scope.scheduler,
                                 scope.execCount);

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingExec.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingExec.java
@@ -318,7 +318,7 @@ class CachingExec extends CachingExecBase implements ExecChainHandler {
                             scope.route,
                             scope.originalRequest,
                             scope.execRuntime.fork(null),
-                            HttpClientContext.create());
+                            HttpCacheContext.create());
                     if (LOG.isDebugEnabled()) {
                         LOG.debug("{} starting asynchronous revalidation exchange {}", exchangeId, revalidationExchangeId);
                     }

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingHttpAsyncClientBuilder.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingHttpAsyncClientBuilder.java
@@ -29,19 +29,23 @@ package org.apache.hc.client5.http.impl.cache;
 import java.io.File;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.function.Function;
 
 import org.apache.hc.client5.http.async.AsyncExecChainHandler;
 import org.apache.hc.client5.http.cache.HttpAsyncCacheStorage;
 import org.apache.hc.client5.http.cache.HttpAsyncCacheStorageAdaptor;
+import org.apache.hc.client5.http.cache.HttpCacheContext;
 import org.apache.hc.client5.http.cache.HttpCacheEntryFactory;
 import org.apache.hc.client5.http.cache.HttpCacheStorage;
 import org.apache.hc.client5.http.cache.ResourceFactory;
 import org.apache.hc.client5.http.impl.ChainElement;
 import org.apache.hc.client5.http.impl.async.HttpAsyncClientBuilder;
 import org.apache.hc.client5.http.impl.schedule.ImmediateSchedulingStrategy;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
 import org.apache.hc.client5.http.schedule.SchedulingStrategy;
 import org.apache.hc.core5.annotation.Experimental;
 import org.apache.hc.core5.http.config.NamedElementChain;
+import org.apache.hc.core5.http.protocol.HttpContext;
 
 /**
  * Builder for {@link org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient}
@@ -160,6 +164,11 @@ public class CachingHttpAsyncClientBuilder extends HttpAsyncClientBuilder {
                 cacheRevalidator,
                 config);
         execChainDefinition.addBefore(ChainElement.PROTOCOL.name(), cachingExec, ChainElement.CACHING.name());
+    }
+
+    @Override
+    protected Function<HttpContext, HttpClientContext> contextAdaptor() {
+        return HttpCacheContext::castOrCreate;
     }
 
 }

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingHttpClientBuilder.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingHttpClientBuilder.java
@@ -29,7 +29,9 @@ package org.apache.hc.client5.http.impl.cache;
 import java.io.File;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.function.Function;
 
+import org.apache.hc.client5.http.cache.HttpCacheContext;
 import org.apache.hc.client5.http.cache.HttpCacheEntryFactory;
 import org.apache.hc.client5.http.cache.HttpCacheStorage;
 import org.apache.hc.client5.http.cache.ResourceFactory;
@@ -37,8 +39,10 @@ import org.apache.hc.client5.http.classic.ExecChainHandler;
 import org.apache.hc.client5.http.impl.ChainElement;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.schedule.ImmediateSchedulingStrategy;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
 import org.apache.hc.client5.http.schedule.SchedulingStrategy;
 import org.apache.hc.core5.http.config.NamedElementChain;
+import org.apache.hc.core5.http.protocol.HttpContext;
 
 /**
  * Builder for {@link org.apache.hc.client5.http.impl.classic.CloseableHttpClient}
@@ -151,6 +155,11 @@ public class CachingHttpClientBuilder extends HttpClientBuilder {
                 cacheRevalidator,
                 config);
         execChainDefinition.addBefore(ChainElement.PROTOCOL.name(), cachingExec, ChainElement.CACHING.name());
+    }
+
+    @Override
+    protected Function<HttpContext, HttpClientContext> contextAdaptor() {
+        return HttpCacheContext::castOrCreate;
     }
 
 }

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/cache/example/AsyncClientCacheControl.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/cache/example/AsyncClientCacheControl.java
@@ -87,8 +87,8 @@ public class AsyncClientCacheControl {
                         public void completed(final SimpleHttpResponse response) {
                             System.out.println(httpget1 + "->" + new StatusLine(response));
                             System.out.println("Cache status: " + context.getCacheResponseStatus());
-                            System.out.println("Request cache control: " + context.getRequestCacheControl());
-                            System.out.println("Response cache control: " + context.getResponseCacheControl());
+                            System.out.println("Request cache control: " + context.getRequestCacheControlOrDefault());
+                            System.out.println("Response cache control: " + context.getResponseCacheControlOrDefault());
                             final HttpCacheEntry cacheEntry = context.getCacheEntry();
                             if (cacheEntry != null) {
                                 System.out.println("Cache entry resource: " + cacheEntry.getResource());
@@ -132,8 +132,8 @@ public class AsyncClientCacheControl {
                         public void completed(final SimpleHttpResponse response) {
                             System.out.println(httpget2 + "->" + new StatusLine(response));
                             System.out.println("Cache status: " + context.getCacheResponseStatus());
-                            System.out.println("Request cache control: " + context.getRequestCacheControl());
-                            System.out.println("Response cache control: " + context.getResponseCacheControl());
+                            System.out.println("Request cache control: " + context.getRequestCacheControlOrDefault());
+                            System.out.println("Response cache control: " + context.getResponseCacheControlOrDefault());
                             final HttpCacheEntry cacheEntry = context.getCacheEntry();
                             if (cacheEntry != null) {
                                 System.out.println("Cache entry resource: " + cacheEntry.getResource());
@@ -179,8 +179,8 @@ public class AsyncClientCacheControl {
                         public void completed(final SimpleHttpResponse response) {
                             System.out.println(httpget3 + "->" + new StatusLine(response));
                             System.out.println("Cache status: " + context.getCacheResponseStatus());
-                            System.out.println("Request cache control: " + context.getRequestCacheControl());
-                            System.out.println("Response cache control: " + context.getResponseCacheControl());
+                            System.out.println("Request cache control: " + context.getRequestCacheControlOrDefault());
+                            System.out.println("Response cache control: " + context.getResponseCacheControlOrDefault());
                             final HttpCacheEntry cacheEntry = context.getCacheEntry();
                             if (cacheEntry != null) {
                                 System.out.println("Cache entry resource: " + cacheEntry.getResource());

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/cache/example/ClientCacheControl.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/cache/example/ClientCacheControl.java
@@ -74,8 +74,8 @@ public class ClientCacheControl {
                 System.out.println(httpget1 + "->" + new StatusLine(response));
                 EntityUtils.consume(response.getEntity());
                 System.out.println("Cache status: " + context.getCacheResponseStatus());
-                System.out.println("Request cache control: " + context.getRequestCacheControl());
-                System.out.println("Response cache control: " + context.getResponseCacheControl());
+                System.out.println("Request cache control: " + context.getRequestCacheControlOrDefault());
+                System.out.println("Response cache control: " + context.getResponseCacheControlOrDefault());
                 final HttpCacheEntry cacheEntry = context.getCacheEntry();
                 if (cacheEntry != null) {
                     System.out.println("Cache entry resource: " + cacheEntry.getResource());
@@ -102,8 +102,8 @@ public class ClientCacheControl {
                 System.out.println(httpget2 + "->" + new StatusLine(response));
                 EntityUtils.consume(response.getEntity());
                 System.out.println("Cache status: " + context.getCacheResponseStatus());
-                System.out.println("Request cache control: " + context.getRequestCacheControl());
-                System.out.println("Response cache control: " + context.getResponseCacheControl());
+                System.out.println("Request cache control: " + context.getRequestCacheControlOrDefault());
+                System.out.println("Response cache control: " + context.getResponseCacheControlOrDefault());
                 final HttpCacheEntry cacheEntry = context.getCacheEntry();
                 if (cacheEntry != null) {
                     System.out.println("Cache entry resource: " + cacheEntry.getResource());
@@ -132,8 +132,8 @@ public class ClientCacheControl {
                 System.out.println(httpget3 + "->" + new StatusLine(response));
                 EntityUtils.consume(response.getEntity());
                 System.out.println("Cache status: " + context.getCacheResponseStatus());
-                System.out.println("Request cache control: " + context.getRequestCacheControl());
-                System.out.println("Response cache control: " + context.getResponseCacheControl());
+                System.out.println("Request cache control: " + context.getRequestCacheControlOrDefault());
+                System.out.println("Response cache control: " + context.getResponseCacheControlOrDefault());
                 final HttpCacheEntry cacheEntry = context.getCacheEntry();
                 if (cacheEntry != null) {
                     System.out.println("Cache entry resource: " + cacheEntry.getResource());

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestProtocolAllowedBehavior.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestProtocolAllowedBehavior.java
@@ -29,9 +29,9 @@ package org.apache.hc.client5.http.impl.cache;
 import java.io.IOException;
 
 import org.apache.hc.client5.http.HttpRoute;
+import org.apache.hc.client5.http.cache.HttpCacheContext;
 import org.apache.hc.client5.http.classic.ExecChain;
 import org.apache.hc.client5.http.classic.ExecRuntime;
-import org.apache.hc.client5.http.protocol.HttpClientContext;
 import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.HttpException;
@@ -59,7 +59,7 @@ public class TestProtocolAllowedBehavior {
 
     HttpHost host;
     HttpRoute route;
-    HttpClientContext context;
+    HttpCacheContext context;
     @Mock
     ExecChain mockExecChain;
     @Mock
@@ -81,7 +81,7 @@ public class TestProtocolAllowedBehavior {
 
         request = new BasicClassicHttpRequest("GET", "/foo");
 
-        context = HttpClientContext.create();
+        context = HttpCacheContext.create();
 
         originResponse = HttpTestUtils.make200Response();
 

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestProtocolRecommendations.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestProtocolRecommendations.java
@@ -38,9 +38,9 @@ import java.util.Iterator;
 
 import org.apache.hc.client5.http.HttpRoute;
 import org.apache.hc.client5.http.auth.StandardAuthScheme;
+import org.apache.hc.client5.http.cache.HttpCacheContext;
 import org.apache.hc.client5.http.classic.ExecChain;
 import org.apache.hc.client5.http.classic.ExecRuntime;
-import org.apache.hc.client5.http.protocol.HttpClientContext;
 import org.apache.hc.client5.http.utils.DateUtils;
 import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.ClassicHttpResponse;
@@ -77,7 +77,7 @@ public class TestProtocolRecommendations {
     HttpHost host;
     HttpRoute route;
     HttpEntity body;
-    HttpClientContext context;
+    HttpCacheContext context;
     @Mock
     ExecChain mockExecChain;
     @Mock
@@ -102,7 +102,7 @@ public class TestProtocolRecommendations {
 
         request = new BasicClassicHttpRequest("GET", "/foo");
 
-        context = HttpClientContext.create();
+        context = HttpCacheContext.create();
 
         originResponse = HttpTestUtils.make200Response();
 

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestProtocolRequirements.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestProtocolRequirements.java
@@ -39,10 +39,10 @@ import java.util.Random;
 
 import org.apache.hc.client5.http.HttpRoute;
 import org.apache.hc.client5.http.auth.StandardAuthScheme;
+import org.apache.hc.client5.http.cache.HttpCacheContext;
 import org.apache.hc.client5.http.cache.HttpCacheEntry;
 import org.apache.hc.client5.http.classic.ExecChain;
 import org.apache.hc.client5.http.classic.ExecRuntime;
-import org.apache.hc.client5.http.protocol.HttpClientContext;
 import org.apache.hc.client5.http.utils.DateUtils;
 import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.ClassicHttpResponse;
@@ -81,7 +81,7 @@ public class TestProtocolRequirements {
     HttpHost host;
     HttpRoute route;
     HttpEntity body;
-    HttpClientContext context;
+    HttpCacheContext context;
     @Mock
     ExecChain mockExecChain;
     @Mock
@@ -105,7 +105,7 @@ public class TestProtocolRequirements {
 
         request = new BasicClassicHttpRequest("GET", "/");
 
-        context = HttpClientContext.create();
+        context = HttpCacheContext.create();
 
         originResponse = HttpTestUtils.make200Response();
 

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestRFC5861Compliance.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestRFC5861Compliance.java
@@ -37,9 +37,9 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 import org.apache.hc.client5.http.HttpRoute;
+import org.apache.hc.client5.http.cache.HttpCacheContext;
 import org.apache.hc.client5.http.classic.ExecChain;
 import org.apache.hc.client5.http.classic.ExecRuntime;
-import org.apache.hc.client5.http.protocol.HttpClientContext;
 import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.HttpEntity;
@@ -70,7 +70,7 @@ public class TestRFC5861Compliance {
     HttpHost host;
     HttpRoute route;
     HttpEntity body;
-    HttpClientContext context;
+    HttpCacheContext context;
     @Mock
     ExecChain mockExecChain;
     @Mock
@@ -94,7 +94,7 @@ public class TestRFC5861Compliance {
 
         request = new BasicClassicHttpRequest("GET", "/foo");
 
-        context = HttpClientContext.create();
+        context = HttpCacheContext.create();
 
         originResponse = HttpTestUtils.make200Response();
 

--- a/httpclient5-fluent/src/main/java/org/apache/hc/client5/http/fluent/Executor.java
+++ b/httpclient5-fluent/src/main/java/org/apache/hc/client5/http/fluent/Executor.java
@@ -232,14 +232,14 @@ public class Executor {
         final HttpClientContext localContext = HttpClientContext.create();
         final CredentialsStore credentialsStoreSnapshot = credentialsStore;
         if (credentialsStoreSnapshot != null) {
-            localContext.setAttribute(HttpClientContext.CREDS_PROVIDER, credentialsStoreSnapshot);
+            localContext.setCredentialsProvider(credentialsStoreSnapshot);
         }
         if (this.authCache != null) {
-            localContext.setAttribute(HttpClientContext.AUTH_CACHE, this.authCache);
+            localContext.setAuthCache(this.authCache);
         }
         final CookieStore cookieStoreSnapshot = cookieStore;
         if (cookieStoreSnapshot != null) {
-            localContext.setAttribute(HttpClientContext.COOKIE_STORE, cookieStoreSnapshot);
+            localContext.setCookieStore(cookieStoreSnapshot);
         }
         return new Response(request.internalExecute(this.httpclient, localContext));
     }

--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/TestHttp1AsyncStatefulConnManagement.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/TestHttp1AsyncStatefulConnManagement.java
@@ -206,7 +206,7 @@ public class TestHttp1AsyncStatefulConnManagement extends AbstractIntegrationTes
         connManager.setDefaultMaxPerRoute(maxConn);
 
         // Bottom of the pool : a *keep alive* connection to Route 1.
-        final HttpContext context1 = new HttpClientContext();
+        final HttpContext context1 = HttpClientContext.create();
         context1.setAttribute("user", "stuff");
 
         final SimpleHttpRequest request1 = SimpleRequestBuilder.get()
@@ -226,7 +226,7 @@ public class TestHttp1AsyncStatefulConnManagement extends AbstractIntegrationTes
 
         // Send a very simple HTTP get (it MUST be simple, no auth, no proxy, no 302, no 401, ...)
         // Send it to another route. Must be a keepalive.
-        final HttpContext context2 = new HttpClientContext();
+        final HttpContext context2 = HttpClientContext.create();
 
         final SimpleHttpRequest request2 = SimpleRequestBuilder.get()
                 .setScheme(target.getSchemeName())
@@ -249,7 +249,7 @@ public class TestHttp1AsyncStatefulConnManagement extends AbstractIntegrationTes
         // So the ConnPoolByRoute will need to kill one connection (it is maxed out globally).
         // The killed conn is the oldest, which means the first HTTPGet ([localhost][stuff]).
         // When this happens, the RouteSpecificPool becomes empty.
-        final HttpContext context3 = new HttpClientContext();
+        final HttpContext context3 = HttpClientContext.create();
 
         final SimpleHttpRequest request3 = SimpleRequestBuilder.get()
                 .setHttpHost(target)

--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestConnectionManagement.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestConnectionManagement.java
@@ -128,7 +128,7 @@ public class TestConnectionManagement {
         final String uri = "/random/" + rsplen;
 
         final ClassicHttpRequest request = new BasicClassicHttpRequest("GET", target, uri);
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
 
         final LeaseRequest leaseRequest1 = connManager.lease("id1", route, null);
         final ConnectionEndpoint endpoint1 = leaseRequest1.get(Timeout.ZERO_MILLISECONDS);
@@ -192,7 +192,7 @@ public class TestConnectionManagement {
         final String uri = "/random/" + rsplen;
 
         final ClassicHttpRequest request = new BasicClassicHttpRequest("GET", target, uri);
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
 
         final LeaseRequest leaseRequest1 = connManager.lease("id1", route, null);
         final ConnectionEndpoint endpoint1 = leaseRequest1.get(Timeout.ZERO_MILLISECONDS);
@@ -258,7 +258,7 @@ public class TestConnectionManagement {
         connManager.setMaxTotal(1);
 
         final HttpRoute route = new HttpRoute(target, null, false);
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
 
         final LeaseRequest leaseRequest1 = connManager.lease("id1", route, null);
         final ConnectionEndpoint endpoint1 = leaseRequest1.get(Timeout.ZERO_MILLISECONDS);
@@ -311,7 +311,7 @@ public class TestConnectionManagement {
         connManager.setMaxTotal(1);
 
         final HttpRoute route = new HttpRoute(target, null, false);
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
 
         final LeaseRequest leaseRequest1 = connManager.lease("id1", route, null);
         final ConnectionEndpoint endpoint1 = leaseRequest1.get(Timeout.ZERO_MILLISECONDS);

--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestDefaultClientTlsStrategy.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestDefaultClientTlsStrategy.java
@@ -104,7 +104,7 @@ public class TestDefaultClientTlsStrategy {
         // @formatter:on
         this.server.start();
 
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
         final TestX509HostnameVerifier hostVerifier = new TestX509HostnameVerifier();
         final TlsSocketStrategy tlsStrategy = new DefaultClientTlsStrategy(
                 SSLTestContexts.createClientSSLContext(), hostVerifier);
@@ -133,7 +133,7 @@ public class TestDefaultClientTlsStrategy {
         // @formatter:on
         this.server.start();
 
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
         final TlsSocketStrategy tlsStrategy = new DefaultClientTlsStrategy(SSLTestContexts.createClientSSLContext());
         final HttpHost target = new HttpHost("https", "localhost", server.getLocalPort());
         try (final Socket socket = new Socket(target.getHostName(), target.getPort())) {
@@ -159,7 +159,7 @@ public class TestDefaultClientTlsStrategy {
         // @formatter:on
         this.server.start();
 
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
         final TestX509HostnameVerifier hostVerifier = new TestX509HostnameVerifier();
         final TlsSocketStrategy tlsStrategy = new DefaultClientTlsStrategy(
                 SSLTestContexts.createClientSSLContext(), hostVerifier);
@@ -189,7 +189,7 @@ public class TestDefaultClientTlsStrategy {
         // @formatter:on
         this.server.start();
 
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
         final TestX509HostnameVerifier hostVerifier = new TestX509HostnameVerifier();
         final TlsSocketStrategy tlsStrategy = new DefaultClientTlsStrategy(
                 SSLTestContexts.createClientSSLContext(), hostVerifier);
@@ -221,7 +221,7 @@ public class TestDefaultClientTlsStrategy {
         // @formatter:on
         this.server.start();
 
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
         // Use default SSL context
         final SSLContext defaultSslContext = SSLContexts.createDefault();
 
@@ -254,7 +254,7 @@ public class TestDefaultClientTlsStrategy {
         // @formatter:on
         this.server.start();
 
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
 
         // @formatter:off
         final SSLContext sslContext = SSLContexts.custom()
@@ -287,7 +287,7 @@ public class TestDefaultClientTlsStrategy {
         // @formatter:on
         this.server.start();
 
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
         final TlsSocketStrategy tlsStrategy = new DefaultClientTlsStrategy(
                 SSLTestContexts.createClientSSLContext());
         final HttpHost target = new HttpHost("https", "localhost", server.getLocalPort());
@@ -339,7 +339,7 @@ public class TestDefaultClientTlsStrategy {
         // @formatter:on
         this.server.start();
 
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
         final TlsSocketStrategy tlsStrategy = new DefaultClientTlsStrategy(
                 SSLTestContexts.createClientSSLContext());
         final HttpHost target = new HttpHost("https", "localhost", server.getLocalPort());
@@ -369,7 +369,7 @@ public class TestDefaultClientTlsStrategy {
                     SSLTestContexts.createClientSSLContext(),
                     HostnameVerificationPolicy.CLIENT,
                     HttpsSupport.getDefaultHostnameVerifier());
-            final HttpClientContext context = new HttpClientContext();
+            final HttpClientContext context = HttpClientContext.create();
             final SSLSocket upgradedSocket = tlsStrategy.upgrade(
                     socket,
                     target1.getHostName(),
@@ -387,7 +387,7 @@ public class TestDefaultClientTlsStrategy {
                     SSLTestContexts.createClientSSLContext(),
                     HostnameVerificationPolicy.CLIENT,
                     HttpsSupport.getDefaultHostnameVerifier());
-            final HttpClientContext context = new HttpClientContext();
+            final HttpClientContext context = HttpClientContext.create();
             Assertions.assertThrows(SSLPeerUnverifiedException.class, () ->
                     tlsStrategy.upgrade(
                             socket,
@@ -402,7 +402,7 @@ public class TestDefaultClientTlsStrategy {
                     SSLTestContexts.createClientSSLContext(),
                     HostnameVerificationPolicy.CLIENT,
                     NoopHostnameVerifier.INSTANCE);
-            final HttpClientContext context = new HttpClientContext();
+            final HttpClientContext context = HttpClientContext.create();
             final SSLSocket upgradedSocket = tlsStrategy.upgrade(
                     socket,
                     target1.getHostName(),
@@ -430,7 +430,7 @@ public class TestDefaultClientTlsStrategy {
                     SSLTestContexts.createClientSSLContext(),
                     HostnameVerificationPolicy.BUILTIN,
                     NoopHostnameVerifier.INSTANCE);
-            final HttpClientContext context = new HttpClientContext();
+            final HttpClientContext context = HttpClientContext.create();
             final SSLSocket upgradedSocket = tlsStrategy.upgrade(
                     socket,
                     target1.getHostName(),
@@ -448,7 +448,7 @@ public class TestDefaultClientTlsStrategy {
                     SSLTestContexts.createClientSSLContext(),
                     HostnameVerificationPolicy.BUILTIN,
                     NoopHostnameVerifier.INSTANCE);
-            final HttpClientContext context = new HttpClientContext();
+            final HttpClientContext context = HttpClientContext.create();
             Assertions.assertThrows(SSLHandshakeException.class, () ->
                     tlsStrategy.upgrade(
                             socket,

--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestStatefulConnManagement.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestStatefulConnManagement.java
@@ -216,7 +216,7 @@ public class TestStatefulConnManagement {
         );
 
         // Bottom of the pool : a *keep alive* connection to Route 1.
-        final HttpContext context1 = new HttpClientContext();
+        final HttpContext context1 = HttpClientContext.create();
         context1.setAttribute("user", "stuff");
         client.execute(target, new HttpGet("/"), context1, response -> {
             EntityUtils.consume(response.getEntity());
@@ -231,7 +231,7 @@ public class TestStatefulConnManagement {
 
         // Send a very simple HTTP get (it MUST be simple, no auth, no proxy, no 302, no 401, ...)
         // Send it to another route. Must be a keepalive.
-        final HttpContext context2 = new HttpClientContext();
+        final HttpContext context2 = HttpClientContext.create();
         client.execute(new HttpHost("127.0.0.1", server.getPort()), new HttpGet("/"), context2, response -> {
             EntityUtils.consume(response.getEntity());
             return null;
@@ -247,7 +247,7 @@ public class TestStatefulConnManagement {
         // So the ConnPoolByRoute will need to kill one connection (it is maxed out globally).
         // The killed conn is the oldest, which means the first HTTPGet ([localhost][stuff]).
         // When this happens, the RouteSpecificPool becomes empty.
-        final HttpContext context3 = new HttpClientContext();
+        final HttpContext context3 = HttpClientContext.create();
         client.execute(target, new HttpGet("/"), context3, response -> {
             EntityUtils.consume(response.getEntity());
             return null;

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/ContextBuilder.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/ContextBuilder.java
@@ -102,7 +102,7 @@ public class ContextBuilder extends AbstractClientContextBuilder<HttpClientConte
 
     @Override
     protected HttpClientContext createContext() {
-        return new HttpClientContext();
+        return HttpClientContext.create();
     }
 
 }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/async/AsyncExecChain.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/async/AsyncExecChain.java
@@ -81,7 +81,7 @@ public interface AsyncExecChain {
             this.route = Args.notNull(route, "Route");
             this.originalRequest = Args.notNull(originalRequest, "Original request");
             this.cancellableDependency = Args.notNull(cancellableDependency, "Dependency");
-            this.clientContext = clientContext != null ? clientContext : HttpClientContext.create();
+            this.clientContext = Args.notNull(clientContext, "HTTP context");
             this.execRuntime = Args.notNull(execRuntime, "Exec runtime");
             this.scheduler = scheduler;
             this.execCount = execCount != null ? execCount : new AtomicInteger(1);

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/classic/ExecChain.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/classic/ExecChain.java
@@ -59,7 +59,7 @@ public interface ExecChain {
             this.route = Args.notNull(route, "Route");
             this.originalRequest = Args.notNull(originalRequest, "Original request");
             this.execRuntime = Args.notNull(execRuntime, "Exec runtime");
-            this.clientContext = clientContext != null ? clientContext : HttpClientContext.create();
+            this.clientContext = Args.notNull(clientContext, "HTTP context");
         }
 
     }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/DefaultAuthenticationStrategy.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/DefaultAuthenticationStrategy.java
@@ -77,7 +77,7 @@ public class DefaultAuthenticationStrategy implements AuthenticationStrategy {
         Args.notNull(challengeType, "ChallengeType");
         Args.notNull(challenges, "Map of auth challenges");
         Args.notNull(context, "HTTP context");
-        final HttpClientContext clientContext = HttpClientContext.adapt(context);
+        final HttpClientContext clientContext = HttpClientContext.cast(context);
         final String exchangeId = clientContext.getExchangeId();
 
         final List<AuthScheme> options = new ArrayList<>();
@@ -88,7 +88,7 @@ public class DefaultAuthenticationStrategy implements AuthenticationStrategy {
             }
             return options;
         }
-        final RequestConfig config = clientContext.getRequestConfig();
+        final RequestConfig config = clientContext.getRequestConfigOrDefault();
         Collection<String> authPrefs = challengeType == ChallengeType.TARGET ?
                 config.getTargetPreferredAuthSchemes() : config.getProxyPreferredAuthSchemes();
         if (authPrefs == null) {

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/DefaultConnectionKeepAliveStrategy.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/DefaultConnectionKeepAliveStrategy.java
@@ -71,8 +71,8 @@ public class DefaultConnectionKeepAliveStrategy implements ConnectionKeepAliveSt
                 }
             }
         }
-        final HttpClientContext clientContext = HttpClientContext.adapt(context);
-        final RequestConfig requestConfig = clientContext.getRequestConfig();
+        final HttpClientContext clientContext = HttpClientContext.cast(context);
+        final RequestConfig requestConfig = clientContext.getRequestConfigOrDefault();
         return requestConfig.getConnectionKeepAlive();
     }
 

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/DefaultUserTokenHandler.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/DefaultUserTokenHandler.java
@@ -69,7 +69,7 @@ public class DefaultUserTokenHandler implements UserTokenHandler {
     @Override
     public Object getUserToken(final HttpRoute route, final HttpRequest request, final HttpContext context) {
 
-        final HttpClientContext clientContext = HttpClientContext.adapt(context);
+        final HttpClientContext clientContext = HttpClientContext.cast(context);
 
         final HttpHost target = request != null ? new HttpHost(request.getScheme(), request.getAuthority()) : route.getTargetHost();
 

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/AbstractMinimalHttpAsyncClientBase.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/AbstractMinimalHttpAsyncClientBase.java
@@ -29,7 +29,6 @@ package org.apache.hc.client5.http.impl.async;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadFactory;
 
-import org.apache.hc.client5.http.protocol.HttpClientContext;
 import org.apache.hc.core5.concurrent.Cancellable;
 import org.apache.hc.core5.concurrent.ComplexFuture;
 import org.apache.hc.core5.concurrent.FutureCallback;
@@ -86,7 +85,7 @@ abstract class AbstractMinimalHttpAsyncClientBase extends AbstractHttpAsyncClien
     }
 
     public final Cancellable execute(final AsyncClientExchangeHandler exchangeHandler) {
-        return execute(exchangeHandler, null, HttpClientContext.create());
+        return execute(exchangeHandler, null, null);
     }
 
     public abstract Cancellable execute(

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/AsyncConnectExec.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/AsyncConnectExec.java
@@ -509,7 +509,7 @@ public final class AsyncConnectExec implements AsyncExecChainHandler {
             final HttpHost proxy,
             final HttpResponse response,
             final HttpClientContext context) {
-        final RequestConfig config = context.getRequestConfig();
+        final RequestConfig config = context.getRequestConfigOrDefault();
         if (config.isAuthenticationEnabled()) {
             final boolean proxyAuthRequested = authenticator.isChallenged(proxy, ChallengeType.PROXY, response, proxyAuthExchange, context);
 

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/AsyncProtocolExec.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/AsyncProtocolExec.java
@@ -306,7 +306,7 @@ public final class AsyncProtocolExec implements AsyncExecChainHandler {
             final String pathPrefix,
             final HttpResponse response,
             final HttpClientContext context) {
-        final RequestConfig config = context.getRequestConfig();
+        final RequestConfig config = context.getRequestConfigOrDefault();
         if (config.isAuthenticationEnabled()) {
             final boolean targetAuthRequested = authenticator.isChallenged(
                     target, ChallengeType.TARGET, response, targetAuthExchange, context);

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/AsyncRedirectExec.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/AsyncRedirectExec.java
@@ -118,7 +118,7 @@ public final class AsyncRedirectExec implements AsyncExecChainHandler {
                     final EntityDetails entityDetails) throws HttpException, IOException {
 
                 state.redirectURI = null;
-                final RequestConfig config = clientContext.getRequestConfig();
+                final RequestConfig config = clientContext.getRequestConfigOrDefault();
                 if (config.isRedirectsEnabled() && redirectStrategy.isRedirected(request, response, clientContext)) {
                     if (state.redirectCount >= state.maxRedirects) {
                         throw new RedirectException("Maximum redirects (" + state.maxRedirects + ") exceeded");
@@ -263,11 +263,11 @@ public final class AsyncRedirectExec implements AsyncExecChainHandler {
         RedirectLocations redirectLocations = clientContext.getRedirectLocations();
         if (redirectLocations == null) {
             redirectLocations = new RedirectLocations();
-            clientContext.setAttribute(HttpClientContext.REDIRECT_LOCATIONS, redirectLocations);
+            clientContext.setRedirectLocations(redirectLocations);
         }
         redirectLocations.clear();
 
-        final RequestConfig config = clientContext.getRequestConfig();
+        final RequestConfig config = clientContext.getRequestConfigOrDefault();
 
         final State state = new State();
         state.maxRedirects = config.getMaxRedirects() > 0 ? config.getMaxRedirects() : 50;

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/CloseableHttpAsyncClient.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/CloseableHttpAsyncClient.java
@@ -33,7 +33,6 @@ import org.apache.hc.client5.http.async.methods.SimpleHttpRequest;
 import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
 import org.apache.hc.client5.http.async.methods.SimpleRequestProducer;
 import org.apache.hc.client5.http.async.methods.SimpleResponseConsumer;
-import org.apache.hc.client5.http.protocol.HttpClientContext;
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.concurrent.FutureCallback;
@@ -113,7 +112,7 @@ public abstract class CloseableHttpAsyncClient implements HttpAsyncClient, Modal
             final FutureCallback<T> callback) {
         Args.notNull(requestProducer, "Request producer");
         Args.notNull(responseConsumer, "Response consumer");
-        return execute(requestProducer, responseConsumer, HttpClientContext.create(), callback);
+        return execute(requestProducer, responseConsumer, null, callback);
     }
 
     public final Future<SimpleHttpResponse> execute(
@@ -127,7 +126,7 @@ public abstract class CloseableHttpAsyncClient implements HttpAsyncClient, Modal
     public final Future<SimpleHttpResponse> execute(
             final SimpleHttpRequest request,
             final FutureCallback<SimpleHttpResponse> callback) {
-        return execute(request, HttpClientContext.create(), callback);
+        return execute(request, null, callback);
     }
 
     public abstract void register(String hostname, String uriPattern, Supplier<AsyncPushConsumer> supplier);

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/H2AsyncMainClientExec.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/H2AsyncMainClientExec.java
@@ -125,9 +125,8 @@ public class H2AsyncMainClientExec implements AsyncExecChainHandler {
 
             @Override
             public void produceRequest(final RequestChannel channel, final HttpContext context) throws HttpException, IOException {
-
-                clientContext.setAttribute(HttpClientContext.HTTP_ROUTE, route);
                 clientContext.setRequest(request);
+                clientContext.setRoute(route);
                 httpProcessor.process(request, entityProducer, clientContext);
 
                 channel.sendRequest(request, entityProducer, context);

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncClientBuilder.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncClientBuilder.java
@@ -36,6 +36,7 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.ThreadFactory;
+import java.util.function.Function;
 
 import org.apache.hc.client5.http.AuthenticationStrategy;
 import org.apache.hc.client5.http.ConnectionKeepAliveStrategy;
@@ -72,6 +73,7 @@ import org.apache.hc.client5.http.impl.routing.DefaultProxyRoutePlanner;
 import org.apache.hc.client5.http.impl.routing.DefaultRoutePlanner;
 import org.apache.hc.client5.http.impl.routing.SystemDefaultRoutePlanner;
 import org.apache.hc.client5.http.nio.AsyncClientConnectionManager;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
 import org.apache.hc.client5.http.protocol.RedirectStrategy;
 import org.apache.hc.client5.http.protocol.RequestAddCookies;
 import org.apache.hc.client5.http.protocol.RequestDefaultHeaders;
@@ -96,6 +98,7 @@ import org.apache.hc.core5.http.config.NamedElementChain;
 import org.apache.hc.core5.http.config.RegistryBuilder;
 import org.apache.hc.core5.http.nio.command.ShutdownCommand;
 import org.apache.hc.core5.http.protocol.DefaultHttpProcessor;
+import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.http.protocol.HttpProcessor;
 import org.apache.hc.core5.http.protocol.HttpProcessorBuilder;
 import org.apache.hc.core5.http.protocol.RequestTargetHost;
@@ -777,6 +780,12 @@ public class HttpAsyncClientBuilder {
         }
         closeables.add(closeable);
     }
+
+    @Internal
+    protected Function<HttpContext, HttpClientContext> contextAdaptor() {
+        return HttpClientContext::castOrCreate;
+    }
+
     @SuppressWarnings("deprecated")
     public CloseableHttpAsyncClient build() {
         AsyncClientConnectionManager connManagerCopy = this.connManager;
@@ -1047,6 +1056,7 @@ public class HttpAsyncClientBuilder {
                 authSchemeRegistryCopy,
                 cookieStoreCopy,
                 credentialsProviderCopy,
+                contextAdaptor(),
                 defaultRequestConfig,
                 closeablesCopy);
     }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncMainClientExec.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncMainClientExec.java
@@ -148,7 +148,7 @@ class HttpAsyncMainClientExec implements AsyncExecChainHandler {
                     final RequestChannel channel,
                     final HttpContext context) throws HttpException, IOException {
 
-                clientContext.setAttribute(HttpClientContext.HTTP_ROUTE, route);
+                clientContext.setRoute(route);
                 clientContext.setRequest(request);
                 httpProcessor.process(request, entityProducer, clientContext);
 
@@ -248,7 +248,7 @@ class HttpAsyncMainClientExec implements AsyncExecChainHandler {
                 Object userToken = clientContext.getUserToken();
                 if (userToken == null) {
                     userToken = userTokenHandler.getUserToken(route, request, clientContext);
-                    clientContext.setAttribute(HttpClientContext.USER_TOKEN, userToken);
+                    clientContext.setUserToken(userToken);
                 }
                 execRuntime.markConnectionReusable(userToken, keepAliveDuration);
                 if (entityDetails == null) {

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalAbstractHttpAsyncClient.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalAbstractHttpAsyncClient.java
@@ -84,6 +84,7 @@ abstract class InternalAbstractHttpAsyncClient extends AbstractHttpAsyncClientBa
     private final static ThreadFactory SCHEDULER_THREAD_FACTORY = new DefaultThreadFactory("Scheduled-executor", true);
 
     private static final Logger LOG = LoggerFactory.getLogger(InternalAbstractHttpAsyncClient.class);
+
     private final AsyncExecChainElement execChain;
     private final Lookup<CookieSpecFactory> cookieSpecRegistry;
     private final Lookup<AuthSchemeFactory> authSchemeRegistry;
@@ -165,20 +166,20 @@ abstract class InternalAbstractHttpAsyncClient extends AbstractHttpAsyncClientBa
     }
 
     private void setupContext(final HttpClientContext context) {
-        if (context.getAttribute(HttpClientContext.AUTHSCHEME_REGISTRY) == null) {
-            context.setAttribute(HttpClientContext.AUTHSCHEME_REGISTRY, authSchemeRegistry);
+        if (context.getAuthSchemeRegistry() == null) {
+            context.setAuthSchemeRegistry(authSchemeRegistry);
         }
-        if (context.getAttribute(HttpClientContext.COOKIESPEC_REGISTRY) == null) {
-            context.setAttribute(HttpClientContext.COOKIESPEC_REGISTRY, cookieSpecRegistry);
+        if (context.getCookieSpecRegistry() == null) {
+            context.setCookieSpecRegistry(cookieSpecRegistry);
         }
-        if (context.getAttribute(HttpClientContext.COOKIE_STORE) == null) {
-            context.setAttribute(HttpClientContext.COOKIE_STORE, cookieStore);
+        if (context.getCookieStore() == null) {
+            context.setCookieStore(cookieStore);
         }
-        if (context.getAttribute(HttpClientContext.CREDS_PROVIDER) == null) {
-            context.setAttribute(HttpClientContext.CREDS_PROVIDER, credentialsProvider);
+        if (context.getCredentialsProvider() == null) {
+            context.setCredentialsProvider(credentialsProvider);
         }
-        if (context.getAttribute(HttpClientContext.REQUEST_CONFIG) == null) {
-            context.setAttribute(HttpClientContext.REQUEST_CONFIG, defaultConfig);
+        if (context.getRequestConfig() == null) {
+            context.setRequestConfig(defaultConfig);
         }
     }
 
@@ -199,7 +200,7 @@ abstract class InternalAbstractHttpAsyncClient extends AbstractHttpAsyncClientBa
             if (!isRunning()) {
                 throw new CancellationException("Request execution cancelled");
             }
-            final HttpClientContext clientContext = context != null ? HttpClientContext.adapt(context) : HttpClientContext.create();
+            final HttpClientContext clientContext = HttpClientContext.adapt(context);
             requestProducer.sendRequest((request, entityDetails, c) -> {
 
                 RequestConfig requestConfig = null;

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalH2AsyncClient.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalH2AsyncClient.java
@@ -84,7 +84,8 @@ public final class InternalH2AsyncClient extends InternalAbstractHttpAsyncClient
             final RequestConfig defaultConfig,
             final List<Closeable> closeables) {
         super(ioReactor, pushConsumerRegistry, threadFactory, execChain,
-                cookieSpecRegistry, authSchemeRegistry, cookieStore, credentialsProvider, defaultConfig, closeables);
+                cookieSpecRegistry, authSchemeRegistry, cookieStore, credentialsProvider, HttpClientContext::castOrCreate,
+                defaultConfig, closeables);
         this.connPool = connPool;
         this.routePlanner = routePlanner;
     }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalH2AsyncExecRuntime.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalH2AsyncExecRuntime.java
@@ -87,7 +87,7 @@ class InternalH2AsyncExecRuntime implements AsyncExecRuntime {
             final HttpClientContext context,
             final FutureCallback<AsyncExecRuntime> callback) {
         if (sessionRef.get() == null) {
-            final RequestConfig requestConfig = context.getRequestConfig();
+            final RequestConfig requestConfig = context.getRequestConfigOrDefault();
             @SuppressWarnings("deprecation")
             final Timeout connectTimeout = requestConfig.getConnectTimeout();
             if (log.isDebugEnabled()) {
@@ -183,7 +183,7 @@ class InternalH2AsyncExecRuntime implements AsyncExecRuntime {
             return Operations.nonCancellable();
         }
         final HttpRoute route = endpoint.route;
-        final RequestConfig requestConfig = context.getRequestConfig();
+        final RequestConfig requestConfig = context.getRequestConfigOrDefault();
         @SuppressWarnings("deprecation")
         final Timeout connectTimeout = requestConfig.getConnectTimeout();
         if (log.isDebugEnabled()) {
@@ -262,7 +262,7 @@ class InternalH2AsyncExecRuntime implements AsyncExecRuntime {
                     Command.Priority.NORMAL);
         } else {
             final HttpRoute route = endpoint.route;
-            final RequestConfig requestConfig = context.getRequestConfig();
+            final RequestConfig requestConfig = context.getRequestConfigOrDefault();
             @SuppressWarnings("deprecation")
             final Timeout connectTimeout = requestConfig.getConnectTimeout();
             connPool.getSession(route, connectTimeout, new FutureCallback<IOSession>() {

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalHttpAsyncClient.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalHttpAsyncClient.java
@@ -29,6 +29,7 @@ package org.apache.hc.client5.http.impl.async;
 import java.io.Closeable;
 import java.util.List;
 import java.util.concurrent.ThreadFactory;
+import java.util.function.Function;
 
 import org.apache.hc.client5.http.HttpRoute;
 import org.apache.hc.client5.http.async.AsyncExecRuntime;
@@ -50,6 +51,7 @@ import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.config.Lookup;
 import org.apache.hc.core5.http.nio.AsyncPushConsumer;
 import org.apache.hc.core5.http.nio.HandlerFactory;
+import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.reactor.DefaultConnectingIOReactor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -86,10 +88,12 @@ public final class InternalHttpAsyncClient extends InternalAbstractHttpAsyncClie
             final Lookup<AuthSchemeFactory> authSchemeRegistry,
             final CookieStore cookieStore,
             final CredentialsProvider credentialsProvider,
+            final Function<HttpContext, HttpClientContext> contextAdaptor,
             final RequestConfig defaultConfig,
             final List<Closeable> closeables) {
         super(ioReactor, pushConsumerRegistry, threadFactory, execChain,
-                cookieSpecRegistry, authSchemeRegistry, cookieStore, credentialsProvider, defaultConfig, closeables);
+                cookieSpecRegistry, authSchemeRegistry, cookieStore, credentialsProvider, contextAdaptor,
+                defaultConfig, closeables);
         this.manager = manager;
         this.routePlanner = routePlanner;
         this.tlsConfig = tlsConfig;

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalHttpAsyncExecRuntime.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalHttpAsyncExecRuntime.java
@@ -98,7 +98,7 @@ class InternalHttpAsyncExecRuntime implements AsyncExecRuntime {
             final FutureCallback<AsyncExecRuntime> callback) {
         if (endpointRef.get() == null) {
             state = object;
-            final RequestConfig requestConfig = context.getRequestConfig();
+            final RequestConfig requestConfig = context.getRequestConfigOrDefault();
             final Timeout connectionRequestTimeout = requestConfig.getConnectionRequestTimeout();
             if (log.isDebugEnabled()) {
                 log.debug("{} acquiring endpoint ({})", id, connectionRequestTimeout);
@@ -208,7 +208,7 @@ class InternalHttpAsyncExecRuntime implements AsyncExecRuntime {
             callback.completed(this);
             return Operations.nonCancellable();
         }
-        final RequestConfig requestConfig = context.getRequestConfig();
+        final RequestConfig requestConfig = context.getRequestConfigOrDefault();
         @SuppressWarnings("deprecation")
         final Timeout connectTimeout = requestConfig.getConnectTimeout();
         if (log.isDebugEnabled()) {
@@ -280,13 +280,13 @@ class InternalHttpAsyncExecRuntime implements AsyncExecRuntime {
             if (log.isDebugEnabled()) {
                 log.debug("{} start execution {}", ConnPoolSupport.getId(endpoint), id);
             }
-            final RequestConfig requestConfig = context.getRequestConfig();
+            final RequestConfig requestConfig = context.getRequestConfigOrDefault();
             final Timeout responseTimeout = requestConfig.getResponseTimeout();
             if (responseTimeout != null) {
                 endpoint.setSocketTimeout(responseTimeout);
             }
             endpoint.execute(id, exchangeHandler, context);
-            if (context.getRequestConfig().isHardCancellationEnabled()) {
+            if (context.getRequestConfigOrDefault().isHardCancellationEnabled()) {
                 return () -> {
                     exchangeHandler.cancel();
                     return true;

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/MinimalH2AsyncClient.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/MinimalH2AsyncClient.java
@@ -129,7 +129,7 @@ public final class MinimalH2AsyncClient extends AbstractMinimalHttpAsyncClientBa
             if (!isRunning()) {
                 throw new CancellationException("Request execution cancelled");
             }
-            final HttpClientContext clientContext = HttpClientContext.adapt(context);
+            final HttpClientContext clientContext = HttpClientContext.castOrCreate(context);
             exchangeHandler.produceRequest((request, entityDetails, context1) -> {
                 RequestConfig requestConfig = null;
                 if (request instanceof Configurable) {

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/MinimalH2AsyncClient.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/MinimalH2AsyncClient.java
@@ -71,6 +71,7 @@ import org.apache.hc.core5.reactor.DefaultConnectingIOReactor;
 import org.apache.hc.core5.reactor.IOEventHandlerFactory;
 import org.apache.hc.core5.reactor.IOReactorConfig;
 import org.apache.hc.core5.reactor.IOSession;
+import org.apache.hc.core5.util.Args;
 import org.apache.hc.core5.util.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -122,12 +123,13 @@ public final class MinimalH2AsyncClient extends AbstractMinimalHttpAsyncClientBa
             final AsyncClientExchangeHandler exchangeHandler,
             final HandlerFactory<AsyncPushConsumer> pushHandlerFactory,
             final HttpContext context) {
+        Args.notNull(exchangeHandler, "Message exchange handler");
         final ComplexCancellable cancellable = new ComplexCancellable();
         try {
             if (!isRunning()) {
                 throw new CancellationException("Request execution cancelled");
             }
-            final HttpClientContext clientContext = context != null ? HttpClientContext.adapt(context) : HttpClientContext.create();
+            final HttpClientContext clientContext = HttpClientContext.adapt(context);
             exchangeHandler.produceRequest((request, entityDetails, context1) -> {
                 RequestConfig requestConfig = null;
                 if (request instanceof Configurable) {
@@ -136,7 +138,7 @@ public final class MinimalH2AsyncClient extends AbstractMinimalHttpAsyncClientBa
                 if (requestConfig != null) {
                     clientContext.setRequestConfig(requestConfig);
                 } else {
-                    requestConfig = clientContext.getRequestConfig();
+                    requestConfig = clientContext.getRequestConfigOrDefault();
                 }
                 @SuppressWarnings("deprecation")
                 final Timeout connectTimeout = requestConfig.getConnectTimeout();

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/MinimalHttpAsyncClient.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/MinimalHttpAsyncClient.java
@@ -218,7 +218,7 @@ public final class MinimalHttpAsyncClient extends AbstractMinimalHttpAsyncClient
             future.failed(new CancellationException("Connection lease cancelled"));
             return future;
         }
-        final HttpClientContext clientContext = HttpClientContext.adapt(context);
+        final HttpClientContext clientContext = HttpClientContext.castOrCreate(context);
         final RequestConfig requestConfig = clientContext.getRequestConfigOrDefault();
         final Timeout connectionRequestTimeout = requestConfig.getConnectionRequestTimeout();
         @SuppressWarnings("deprecation")
@@ -259,7 +259,7 @@ public final class MinimalHttpAsyncClient extends AbstractMinimalHttpAsyncClient
             if (!isRunning()) {
                 throw new CancellationException("Request execution cancelled");
             }
-            final HttpClientContext clientContext = HttpClientContext.adapt(context);
+            final HttpClientContext clientContext = HttpClientContext.castOrCreate(context);
             exchangeHandler.produceRequest((request, entityDetails, context1) -> {
                 RequestConfig requestConfig = null;
                 if (request instanceof Configurable) {
@@ -455,7 +455,7 @@ public final class MinimalHttpAsyncClient extends AbstractMinimalHttpAsyncClient
                 final HttpContext context) {
             Asserts.check(!released.get(), "Endpoint has already been released");
 
-            final HttpClientContext clientContext = HttpClientContext.adapt(context);
+            final HttpClientContext clientContext = HttpClientContext.castOrCreate(context);
             final String exchangeId = ExecSupport.getNextExchangeId();
             clientContext.setExchangeId(exchangeId);
             if (LOG.isDebugEnabled()) {

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/MinimalHttpAsyncClient.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/MinimalHttpAsyncClient.java
@@ -205,7 +205,7 @@ public final class MinimalHttpAsyncClient extends AbstractMinimalHttpAsyncClient
     public Future<AsyncClientEndpoint> lease(
             final HttpHost host,
             final FutureCallback<AsyncClientEndpoint> callback) {
-        return lease(host, HttpClientContext.create(), callback);
+        return lease(host, null, callback);
     }
 
     public Future<AsyncClientEndpoint> lease(
@@ -213,14 +213,13 @@ public final class MinimalHttpAsyncClient extends AbstractMinimalHttpAsyncClient
             final HttpContext context,
             final FutureCallback<AsyncClientEndpoint> callback) {
         Args.notNull(host, "Host");
-        Args.notNull(context, "HTTP context");
         final BasicFuture<AsyncClientEndpoint> future = new BasicFuture<>(callback);
         if (!isRunning()) {
             future.failed(new CancellationException("Connection lease cancelled"));
             return future;
         }
         final HttpClientContext clientContext = HttpClientContext.adapt(context);
-        final RequestConfig requestConfig = clientContext.getRequestConfig();
+        final RequestConfig requestConfig = clientContext.getRequestConfigOrDefault();
         final Timeout connectionRequestTimeout = requestConfig.getConnectionRequestTimeout();
         @SuppressWarnings("deprecation")
         final Timeout connectTimeout = requestConfig.getConnectTimeout();
@@ -260,7 +259,7 @@ public final class MinimalHttpAsyncClient extends AbstractMinimalHttpAsyncClient
             if (!isRunning()) {
                 throw new CancellationException("Request execution cancelled");
             }
-            final HttpClientContext clientContext = context != null ? HttpClientContext.adapt(context) : HttpClientContext.create();
+            final HttpClientContext clientContext = HttpClientContext.adapt(context);
             exchangeHandler.produceRequest((request, entityDetails, context1) -> {
                 RequestConfig requestConfig = null;
                 if (request instanceof Configurable) {
@@ -269,7 +268,7 @@ public final class MinimalHttpAsyncClient extends AbstractMinimalHttpAsyncClient
                 if (requestConfig != null) {
                     clientContext.setRequestConfig(requestConfig);
                 } else {
-                    requestConfig = clientContext.getRequestConfig();
+                    requestConfig = clientContext.getRequestConfigOrDefault();
                 }
                 final Timeout connectionRequestTimeout = requestConfig.getConnectionRequestTimeout();
                 @SuppressWarnings("deprecation")
@@ -456,7 +455,7 @@ public final class MinimalHttpAsyncClient extends AbstractMinimalHttpAsyncClient
                 final HttpContext context) {
             Asserts.check(!released.get(), "Endpoint has already been released");
 
-            final HttpClientContext clientContext = context != null ? HttpClientContext.adapt(context) : HttpClientContext.create();
+            final HttpClientContext clientContext = HttpClientContext.adapt(context);
             final String exchangeId = ExecSupport.getNextExchangeId();
             clientContext.setExchangeId(exchangeId);
             if (LOG.isDebugEnabled()) {

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/AuthCacheKeeper.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/AuthCacheKeeper.java
@@ -62,7 +62,7 @@ public final class AuthCacheKeeper {
                                   final String pathPrefix,
                                   final AuthExchange authExchange,
                                   final HttpContext context) {
-        clearCache(host, pathPrefix, HttpClientContext.adapt(context));
+        clearCache(host, pathPrefix, HttpClientContext.cast(context));
     }
 
     public void updateOnNoChallenge(final HttpHost host,
@@ -70,7 +70,7 @@ public final class AuthCacheKeeper {
                                     final AuthExchange authExchange,
                                     final HttpContext context) {
         if (authExchange.getState() == AuthExchange.State.SUCCESS) {
-            updateCache(host, pathPrefix, authExchange.getAuthScheme(), HttpClientContext.adapt(context));
+            updateCache(host, pathPrefix, authExchange.getAuthScheme(), HttpClientContext.cast(context));
         }
     }
 
@@ -79,7 +79,7 @@ public final class AuthCacheKeeper {
                                  final AuthExchange authExchange,
                                  final HttpContext context) {
         if (authExchange.getState() == AuthExchange.State.FAILURE) {
-            clearCache(host, pathPrefix, HttpClientContext.adapt(context));
+            clearCache(host, pathPrefix, HttpClientContext.cast(context));
         }
     }
 
@@ -88,9 +88,9 @@ public final class AuthCacheKeeper {
                                  final AuthExchange authExchange,
                                  final HttpContext context) {
         if (authExchange.getState() == AuthExchange.State.UNCHALLENGED) {
-            AuthScheme authScheme = loadFromCache(host, pathPrefix, HttpClientContext.adapt(context));
+            AuthScheme authScheme = loadFromCache(host, pathPrefix, HttpClientContext.cast(context));
             if (authScheme == null && pathPrefix != null) {
-                authScheme = loadFromCache(host, null, HttpClientContext.adapt(context));
+                authScheme = loadFromCache(host, null, HttpClientContext.cast(context));
             }
             if (authScheme != null) {
                 authExchange.select(authScheme);

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/BasicScheme.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/BasicScheme.java
@@ -162,7 +162,7 @@ public class BasicScheme implements AuthScheme, StateHolder<BasicScheme.State>, 
         }
 
         if (LOG.isDebugEnabled()) {
-            final HttpClientContext clientContext = HttpClientContext.adapt(context);
+            final HttpClientContext clientContext = HttpClientContext.cast(context);
             final String exchangeId = clientContext.getExchangeId();
             LOG.debug("{} No credentials found for auth scope [{}]", exchangeId, authScope);
         }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/BearerScheme.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/BearerScheme.java
@@ -141,7 +141,7 @@ public class BearerScheme implements AuthScheme, StateHolder<BearerScheme.State>
         }
 
         if (LOG.isDebugEnabled()) {
-            final HttpClientContext clientContext = HttpClientContext.adapt(context);
+            final HttpClientContext clientContext = HttpClientContext.cast(context);
             final String exchangeId = clientContext.getExchangeId();
             LOG.debug("{} No credentials found for auth scope [{}]", exchangeId, authScope);
         }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/DigestScheme.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/DigestScheme.java
@@ -227,7 +227,7 @@ public class DigestScheme implements AuthScheme, Serializable {
         }
 
         if (LOG.isDebugEnabled()) {
-            final HttpClientContext clientContext = HttpClientContext.adapt(context);
+            final HttpClientContext clientContext = HttpClientContext.cast(context);
             final String exchangeId = clientContext.getExchangeId();
             LOG.debug("{} No credentials found for auth scope [{}]", exchangeId, authScope);
         }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/GGSSchemeBase.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/GGSSchemeBase.java
@@ -118,7 +118,7 @@ public abstract class GGSSchemeBase implements AuthScheme {
             state = State.CHALLENGE_RECEIVED;
         } else {
             if (LOG.isDebugEnabled()) {
-                final HttpClientContext clientContext = HttpClientContext.adapt(context);
+                final HttpClientContext clientContext = HttpClientContext.cast(context);
                 final String exchangeId = clientContext.getExchangeId();
                 LOG.debug("{} Authentication already attempted", exchangeId);
             }
@@ -225,7 +225,7 @@ public abstract class GGSSchemeBase implements AuthScheme {
                 }
 
                 if (LOG.isDebugEnabled()) {
-                    final HttpClientContext clientContext = HttpClientContext.adapt(context);
+                    final HttpClientContext clientContext = HttpClientContext.cast(context);
                     final String exchangeId = clientContext.getExchangeId();
                     LOG.debug("{} init {}", exchangeId, authServer);
                 }
@@ -252,7 +252,7 @@ public abstract class GGSSchemeBase implements AuthScheme {
             final Base64 codec = new Base64(0);
             final String tokenstr = new String(codec.encode(token));
             if (LOG.isDebugEnabled()) {
-                final HttpClientContext clientContext = HttpClientContext.adapt(context);
+                final HttpClientContext clientContext = HttpClientContext.cast(context);
                 final String exchangeId = clientContext.getExchangeId();
                 LOG.debug("{} Sending response '{}' back to the auth server", exchangeId, tokenstr);
             }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/HttpAuthenticator.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/HttpAuthenticator.java
@@ -109,7 +109,7 @@ public final class HttpAuthenticator {
                 throw new IllegalStateException("Unexpected challenge type: " + challengeType);
         }
 
-        final HttpClientContext clientContext = HttpClientContext.adapt(context);
+        final HttpClientContext clientContext = HttpClientContext.cast(context);
         final String exchangeId = clientContext.getExchangeId();
 
         if (response.getCode() == challengeCode) {
@@ -155,7 +155,7 @@ public final class HttpAuthenticator {
             final AuthExchange authExchange,
             final HttpContext context) {
 
-        final HttpClientContext clientContext = HttpClientContext.adapt(context);
+        final HttpClientContext clientContext = HttpClientContext.cast(context);
         final String exchangeId = clientContext.getExchangeId();
 
         if (LOG.isDebugEnabled()) {
@@ -304,7 +304,7 @@ public final class HttpAuthenticator {
             final HttpRequest request,
             final AuthExchange authExchange,
             final HttpContext context) {
-        final HttpClientContext clientContext = HttpClientContext.adapt(context);
+        final HttpClientContext clientContext = HttpClientContext.cast(context);
         final String exchangeId = clientContext.getExchangeId();
         AuthScheme authScheme = authExchange.getAuthScheme();
         switch (authExchange.getState()) {

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/NTLMScheme.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/NTLMScheme.java
@@ -146,7 +146,7 @@ public final class NTLMScheme implements AuthScheme {
         }
 
         if (LOG.isDebugEnabled()) {
-            final HttpClientContext clientContext = HttpClientContext.adapt(context);
+            final HttpClientContext clientContext = HttpClientContext.cast(context);
             final String exchangeId = clientContext.getExchangeId();
             LOG.debug("{} No credentials found for auth scope [{}]", exchangeId, authScope);
         }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/SystemDefaultCredentialsProvider.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/SystemDefaultCredentialsProvider.java
@@ -105,7 +105,7 @@ public class SystemDefaultCredentialsProvider implements CredentialsStore {
         }
         final String host = authScope.getHost();
         if (host != null) {
-            final HttpClientContext clientContext = context != null ? HttpClientContext.adapt(context) : null;
+            final HttpClientContext clientContext = context != null ? HttpClientContext.cast(context) : null;
             final String protocol = authScope.getProtocol() != null ? authScope.getProtocol() : (authScope.getPort() == 443 ? URIScheme.HTTPS.id : URIScheme.HTTP.id);
             PasswordAuthentication systemcreds = getSystemCreds(
                     protocol, authScope, Authenticator.RequestorType.SERVER, clientContext);

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/ConnectExec.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/ConnectExec.java
@@ -214,7 +214,7 @@ public final class ConnectExec implements ExecChainHandler {
             final ExecRuntime execRuntime,
             final HttpClientContext context) throws HttpException, IOException {
 
-        final RequestConfig config = context.getRequestConfig();
+        final RequestConfig config = context.getRequestConfigOrDefault();
 
         final HttpHost target = route.getTargetHost();
         final HttpHost proxy = route.getProxyHost();

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/ContentCompressionExec.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/ContentCompressionExec.java
@@ -137,7 +137,7 @@ public final class ContentCompressionExec implements ExecChainHandler {
         Args.notNull(scope, "Scope");
 
         final HttpClientContext clientContext = scope.clientContext;
-        final RequestConfig requestConfig = clientContext.getRequestConfig();
+        final RequestConfig requestConfig = clientContext.getRequestConfigOrDefault();
 
         /* Signal support for Accept-Encoding transfer encodings. */
         if (!request.containsHeader(HttpHeaders.ACCEPT_ENCODING) && requestConfig.isContentCompressionEnabled()) {

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/HttpClientBuilder.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/HttpClientBuilder.java
@@ -37,6 +37,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 import org.apache.hc.client5.http.AuthenticationStrategy;
 import org.apache.hc.client5.http.ConnectionKeepAliveStrategy;
@@ -75,6 +76,7 @@ import org.apache.hc.client5.http.impl.routing.DefaultProxyRoutePlanner;
 import org.apache.hc.client5.http.impl.routing.DefaultRoutePlanner;
 import org.apache.hc.client5.http.impl.routing.SystemDefaultRoutePlanner;
 import org.apache.hc.client5.http.io.HttpClientConnectionManager;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
 import org.apache.hc.client5.http.protocol.RedirectStrategy;
 import org.apache.hc.client5.http.protocol.RequestAddCookies;
 import org.apache.hc.client5.http.protocol.RequestClientConnControl;
@@ -96,6 +98,7 @@ import org.apache.hc.core5.http.config.Registry;
 import org.apache.hc.core5.http.config.RegistryBuilder;
 import org.apache.hc.core5.http.impl.io.HttpRequestExecutor;
 import org.apache.hc.core5.http.protocol.DefaultHttpProcessor;
+import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.http.protocol.HttpProcessor;
 import org.apache.hc.core5.http.protocol.HttpProcessorBuilder;
 import org.apache.hc.core5.http.protocol.RequestContent;
@@ -742,6 +745,11 @@ public class HttpClientBuilder {
         closeables.add(closeable);
     }
 
+    @Internal
+    protected Function<HttpContext, HttpClientContext> contextAdaptor() {
+        return HttpClientContext::castOrCreate;
+    }
+
     public CloseableHttpClient build() {
         // Create main request executor
         // We copy the instance fields to avoid changing them, and rename to avoid accidental use of the wrong version
@@ -1024,6 +1032,7 @@ public class HttpClientBuilder {
                 authSchemeRegistryCopy,
                 defaultCookieStore,
                 defaultCredentialsProvider,
+                contextAdaptor(),
                 defaultRequestConfig != null ? defaultRequestConfig : RequestConfig.DEFAULT,
                 closeablesCopy);
     }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/HttpRequestRetryExec.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/HttpRequestRetryExec.java
@@ -167,7 +167,7 @@ public class HttpRequestRetryExec implements ExecChainHandler {
                     final TimeValue nextInterval = retryStrategy.getRetryInterval(response, execCount, context);
                     // Make sure the retry interval does not exceed the response timeout
                     if (TimeValue.isPositive(nextInterval)) {
-                        final RequestConfig requestConfig = context.getRequestConfig();
+                        final RequestConfig requestConfig = context.getRequestConfigOrDefault();
                         final Timeout responseTimeout = requestConfig.getResponseTimeout();
                         if (responseTimeout != null && nextInterval.compareTo(responseTimeout) > 0) {
                             return response;

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/InternalExecRuntime.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/InternalExecRuntime.java
@@ -97,7 +97,7 @@ class InternalExecRuntime implements ExecRuntime, Cancellable {
             final String id, final HttpRoute route, final Object object, final HttpClientContext context) throws IOException {
         Args.notNull(route, "Route");
         if (endpointRef.get() == null) {
-            final RequestConfig requestConfig = context.getRequestConfig();
+            final RequestConfig requestConfig = context.getRequestConfigOrDefault();
             final Timeout connectionRequestTimeout = requestConfig.getConnectionRequestTimeout();
             if (log.isDebugEnabled()) {
                 log.debug("{} acquiring endpoint ({})", id, connectionRequestTimeout);
@@ -155,7 +155,7 @@ class InternalExecRuntime implements ExecRuntime, Cancellable {
         if (isExecutionAborted()) {
             throw new RequestFailedException("Request aborted");
         }
-        final RequestConfig requestConfig = context.getRequestConfig();
+        final RequestConfig requestConfig = context.getRequestConfigOrDefault();
         @SuppressWarnings("deprecation")
         final Timeout connectTimeout = requestConfig.getConnectTimeout();
         if (log.isDebugEnabled()) {
@@ -222,7 +222,7 @@ class InternalExecRuntime implements ExecRuntime, Cancellable {
         if (isExecutionAborted()) {
             throw new RequestFailedException("Request aborted");
         }
-        final RequestConfig requestConfig = context.getRequestConfig();
+        final RequestConfig requestConfig = context.getRequestConfigOrDefault();
         final Timeout responseTimeout = requestConfig.getResponseTimeout();
         if (responseTimeout != null) {
             endpoint.setSocketTimeout(responseTimeout);

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/InternalHttpClient.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/InternalHttpClient.java
@@ -121,20 +121,20 @@ class InternalHttpClient extends CloseableHttpClient implements Configurable {
     }
 
     private void setupContext(final HttpClientContext context) {
-        if (context.getAttribute(HttpClientContext.AUTHSCHEME_REGISTRY) == null) {
-            context.setAttribute(HttpClientContext.AUTHSCHEME_REGISTRY, this.authSchemeRegistry);
+        if (context.getAuthSchemeRegistry() == null) {
+            context.setAuthSchemeRegistry(this.authSchemeRegistry);
         }
-        if (context.getAttribute(HttpClientContext.COOKIESPEC_REGISTRY) == null) {
-            context.setAttribute(HttpClientContext.COOKIESPEC_REGISTRY, this.cookieSpecRegistry);
+        if (context.getCookieSpecRegistry() == null) {
+            context.setCookieSpecRegistry(this.cookieSpecRegistry);
         }
-        if (context.getAttribute(HttpClientContext.COOKIE_STORE) == null) {
-            context.setAttribute(HttpClientContext.COOKIE_STORE, this.cookieStore);
+        if (context.getCookieStore() == null) {
+            context.setCookieStore(this.cookieStore);
         }
-        if (context.getAttribute(HttpClientContext.CREDS_PROVIDER) == null) {
-            context.setAttribute(HttpClientContext.CREDS_PROVIDER, this.credentialsProvider);
+        if (context.getCredentialsProvider() == null) {
+            context.setCredentialsProvider(this.credentialsProvider);
         }
-        if (context.getAttribute(HttpClientContext.REQUEST_CONFIG) == null) {
-            context.setAttribute(HttpClientContext.REQUEST_CONFIG, this.defaultConfig);
+        if (context.getRequestConfig() == null) {
+            context.setRequestConfig(this.defaultConfig);
         }
     }
 
@@ -145,8 +145,7 @@ class InternalHttpClient extends CloseableHttpClient implements Configurable {
             final HttpContext context) throws IOException {
         Args.notNull(request, "HTTP request");
         try {
-            final HttpClientContext localcontext = HttpClientContext.adapt(
-                    context != null ? context : new HttpClientContext());
+            final HttpClientContext localcontext = HttpClientContext.adapt(context);
             RequestConfig config = null;
             if (request instanceof Configurable) {
                 config = ((Configurable) request).getConfig();

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/MainClientExec.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/MainClientExec.java
@@ -113,7 +113,7 @@ public final class MainClientExec implements ExecChainHandler {
         }
         try {
             // Run request protocol interceptors
-            context.setAttribute(HttpClientContext.HTTP_ROUTE, route);
+            context.setRoute(route);
             context.setRequest(request);
 
             httpProcessor.process(request, request.getEntity(), context);
@@ -146,7 +146,7 @@ public final class MainClientExec implements ExecChainHandler {
             Object userToken = context.getUserToken();
             if (userToken == null) {
                 userToken = userTokenHandler.getUserToken(route, request, context);
-                context.setAttribute(HttpClientContext.USER_TOKEN, userToken);
+                context.setUserToken(userToken);
             }
 
             // The connection is in or can be brought to a re-usable state.

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/MinimalHttpClient.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/MinimalHttpClient.java
@@ -118,8 +118,7 @@ public class MinimalHttpClient extends CloseableHttpClient {
         if (request.getAuthority() == null) {
             request.setAuthority(new URIAuthority(target));
         }
-        final HttpClientContext clientContext = HttpClientContext.adapt(
-                context != null ? context : new HttpClientContext());
+        final HttpClientContext clientContext = HttpClientContext.adapt(context);
         RequestConfig config = null;
         if (request instanceof Configurable) {
             config = ((Configurable) request).getConfig();
@@ -142,7 +141,7 @@ public class MinimalHttpClient extends CloseableHttpClient {
             }
 
             clientContext.setRequest(request);
-            clientContext.setAttribute(HttpClientContext.HTTP_ROUTE, route);
+            clientContext.setRoute(route);
 
             httpProcessor.process(request, request.getEntity(), clientContext);
             final ClassicHttpResponse response = execRuntime.execute(exchangeId, request, clientContext);

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/MinimalHttpClient.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/MinimalHttpClient.java
@@ -118,7 +118,7 @@ public class MinimalHttpClient extends CloseableHttpClient {
         if (request.getAuthority() == null) {
             request.setAuthority(new URIAuthority(target));
         }
-        final HttpClientContext clientContext = HttpClientContext.adapt(context);
+        final HttpClientContext clientContext = HttpClientContext.castOrCreate(context);
         RequestConfig config = null;
         if (request instanceof Configurable) {
             config = ((Configurable) request).getConfig();

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/ProtocolExec.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/ProtocolExec.java
@@ -266,7 +266,7 @@ public final class ProtocolExec implements ExecChainHandler {
             final String pathPrefix,
             final HttpResponse response,
             final HttpClientContext context) {
-        final RequestConfig config = context.getRequestConfig();
+        final RequestConfig config = context.getRequestConfigOrDefault();
         if (config.isAuthenticationEnabled()) {
             final boolean targetAuthRequested = authenticator.isChallenged(
                     target, ChallengeType.TARGET, response, targetAuthExchange, context);

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/ProxyClient.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/ProxyClient.java
@@ -145,7 +145,7 @@ public class ProxyClient {
                 proxy, false, TunnelType.TUNNELLED, LayerType.PLAIN);
 
         final ManagedHttpClientConnection conn = this.connFactory.createConnection(null);
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
         ClassicHttpResponse response;
 
         final ClassicHttpRequest connect = new BasicClassicHttpRequest(Method.CONNECT, proxy, target.toHostString());
@@ -155,10 +155,10 @@ public class ProxyClient {
 
         // Populate the execution context
         context.setRequest(connect);
-        context.setAttribute(HttpClientContext.HTTP_ROUTE, route);
-        context.setAttribute(HttpClientContext.CREDS_PROVIDER, credsProvider);
-        context.setAttribute(HttpClientContext.AUTHSCHEME_REGISTRY, this.authSchemeRegistry);
-        context.setAttribute(HttpClientContext.REQUEST_CONFIG, this.requestConfig);
+        context.setRoute(route);
+        context.setCredentialsProvider(credsProvider);
+        context.setAuthSchemeRegistry(this.authSchemeRegistry);
+        context.setRequestConfig(this.requestConfig);
 
         this.requestExec.preProcess(connect, this.httpProcessor, context);
 

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/RedirectExec.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/RedirectExec.java
@@ -99,14 +99,9 @@ public final class RedirectExec implements ExecChainHandler {
         Args.notNull(scope, "Scope");
 
         final HttpClientContext context = scope.clientContext;
-        RedirectLocations redirectLocations = context.getRedirectLocations();
-        if (redirectLocations == null) {
-            redirectLocations = new RedirectLocations();
-            context.setAttribute(HttpClientContext.REDIRECT_LOCATIONS, redirectLocations);
-        }
-        redirectLocations.clear();
+        context.setRedirectLocations(null);
 
-        final RequestConfig config = context.getRequestConfig();
+        final RequestConfig config = context.getRequestConfigOrDefault();
         final int maxRedirects = config.getMaxRedirects() > 0 ? config.getMaxRedirects() : 50;
         ClassicHttpRequest originalRequest = scope.originalRequest;
         ClassicHttpRequest currentRequest = request;
@@ -139,6 +134,7 @@ public final class RedirectExec implements ExecChainHandler {
                                 redirectUri);
                     }
 
+                    final RedirectLocations redirectLocations = context.getRedirectLocations();
                     if (!config.isCircularRedirectsAllowed()) {
                         if (redirectLocations.contains(redirectUri)) {
                             throw new CircularRedirectException("Circular redirect to '" + redirectUri + "'");

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/routing/DefaultRoutePlanner.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/routing/DefaultRoutePlanner.java
@@ -76,8 +76,8 @@ public class DefaultRoutePlanner implements HttpRoutePlanner {
         if (host == null) {
             throw new ProtocolException("Target host is not specified");
         }
-        final HttpClientContext clientContext = HttpClientContext.adapt(context);
-        final RequestConfig config = clientContext.getRequestConfig();
+        final HttpClientContext clientContext = HttpClientContext.cast(context);
+        final RequestConfig config = clientContext.getRequestConfigOrDefault();
         @SuppressWarnings("deprecation")
         HttpHost proxy = config.getProxy();
         if (proxy == null) {

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/protocol/HttpClientContext.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/protocol/HttpClientContext.java
@@ -55,9 +55,12 @@ import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.http.protocol.HttpCoreContext;
 
 /**
- * Adaptor class that provides convenience type safe setters and getters
- * for common {@link HttpContext} attributes used in the course
- * of HTTP request execution.
+ * Client execution {@link HttpContext}. This class can be re-used for
+ * multiple consecutive logically related request executions that represent
+ * a single communication session. This context may not be used concurrently.
+ * <p>
+ * IMPORTANT: This class is NOT thread-safe and MUST NOT be used concurrently by
+ * multiple message exchanges.
  *
  * @since 4.3
  */
@@ -141,18 +144,23 @@ public class HttpClientContext extends HttpCoreContext {
     @Deprecated
     public static final String EXCHANGE_ID = "http.exchange-id";
 
-    @SuppressWarnings("deprecation")
+    /**
+     * @deprecated Use {@link #castOrCreate(HttpContext)}.
+     */
+    @Deprecated
     public static HttpClientContext adapt(final HttpContext context) {
+        if (context == null) {
+            return new HttpClientContext();
+        }
         if (context instanceof HttpClientContext) {
             return (HttpClientContext) context;
         }
-        return new HttpClientContext.Delegate(HttpCoreContext.adapt(context));
+        return new HttpClientContext(context);
     }
 
     /**
-     * Casts the given generic {@link HttpContext} as {@link HttpClientContext}
-     * or creates a new {@link HttpClientContext} with the given {@link HttpContext}
-     * as a parent.
+     * Casts the given generic {@link HttpContext} as {@link HttpClientContext} or
+     * throws an {@link IllegalStateException} if the given context is not suitable.
      *
      * @since 5.4
      */
@@ -163,9 +171,18 @@ public class HttpClientContext extends HttpCoreContext {
         if (context instanceof HttpClientContext) {
             return (HttpClientContext) context;
         } else {
-            throw new IllegalStateException("Unexpected context type: " + context.getClass().getSimpleName() +
-                    "; required context type: " + HttpClientContext.class.getSimpleName());
+            return new Delegate(context);
         }
+    }
+
+    /**
+     * Casts the given generic {@link HttpContext} as {@link HttpClientContext} or
+     * creates new {@link HttpClientContext} if the given context is null..
+     *
+     * @since 5.4
+     */
+    public static HttpClientContext castOrCreate(final HttpContext context) {
+        return context != null ? cast(context) : create();
     }
 
     public static HttpClientContext create() {
@@ -198,8 +215,7 @@ public class HttpClientContext extends HttpCoreContext {
     /**
      * Represents current route used to execute message exchanges.
      * <p>
-     * This context attribute is expected to be populated by the protocol handler
-     * in the course of request execution.
+     * This context attribute is expected to be populated by the protocol handler.
      */
     public RouteInfo getHttpRoute() {
         return route;
@@ -214,10 +230,9 @@ public class HttpClientContext extends HttpCoreContext {
     }
 
     /**
-     * Represents a collection of all redirects executed in the course of request execution.
+     * Represents a collection of all redirects executed in the context of request execution.
      * <p>
-     * This context attribute is expected to be populated by the protocol handler
-     * in the course of request execution.
+     * This context attribute is expected to be populated by the protocol handler.
      */
     public RedirectLocations getRedirectLocations() {
         if (this.redirectLocations == null) {
@@ -234,6 +249,11 @@ public class HttpClientContext extends HttpCoreContext {
         this.redirectLocations = redirectLocations;
     }
 
+    /**
+     * Represents a {@link CookieStore} used in the context of the request execution.
+     * <p>
+     * This context attribute can be set by the caller.
+     */
     public CookieStore getCookieStore() {
         return cookieStore;
     }
@@ -242,6 +262,11 @@ public class HttpClientContext extends HttpCoreContext {
         this.cookieStore = cookieStore;
     }
 
+    /**
+     * Represents a {@link CookieSpec} chosen in the context of request execution.
+     * <p>
+     * This context attribute is expected to be populated by the protocol handler.
+     */
     public CookieSpec getCookieSpec() {
         return cookieSpec;
     }
@@ -254,6 +279,11 @@ public class HttpClientContext extends HttpCoreContext {
         this.cookieSpec = cookieSpec;
     }
 
+    /**
+     * Represents a {@link CookieOrigin} produced in the context of request execution.
+     * <p>
+     * This context attribute is expected to be populated by the protocol handler.
+     */
     public CookieOrigin getCookieOrigin() {
         return cookieOrigin;
     }
@@ -266,6 +296,11 @@ public class HttpClientContext extends HttpCoreContext {
         this.cookieOrigin = cookieOrigin;
     }
 
+    /**
+     * Represents a {@link CookieSpecFactory} registry used in the context of the request execution.
+     * <p>
+     * This context attribute can be set by the caller.
+     */
     public Lookup<CookieSpecFactory> getCookieSpecRegistry() {
         return cookieSpecFactoryLookup;
     }
@@ -274,6 +309,11 @@ public class HttpClientContext extends HttpCoreContext {
         this.cookieSpecFactoryLookup = lookup;
     }
 
+    /**
+     * Represents a {@link AuthSchemeFactory} registry used in the context of the request execution.
+     * <p>
+     * This context attribute can be set by the caller.
+     */
     public Lookup<AuthSchemeFactory> getAuthSchemeRegistry() {
         return authSchemeFactoryLookup;
     }
@@ -282,6 +322,11 @@ public class HttpClientContext extends HttpCoreContext {
         this.authSchemeFactoryLookup = lookup;
     }
 
+    /**
+     * Represents a {@link CredentialsProvider} registry used in the context of the request execution.
+     * <p>
+     * This context attribute can be set by the caller.
+     */
     public CredentialsProvider getCredentialsProvider() {
         return credentialsProvider;
     }
@@ -290,6 +335,11 @@ public class HttpClientContext extends HttpCoreContext {
         this.credentialsProvider = credentialsProvider;
     }
 
+    /**
+     * Represents a {@link AuthCache} used in the context of the request execution.
+     * <p>
+     * This context attribute can be set by the caller.
+     */
     public AuthCache getAuthCache() {
         return authCache;
     }
@@ -299,6 +349,11 @@ public class HttpClientContext extends HttpCoreContext {
     }
 
     /**
+     * Represents a map of {@link AuthExchange}s performed in the context of the request
+     * execution.
+     * <p>
+     * This context attribute is expected to be populated by the protocol handler.
+     *
      * @since 5.0
      */
     public Map<HttpHost, AuthExchange> getAuthExchanges() {
@@ -340,6 +395,12 @@ public class HttpClientContext extends HttpCoreContext {
         return (T) getUserToken();
     }
 
+    /**
+     * Represents an arbitrary user token that identifies the user in the context
+     * of the request execution.
+     * <p>
+     * This context attribute can be set by the caller.
+     */
     public Object getUserToken() {
         return userToken;
     }
@@ -348,13 +409,18 @@ public class HttpClientContext extends HttpCoreContext {
         this.userToken = userToken;
     }
 
+    /**
+     * Represents an {@link RequestConfig used} in the context of the request execution.
+     * <p>
+     * This context attribute can be set by the caller.
+     */
     public RequestConfig getRequestConfig() {
         return requestConfig;
     }
 
     /**
      * Returns {@link RequestConfig} set in the context or {@link RequestConfig#DEFAULT}
-     * if not present in the context.
+     * if not explicitly set in the context.
      *
      * @since 5.4
      */
@@ -368,6 +434,10 @@ public class HttpClientContext extends HttpCoreContext {
     }
 
     /**
+     * Represents an identifier generated for the current message exchange executed
+     * in the given context.
+     * <p>
+     * This context attribute is expected to be populated by the protocol handler.
      * @since 5.1
      */
     public String getExchangeId() {
@@ -381,88 +451,237 @@ public class HttpClientContext extends HttpCoreContext {
         this.exchangeId = exchangeId;
     }
 
+    /**
+     * Internal adaptor class that delegates all its method calls to a plain {@link HttpContext}.
+     * To be removed in the future.
+     */
+    @SuppressWarnings("deprecation")
+    @Internal
     static class Delegate extends HttpClientContext {
 
-        final private HttpCoreContext parent;
+        private final HttpContext httpContext;
 
-        Delegate(final HttpCoreContext parent) {
-            super(parent);
-            this.parent = parent;
+        Delegate(final HttpContext httpContext) {
+            super(null);
+            this.httpContext = httpContext;
+        }
+
+        <T> T getAttr(final String id, final Class<T> clazz) {
+            final Object obj = httpContext.getAttribute(id);
+            if (obj == null) {
+                return null;
+            }
+            return clazz.cast(obj);
         }
 
         @Override
-        public ProtocolVersion getProtocolVersion() {
-            return parent.getProtocolVersion();
+        public RouteInfo getHttpRoute() {
+            return getAttr(HTTP_ROUTE, RouteInfo.class);
         }
 
         @Override
-        public void setProtocolVersion(final ProtocolVersion version) {
-            parent.setProtocolVersion(version);
+        public void setRoute(final HttpRoute route) {
+            httpContext.setAttribute(HTTP_ROUTE, route);
         }
 
         @Override
-        public Object getAttribute(final String id) {
-            return parent.getAttribute(id);
+        public RedirectLocations getRedirectLocations() {
+            RedirectLocations redirectLocations = getAttr(REDIRECT_LOCATIONS, RedirectLocations.class);
+            if (redirectLocations == null) {
+                redirectLocations = new RedirectLocations();
+                httpContext.setAttribute(REDIRECT_LOCATIONS, redirectLocations);
+            }
+            return redirectLocations;
         }
 
         @Override
-        public Object setAttribute(final String id, final Object obj) {
-            return parent.setAttribute(id, obj);
+        public void setRedirectLocations(final RedirectLocations redirectLocations) {
+            httpContext.setAttribute(REDIRECT_LOCATIONS, redirectLocations);
         }
 
         @Override
-        public Object removeAttribute(final String id) {
-            return parent.removeAttribute(id);
+        public CookieStore getCookieStore() {
+            return getAttr(COOKIE_STORE, CookieStore.class);
         }
 
         @Override
-        public <T> T getAttribute(final String id, final Class<T> clazz) {
-            return parent.getAttribute(id, clazz);
+        public void setCookieStore(final CookieStore cookieStore) {
+            httpContext.setAttribute(COOKIE_STORE, cookieStore);
+        }
+
+        @Override
+        public CookieSpec getCookieSpec() {
+            return getAttr(COOKIE_SPEC, CookieSpec.class);
+        }
+
+        @Override
+        public void setCookieSpec(final CookieSpec cookieSpec) {
+            httpContext.setAttribute(COOKIE_SPEC, cookieSpec);
+        }
+
+        @Override
+        public CookieOrigin getCookieOrigin() {
+            return getAttr(COOKIE_ORIGIN, CookieOrigin.class);
+        }
+
+        @Override
+        public void setCookieOrigin(final CookieOrigin cookieOrigin) {
+            httpContext.setAttribute(COOKIE_ORIGIN, cookieOrigin);
+        }
+
+        @Override
+        public Lookup<CookieSpecFactory> getCookieSpecRegistry() {
+            return getAttr(COOKIESPEC_REGISTRY, Lookup.class);
+        }
+
+        @Override
+        public void setCookieSpecRegistry(final Lookup<CookieSpecFactory> lookup) {
+            httpContext.setAttribute(COOKIESPEC_REGISTRY, lookup);
+        }
+
+        @Override
+        public Lookup<AuthSchemeFactory> getAuthSchemeRegistry() {
+            return getAttr(AUTHSCHEME_REGISTRY, Lookup.class);
+        }
+
+        @Override
+        public void setAuthSchemeRegistry(final Lookup<AuthSchemeFactory> lookup) {
+            httpContext.setAttribute(AUTHSCHEME_REGISTRY, lookup);
+        }
+
+        @Override
+        public CredentialsProvider getCredentialsProvider() {
+            return getAttr(CREDS_PROVIDER, CredentialsProvider.class);
+        }
+
+        @Override
+        public void setCredentialsProvider(final CredentialsProvider credentialsProvider) {
+            httpContext.setAttribute(CREDS_PROVIDER, credentialsProvider);
+        }
+
+        @Override
+        public AuthCache getAuthCache() {
+            return getAttr(AUTH_CACHE, AuthCache.class);
+        }
+
+        @Override
+        public void setAuthCache(final AuthCache authCache) {
+            httpContext.setAttribute(AUTH_CACHE, authCache);
+        }
+
+        @Override
+        public Map<HttpHost, AuthExchange> getAuthExchanges() {
+            Map<HttpHost, AuthExchange> map = getAttr(AUTH_EXCHANGE_MAP, Map.class);
+            if (map == null) {
+                map = new HashMap<>();
+                httpContext.setAttribute(AUTH_EXCHANGE_MAP, map);
+            }
+            return map;
+        }
+
+        @Override
+        public Object getUserToken() {
+            return httpContext.getAttribute(USER_TOKEN);
+        }
+
+        @Override
+        public void setUserToken(final Object userToken) {
+            httpContext.setAttribute(USER_TOKEN, userToken);
+        }
+
+        @Override
+        public RequestConfig getRequestConfig() {
+            return getAttr(REQUEST_CONFIG, RequestConfig.class);
+        }
+
+        @Override
+        public void setRequestConfig(final RequestConfig requestConfig) {
+            httpContext.setAttribute(REQUEST_CONFIG, requestConfig);
+        }
+
+        @Override
+        public String getExchangeId() {
+            return getAttr(EXCHANGE_ID, String.class);
+        }
+
+        @Override
+        public void setExchangeId(final String exchangeId) {
+            httpContext.setAttribute(EXCHANGE_ID, exchangeId);
         }
 
         @Override
         public HttpRequest getRequest() {
-            return parent.getRequest();
+            return getAttr(HttpCoreContext.HTTP_REQUEST, HttpRequest.class);
         }
 
         @Override
         public void setRequest(final HttpRequest request) {
-            parent.setRequest(request);
+            httpContext.setAttribute(HttpCoreContext.HTTP_REQUEST, request);
         }
 
         @Override
         public HttpResponse getResponse() {
-            return parent.getResponse();
+            return getAttr(HttpCoreContext.HTTP_RESPONSE, HttpResponse.class);
         }
 
         @Override
         public void setResponse(final HttpResponse response) {
-            parent.setResponse(response);
+            httpContext.setAttribute(HttpCoreContext.HTTP_RESPONSE, response);
         }
 
         @Override
         public EndpointDetails getEndpointDetails() {
-            return parent.getEndpointDetails();
+            return getAttr(HttpCoreContext.CONNECTION_ENDPOINT, EndpointDetails.class);
         }
 
         @Override
         public void setEndpointDetails(final EndpointDetails endpointDetails) {
-            parent.setEndpointDetails(endpointDetails);
+            httpContext.setAttribute(CONNECTION_ENDPOINT, endpointDetails);
         }
 
         @Override
         public SSLSession getSSLSession() {
-            return parent.getSSLSession();
+            return getAttr(HttpCoreContext.SSL_SESSION, SSLSession.class);
         }
 
         @Override
         public void setSSLSession(final SSLSession sslSession) {
-            parent.setSSLSession(sslSession);
+            httpContext.setAttribute(HttpCoreContext.SSL_SESSION, sslSession);
+        }
+
+        @Override
+        public ProtocolVersion getProtocolVersion() {
+            return httpContext.getProtocolVersion();
+        }
+
+        @Override
+        public void setProtocolVersion(final ProtocolVersion version) {
+            httpContext.setProtocolVersion(version);
+        }
+
+        @Override
+        public Object getAttribute(final String id) {
+            return httpContext.getAttribute(id);
+        }
+
+        @Override
+        public Object setAttribute(final String id, final Object obj) {
+            return httpContext.setAttribute(id, obj);
+        }
+
+        @Override
+        public Object removeAttribute(final String id) {
+            return httpContext.removeAttribute(id);
+        }
+
+        @Override
+        public <T> T getAttribute(final String id, final Class<T> clazz) {
+            return getAttr(id, clazz);
         }
 
         @Override
         public String toString() {
-            return parent.toString();
+            return httpContext.toString();
         }
 
     }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/protocol/RequestAddCookies.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/protocol/RequestAddCookies.java
@@ -33,13 +33,13 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.hc.client5.http.RouteInfo;
-import org.apache.hc.client5.http.cookie.StandardCookieSpec;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.cookie.Cookie;
 import org.apache.hc.client5.http.cookie.CookieOrigin;
 import org.apache.hc.client5.http.cookie.CookieSpec;
 import org.apache.hc.client5.http.cookie.CookieSpecFactory;
 import org.apache.hc.client5.http.cookie.CookieStore;
+import org.apache.hc.client5.http.cookie.StandardCookieSpec;
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.http.EntityDetails;
@@ -90,7 +90,7 @@ public class RequestAddCookies implements HttpRequestInterceptor {
             return;
         }
 
-        final HttpClientContext clientContext = HttpClientContext.adapt(context);
+        final HttpClientContext clientContext = HttpClientContext.cast(context);
         final String exchangeId = clientContext.getExchangeId();
 
         // Obtain cookie store
@@ -120,7 +120,7 @@ public class RequestAddCookies implements HttpRequestInterceptor {
             return;
         }
 
-        final RequestConfig config = clientContext.getRequestConfig();
+        final RequestConfig config = clientContext.getRequestConfigOrDefault();
         String cookieSpecName = config.getCookieSpec();
         if (cookieSpecName == null) {
             cookieSpecName = StandardCookieSpec.STRICT;
@@ -190,8 +190,8 @@ public class RequestAddCookies implements HttpRequestInterceptor {
 
         // Stick the CookieSpec and CookieOrigin instances to the HTTP context
         // so they could be obtained by the response interceptor
-        context.setAttribute(HttpClientContext.COOKIE_SPEC, cookieSpec);
-        context.setAttribute(HttpClientContext.COOKIE_ORIGIN, cookieOrigin);
+        clientContext.setCookieSpec(cookieSpec);
+        clientContext.setCookieOrigin(cookieOrigin);
     }
 
 }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/protocol/RequestAuthCache.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/protocol/RequestAuthCache.java
@@ -72,7 +72,7 @@ public class RequestAuthCache implements HttpRequestInterceptor {
         Args.notNull(request, "HTTP request");
         Args.notNull(context, "HTTP context");
 
-        final HttpClientContext clientContext = HttpClientContext.adapt(context);
+        final HttpClientContext clientContext = HttpClientContext.cast(context);
         final String exchangeId = clientContext.getExchangeId();
 
         final AuthCache authCache = clientContext.getAuthCache();

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/protocol/RequestClientConnControl.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/protocol/RequestClientConnControl.java
@@ -70,7 +70,7 @@ public class RequestClientConnControl implements HttpRequestInterceptor {
             return;
         }
 
-        final HttpClientContext clientContext = HttpClientContext.adapt(context);
+        final HttpClientContext clientContext = HttpClientContext.cast(context);
         final String exchangeId = clientContext.getExchangeId();
 
         // Obtain the client connection (required)

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/protocol/RequestExpectContinue.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/protocol/RequestExpectContinue.java
@@ -66,12 +66,12 @@ public class RequestExpectContinue implements HttpRequestInterceptor {
         Args.notNull(request, "HTTP request");
 
         if (!request.containsHeader(HttpHeaders.EXPECT)) {
-            final HttpClientContext clientContext = HttpClientContext.adapt(context);
+            final HttpClientContext clientContext = HttpClientContext.cast(context);
             final ProtocolVersion version = request.getVersion() != null ? request.getVersion() : clientContext.getProtocolVersion();
             // Do not send the expect header if request body is known to be empty
             if (entity != null
                     && entity.getContentLength() != 0 && !version.lessEquals(HttpVersion.HTTP_1_0)) {
-                final RequestConfig config = clientContext.getRequestConfig();
+                final RequestConfig config = clientContext.getRequestConfigOrDefault();
                 if (config.isExpectContinueEnabled()) {
                     request.addHeader(HttpHeaders.EXPECT, HeaderElements.CONTINUE);
                 }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/protocol/RequestUpgrade.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/protocol/RequestUpgrade.java
@@ -63,8 +63,8 @@ public final class RequestUpgrade implements HttpRequestInterceptor {
         Args.notNull(request, "HTTP request");
         Args.notNull(context, "HTTP context");
 
-        final HttpClientContext clientContext = HttpClientContext.adapt(context);
-        final RequestConfig requestConfig = clientContext.getRequestConfig();
+        final HttpClientContext clientContext = HttpClientContext.cast(context);
+        final RequestConfig requestConfig = clientContext.getRequestConfigOrDefault();
         if (requestConfig.isProtocolUpgradeEnabled()) {
             final ProtocolVersion version = request.getVersion() != null ? request.getVersion() : clientContext.getProtocolVersion();
             if (!request.containsHeader(HttpHeaders.UPGRADE) && version.getMajor() == 1 && version.getMinor() >= 1) {

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/protocol/ResponseProcessCookies.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/protocol/ResponseProcessCookies.java
@@ -77,7 +77,7 @@ public class ResponseProcessCookies implements HttpResponseInterceptor {
         Args.notNull(response, "HTTP request");
         Args.notNull(context, "HTTP context");
 
-        final HttpClientContext clientContext = HttpClientContext.adapt(context);
+        final HttpClientContext clientContext = HttpClientContext.cast(context);
         final String exchangeId = clientContext.getExchangeId();
 
         // Obtain actual CookieSpec instance

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClientMultiThreadedExecution.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClientMultiThreadedExecution.java
@@ -90,7 +90,7 @@ public class ClientMultiThreadedExecution {
 
         public GetThread(final CloseableHttpClient httpClient, final HttpGet httpget, final int id) {
             this.httpClient = httpClient;
-            this.context = new HttpClientContext();
+            this.context = HttpClientContext.create();
             this.httpget = httpget;
             this.id = id;
         }

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClientRemoteEndpointDetails.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClientRemoteEndpointDetails.java
@@ -44,7 +44,7 @@ public class ClientRemoteEndpointDetails {
     public static void main(final String[] args) throws Exception {
         try (final CloseableHttpClient httpclient = HttpClients.createDefault()) {
             // Create local HTTP context
-            final HttpClientContext localContext = new HttpClientContext();
+            final HttpClientContext localContext = HttpClientContext.create();
 
             final HttpGet httpget = new HttpGet("http://httpbin.org/get");
             System.out.println("Executing request " + httpget.getMethod() + " " + httpget.getUri());

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/TestDefaultConnKeepAliveStrategy.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/TestDefaultConnKeepAliveStrategy.java
@@ -43,7 +43,7 @@ public class TestDefaultConnKeepAliveStrategy {
 
     @Test
     public void testIllegalResponseArg() throws Exception {
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
         final ConnectionKeepAliveStrategy keepAliveStrat = new DefaultConnectionKeepAliveStrategy();
         Assertions.assertThrows(NullPointerException.class, () ->
                 keepAliveStrat.getKeepAliveDuration(null, context));

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestHttpAuthenticator.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestHttpAuthenticator.java
@@ -74,7 +74,7 @@ public class TestHttpAuthenticator {
 
     private AuthExchange authExchange;
     private CacheableAuthState authScheme;
-    private HttpContext context;
+    private HttpClientContext context;
     private HttpHost defaultHost;
     private CredentialsProvider credentialsProvider;
     private Lookup<AuthSchemeFactory> authSchemeRegistry;
@@ -89,12 +89,12 @@ public class TestHttpAuthenticator {
         this.context = new HttpClientContext();
         this.defaultHost = new HttpHost("localhost", 80);
         this.credentialsProvider = Mockito.mock(CredentialsProvider.class);
-        this.context.setAttribute(HttpClientContext.CREDS_PROVIDER, this.credentialsProvider);
+        this.context.setCredentialsProvider(this.credentialsProvider);
         this.authSchemeRegistry = RegistryBuilder.<AuthSchemeFactory>create()
             .register(StandardAuthScheme.BASIC, BasicSchemeFactory.INSTANCE)
             .register(StandardAuthScheme.DIGEST, DigestSchemeFactory.INSTANCE)
             .build();
-        this.context.setAttribute(HttpClientContext.AUTHSCHEME_REGISTRY, this.authSchemeRegistry);
+        this.context.setAuthSchemeRegistry(this.authSchemeRegistry);
         this.httpAuthenticator = new HttpAuthenticator();
     }
 

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestHttpAuthenticator.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestHttpAuthenticator.java
@@ -86,7 +86,7 @@ public class TestHttpAuthenticator {
         this.authScheme = Mockito.mock(CacheableAuthState.class, Mockito.withSettings()
                 .defaultAnswer(Answers.CALLS_REAL_METHODS));
         Mockito.when(this.authScheme.isChallengeComplete()).thenReturn(Boolean.TRUE);
-        this.context = new HttpClientContext();
+        this.context = HttpClientContext.create();
         this.defaultHost = new HttpHost("localhost", 80);
         this.credentialsProvider = Mockito.mock(CredentialsProvider.class);
         this.context.setCredentialsProvider(this.credentialsProvider);

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestSystemDefaultCredentialsProvider.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestSystemDefaultCredentialsProvider.java
@@ -94,7 +94,7 @@ public class TestSystemDefaultCredentialsProvider {
 
         final URL httpRequestUrl = new URL(TARGET_SCHEME1, TARGET_HOST1, TARGET_PORT1, "/");
         final AuthScope authScope = new AuthScope(PROXY_PROTOCOL1, PROXY_HOST1, PROXY_PORT1, PROMPT1, StandardAuthScheme.BASIC);
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
         context.setRequest(new HttpGet(httpRequestUrl.toURI()));
 
         final Credentials receivedCredentials =

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/classic/TestConnectExec.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/classic/TestConnectExec.java
@@ -94,7 +94,7 @@ public class TestConnectExec {
     @Test
     public void testExecAcquireConnection() throws Exception {
         final HttpRoute route = new HttpRoute(target);
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
         final ClassicHttpRequest request = new HttpGet("http://bar/test");
         try (final ClassicHttpResponse response = new BasicClassicHttpResponse(200, "OK")) {
             response.setEntity(EntityBuilder.create()
@@ -113,7 +113,7 @@ public class TestConnectExec {
     @Test
     public void testEstablishDirectRoute() throws Exception {
         final HttpRoute route = new HttpRoute(target);
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
         final ClassicHttpRequest request = new HttpGet("http://bar/test");
 
         final ConnectionState connectionState = new ConnectionState();
@@ -133,7 +133,7 @@ public class TestConnectExec {
     @Test
     public void testEstablishRouteDirectProxy() throws Exception {
         final HttpRoute route = new HttpRoute(target, null, proxy, false);
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
         final ClassicHttpRequest request = new HttpGet("http://bar/test");
 
         final ConnectionState connectionState = new ConnectionState();
@@ -153,7 +153,7 @@ public class TestConnectExec {
     @Test
     public void testEstablishRouteViaProxyTunnel() throws Exception {
         final HttpRoute route = new HttpRoute(target, null, proxy, true);
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
         final ClassicHttpRequest request = new HttpGet("http://bar/test");
         final ClassicHttpResponse response = new BasicClassicHttpResponse(200, "OK");
 
@@ -184,7 +184,7 @@ public class TestConnectExec {
     @Test
     public void testEstablishRouteViaProxyTunnelUnexpectedResponse() throws Exception {
         final HttpRoute route = new HttpRoute(target, null, proxy, true);
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
         final ClassicHttpRequest request = new HttpGet("http://bar/test");
         final ClassicHttpResponse response = new BasicClassicHttpResponse(101, "Lost");
 
@@ -204,7 +204,7 @@ public class TestConnectExec {
     @Test
     public void testEstablishRouteViaProxyTunnelFailure() throws Exception {
         final HttpRoute route = new HttpRoute(target, null, proxy, true);
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
         final ClassicHttpRequest request = new HttpGet("http://bar/test");
         final ClassicHttpResponse response = new BasicClassicHttpResponse(500, "Boom");
         response.setEntity(new StringEntity("Ka-boom"));
@@ -228,7 +228,7 @@ public class TestConnectExec {
     @Test
     public void testEstablishRouteViaProxyTunnelRetryOnAuthChallengePersistentConnection() throws Exception {
         final HttpRoute route = new HttpRoute(target, null, proxy, true);
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
         final ClassicHttpRequest request = new HttpGet("http://bar/test");
         final ClassicHttpResponse response1 = new BasicClassicHttpResponse(407, "Huh?");
         response1.setHeader(HttpHeaders.PROXY_AUTHENTICATE, StandardAuthScheme.BASIC + " realm=test");
@@ -269,7 +269,7 @@ public class TestConnectExec {
     @Test
     public void testEstablishRouteViaProxyTunnelRetryOnAuthChallengeNonPersistentConnection() throws Exception {
         final HttpRoute route = new HttpRoute(target, null, proxy, true);
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
         final ClassicHttpRequest request = new HttpGet("http://bar/test");
         final ClassicHttpResponse response1 = new BasicClassicHttpResponse(407, "Huh?");
         response1.setHeader(HttpHeaders.PROXY_AUTHENTICATE, StandardAuthScheme.BASIC + " realm=test");
@@ -311,7 +311,7 @@ public class TestConnectExec {
         final HttpHost proxy2 = new HttpHost("that", 8888);
         final HttpRoute route = new HttpRoute(target, null, new HttpHost[] {proxy1, proxy2},
                 true, RouteInfo.TunnelType.TUNNELLED, RouteInfo.LayerType.LAYERED);
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
         final ClassicHttpRequest request = new HttpGet("http://bar/test");
 
         final ConnectionState connectionState = new ConnectionState();

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/classic/TestContentCompressionExec.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/classic/TestContentCompressionExec.java
@@ -225,7 +225,7 @@ public class TestContentCompressionExec {
                 .setContentCompressionEnabled(false)
                 .build();
 
-        context.setAttribute(HttpClientContext.REQUEST_CONFIG, config);
+        context.setRequestConfig(config);
 
         Mockito.when(execChain.proceed(request, scope)).thenReturn(response);
 

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/classic/TestInternalHttpClient.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/classic/TestInternalHttpClient.java
@@ -89,7 +89,7 @@ public class TestInternalHttpClient {
         MockitoAnnotations.openMocks(this);
         client = new InternalHttpClient(connManager, requestExecutor, new ExecChainElement(execChain, null), routePlanner,
                 cookieSpecRegistry, authSchemeRegistry, cookieStore, credentialsProvider,
-                defaultConfig, Arrays.asList(closeable1, closeable2));
+                HttpClientContext::castOrCreate, defaultConfig, Arrays.asList(closeable1, closeable2));
 
     }
 

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/classic/TestInternalHttpClient.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/classic/TestInternalHttpClient.java
@@ -155,7 +155,7 @@ public class TestInternalHttpClient {
         Assertions.assertSame(authSchemeRegistry, context.getAuthSchemeRegistry());
         Assertions.assertSame(cookieStore, context.getCookieStore());
         Assertions.assertSame(credentialsProvider, context.getCredentialsProvider());
-        Assertions.assertSame(defaultConfig, context.getRequestConfig());
+        Assertions.assertSame(defaultConfig, context.getRequestConfigOrDefault());
     }
 
     @Test
@@ -176,7 +176,7 @@ public class TestInternalHttpClient {
         final HttpClientContext context = HttpClientContext.create();
         client.execute(httpget, context, response -> null);
 
-        Assertions.assertSame(config, context.getRequestConfig());
+        Assertions.assertSame(config, context.getRequestConfigOrDefault());
     }
 
     @Test
@@ -212,7 +212,7 @@ public class TestInternalHttpClient {
         Assertions.assertSame(localAuthSchemeRegistry, context.getAuthSchemeRegistry());
         Assertions.assertSame(localCookieStore, context.getCookieStore());
         Assertions.assertSame(localCredentialsProvider, context.getCredentialsProvider());
-        Assertions.assertSame(localConfig, context.getRequestConfig());
+        Assertions.assertSame(localConfig, context.getRequestConfigOrDefault());
     }
 
     @Test

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/classic/TestMainClientExec.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/classic/TestMainClientExec.java
@@ -114,7 +114,7 @@ public class TestMainClientExec {
     @Test
     public void testExecRequestNonPersistentConnection() throws Exception {
         final HttpRoute route = new HttpRoute(target);
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
         final ClassicHttpRequest request = new HttpGet("http://bar/test");
         final ClassicHttpResponse response = new BasicClassicHttpResponse(200, "OK");
         response.setEntity(EntityBuilder.create()
@@ -145,7 +145,7 @@ public class TestMainClientExec {
     @Test
     public void testExecRequestNonPersistentConnectionNoResponseEntity() throws Exception {
         final HttpRoute route = new HttpRoute(target);
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
         final ClassicHttpRequest request = new HttpGet("http://bar/test");
         final ClassicHttpResponse response = new BasicClassicHttpResponse(200, "OK");
         response.setEntity(null);
@@ -174,7 +174,7 @@ public class TestMainClientExec {
     @Test
     public void testExecRequestPersistentConnection() throws Exception {
         final HttpRoute route = new HttpRoute(target);
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
         final ClassicHttpRequest request = new HttpGet("http://bar/test");
         final ClassicHttpResponse response = new BasicClassicHttpResponse(200, "OK");
         // The entity is streaming
@@ -210,7 +210,7 @@ public class TestMainClientExec {
     @Test
     public void testExecRequestPersistentConnectionNoResponseEntity() throws Exception {
         final HttpRoute route = new HttpRoute(target);
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
         final ClassicHttpRequest request = new HttpGet("http://bar/test");
         final ClassicHttpResponse response = new BasicClassicHttpResponse(200, "OK");
 
@@ -240,7 +240,7 @@ public class TestMainClientExec {
     @Test
     public void testExecRequestConnectionRelease() throws Exception {
         final HttpRoute route = new HttpRoute(target);
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
         final ClassicHttpRequest request = new HttpGet("http://bar/test");
         final ClassicHttpResponse response = new BasicClassicHttpResponse(200, "OK");
         // The entity is streaming
@@ -275,7 +275,7 @@ public class TestMainClientExec {
     @Test
     public void testExecConnectionShutDown() throws Exception {
         final HttpRoute route = new HttpRoute(target);
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
         final ClassicHttpRequest request = new HttpGet("http://bar/test");
 
         Mockito.when(execRuntime.execute(
@@ -293,7 +293,7 @@ public class TestMainClientExec {
     @Test
     public void testExecRuntimeException() throws Exception {
         final HttpRoute route = new HttpRoute(target);
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
         final ClassicHttpRequest request = new HttpGet("http://bar/test");
 
         Mockito.when(execRuntime.execute(
@@ -311,7 +311,7 @@ public class TestMainClientExec {
     @Test
     public void testExecHttpException() throws Exception {
         final HttpRoute route = new HttpRoute(target);
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
         final ClassicHttpRequest request = new HttpGet("http://bar/test");
 
         Mockito.when(execRuntime.execute(
@@ -329,7 +329,7 @@ public class TestMainClientExec {
     @Test
     public void testExecIOException() throws Exception {
         final HttpRoute route = new HttpRoute(target);
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
         final ClassicHttpRequest request = new HttpGet("http://bar/test");
 
         Mockito.when(execRuntime.execute(

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/classic/TestProtocolExec.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/classic/TestProtocolExec.java
@@ -151,7 +151,7 @@ public class TestProtocolExec {
     @Test
     public void testExecRequestRetryOnAuthChallenge() throws Exception {
         final HttpRoute route = new HttpRoute(target);
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
         final ClassicHttpRequest request = new HttpGet("http://foo/test");
         final ClassicHttpResponse response1 = new BasicClassicHttpResponse(401, "Huh?");
         response1.setHeader(HttpHeaders.WWW_AUTHENTICATE, StandardAuthScheme.BASIC + " realm=test");
@@ -204,7 +204,7 @@ public class TestProtocolExec {
                 .setStream(inStream2)
                 .build());
 
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
 
         final AuthExchange authExchange = new AuthExchange();
         authExchange.setState(AuthExchange.State.SUCCESS);
@@ -245,7 +245,7 @@ public class TestProtocolExec {
     @Test
     public void testExecEntityEnclosingRequest() throws Exception {
         final HttpRoute route = new HttpRoute(target);
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
         final HttpPost request = new HttpPost("http://foo/test");
         final InputStream inStream0 = new ByteArrayInputStream(new byte[] {1, 2, 3});
         request.setEntity(EntityBuilder.create()

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/io/TestHttpClientConnectionOperator.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/io/TestHttpClientConnectionOperator.java
@@ -83,7 +83,7 @@ public class TestHttpClientConnectionOperator {
 
     @Test
     public void testConnect() throws Exception {
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
         final HttpHost host = new HttpHost("somehost");
         final InetAddress local = InetAddress.getByAddress(new byte[] {127, 0, 0, 0});
         final InetAddress ip1 = InetAddress.getByAddress(new byte[] {127, 0, 0, 1});
@@ -116,7 +116,7 @@ public class TestHttpClientConnectionOperator {
 
     @Test
     public void testConnectWithTLSUpgrade() throws Exception {
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
         final HttpHost host = new HttpHost("https", "somehost");
         final InetAddress local = InetAddress.getByAddress(new byte[] {127, 0, 0, 0});
         final InetAddress ip1 = InetAddress.getByAddress(new byte[] {127, 0, 0, 1});
@@ -152,7 +152,7 @@ public class TestHttpClientConnectionOperator {
 
     @Test
     public void testConnectTimeout() throws Exception {
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
         final HttpHost host = new HttpHost("somehost");
         final InetAddress ip1 = InetAddress.getByAddress(new byte[] {10, 0, 0, 1});
         final InetAddress ip2 = InetAddress.getByAddress(new byte[] {10, 0, 0, 2});
@@ -169,7 +169,7 @@ public class TestHttpClientConnectionOperator {
 
     @Test
     public void testConnectFailure() throws Exception {
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
         final HttpHost host = new HttpHost("somehost");
         final InetAddress ip1 = InetAddress.getByAddress(new byte[] {10, 0, 0, 1});
         final InetAddress ip2 = InetAddress.getByAddress(new byte[] {10, 0, 0, 2});
@@ -186,7 +186,7 @@ public class TestHttpClientConnectionOperator {
 
     @Test
     public void testConnectFailover() throws Exception {
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
         final HttpHost host = new HttpHost("somehost");
         final InetAddress local = InetAddress.getByAddress(new byte[] {127, 0, 0, 0});
         final InetAddress ip1 = InetAddress.getByAddress(new byte[] {10, 0, 0, 1});
@@ -213,7 +213,7 @@ public class TestHttpClientConnectionOperator {
 
     @Test
     public void testConnectExplicitAddress() throws Exception {
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
         final InetAddress local = InetAddress.getByAddress(new byte[] {127, 0, 0, 0});
         final InetAddress ip = InetAddress.getByAddress(new byte[] {127, 0, 0, 23});
         final HttpHost host = new HttpHost(ip);
@@ -235,7 +235,7 @@ public class TestHttpClientConnectionOperator {
 
     @Test
     public void testUpgrade() throws Exception {
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
         final HttpHost host = new HttpHost("https", "somehost", -1);
 
         Mockito.when(conn.isOpen()).thenReturn(true);
@@ -257,7 +257,7 @@ public class TestHttpClientConnectionOperator {
 
     @Test
     public void testUpgradeUpsupportedScheme() throws Exception {
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
         final HttpHost host = new HttpHost("httpsssss", "somehost", -1);
 
         Mockito.when(conn.isOpen()).thenReturn(true);
@@ -269,7 +269,7 @@ public class TestHttpClientConnectionOperator {
 
     @Test
     public void testUpgradeNonLayeringScheme() throws Exception {
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
         final HttpHost host = new HttpHost("http", "somehost", -1);
 
         Mockito.when(conn.isOpen()).thenReturn(true);

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/routing/TestDefaultProxyRoutePlanner.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/routing/TestDefaultProxyRoutePlanner.java
@@ -59,7 +59,7 @@ public class TestDefaultProxyRoutePlanner {
     public void testDefaultProxyDirect() throws Exception {
         final HttpHost target = new HttpHost("http", "somehost", 80);
 
-        final HttpContext context = new HttpClientContext();
+        final HttpContext context = HttpClientContext.create();
         final HttpRoute route = routePlanner.determineRoute(target, context);
 
         Assertions.assertEquals(target, route.getTargetHost());

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/routing/TestDefaultRoutePlanner.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/routing/TestDefaultRoutePlanner.java
@@ -60,7 +60,7 @@ public class TestDefaultRoutePlanner {
     public void testDirect() throws Exception {
         final HttpHost target = new HttpHost("http", "somehost", 80);
 
-        final HttpContext context = new HttpClientContext();
+        final HttpContext context = HttpClientContext.create();
         final HttpRoute route = routePlanner.determineRoute(target, context);
 
         Assertions.assertEquals(target, route.getTargetHost());
@@ -74,7 +74,7 @@ public class TestDefaultRoutePlanner {
         final HttpHost target = new HttpHost("https", "somehost", -1);
         Mockito.when(schemePortResolver.resolve(target)).thenReturn(443);
 
-        final HttpContext context = new HttpClientContext();
+        final HttpContext context = HttpClientContext.create();
         final HttpRoute route = routePlanner.determineRoute(target, context);
 
         Assertions.assertEquals(new HttpHost("https", "somehost", 443), route.getTargetHost());
@@ -101,7 +101,7 @@ public class TestDefaultRoutePlanner {
 
     @Test
     public void testNullTarget() throws Exception {
-        final HttpContext context = new HttpClientContext();
+        final HttpContext context = HttpClientContext.create();
         Assertions.assertThrows(ProtocolException.class, () ->
                 routePlanner.determineRoute(null, context));
     }
@@ -112,7 +112,7 @@ public class TestDefaultRoutePlanner {
         final URIAuthority virtualHost = new URIAuthority("someotherhost", 443);
         final HttpRequest request = new BasicHttpRequest("https", "GET", virtualHost, "/");
 
-        final HttpContext context = new HttpClientContext();
+        final HttpContext context = HttpClientContext.create();
         final HttpRoute route = routePlanner.determineRoute(target, request, context);
 
         Assertions.assertEquals(target, route.getTargetHost());
@@ -128,7 +128,7 @@ public class TestDefaultRoutePlanner {
         final URIAuthority virtualHost = new URIAuthority("someotherhost", 80);
         final HttpRequest request = new BasicHttpRequest("http", "GET", virtualHost, "/");
 
-        final HttpContext context = new HttpClientContext();
+        final HttpContext context = HttpClientContext.create();
         final HttpRoute route = routePlanner.determineRoute(target, request, context);
 
         Assertions.assertEquals(target, route.getTargetHost());

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/routing/TestSystemDefaultRoutePlanner.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/routing/TestSystemDefaultRoutePlanner.java
@@ -66,7 +66,7 @@ public class TestSystemDefaultRoutePlanner {
     public void testDirect() throws Exception {
         final HttpHost target = new HttpHost("http", "somehost", 80);
 
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
         final HttpRoute route = routePlanner.determineRoute(target, context);
 
         Assertions.assertEquals(target, route.getTargetHost());
@@ -80,7 +80,7 @@ public class TestSystemDefaultRoutePlanner {
         final HttpHost target = new HttpHost("https", "somehost", -1);
         Mockito.when(schemePortResolver.resolve(target)).thenReturn(443);
 
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
         final HttpRoute route = routePlanner.determineRoute(target, context);
 
         Assertions.assertEquals(new HttpHost("https", "somehost", 443), route.getTargetHost());
@@ -105,7 +105,7 @@ public class TestSystemDefaultRoutePlanner {
 
         final HttpHost target = new HttpHost("http", "somehost", 80);
 
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
         final HttpRoute route = routePlanner.determineRoute(target, context);
 
         Assertions.assertEquals(target, route.getTargetHost());

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/protocol/TestRequestAddCookies.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/protocol/TestRequestAddCookies.java
@@ -106,9 +106,9 @@ public class TestRequestAddCookies {
         final HttpRoute route = new HttpRoute(this.target, null, false);
 
         final HttpClientContext context = HttpClientContext.create();
-        context.setAttribute(HttpClientContext.HTTP_ROUTE, route);
-        context.setAttribute(HttpClientContext.COOKIE_STORE, this.cookieStore);
-        context.setAttribute(HttpClientContext.COOKIESPEC_REGISTRY, this.cookieSpecRegistry);
+        context.setRoute(route);
+        context.setCookieStore(this.cookieStore);
+        context.setCookieSpecRegistry(this.cookieSpecRegistry);
 
         final HttpRequestInterceptor interceptor = RequestAddCookies.INSTANCE;
         interceptor.process(request, null, context);
@@ -133,9 +133,9 @@ public class TestRequestAddCookies {
         final HttpRoute route = new HttpRoute(this.target, null, false);
 
         final HttpClientContext context = HttpClientContext.create();
-        context.setAttribute(HttpClientContext.HTTP_ROUTE, route);
-        context.setAttribute(HttpClientContext.COOKIE_STORE, this.cookieStore);
-        context.setAttribute(HttpClientContext.COOKIESPEC_REGISTRY, this.cookieSpecRegistry);
+        context.setRoute(route);
+        context.setCookieStore(this.cookieStore);
+        context.setCookieSpecRegistry(this.cookieSpecRegistry);
 
         final HttpRequestInterceptor interceptor = RequestAddCookies.INSTANCE;
         interceptor.process(request, null, context);
@@ -152,9 +152,9 @@ public class TestRequestAddCookies {
         final HttpRoute route = new HttpRoute(this.target, null, false);
 
         final HttpClientContext context = HttpClientContext.create();
-        context.setAttribute(HttpClientContext.HTTP_ROUTE, route);
-        context.setAttribute(HttpClientContext.COOKIE_STORE, null);
-        context.setAttribute(HttpClientContext.COOKIESPEC_REGISTRY, this.cookieSpecRegistry);
+        context.setRoute(route);
+        context.setCookieStore(null);
+        context.setCookieSpecRegistry(this.cookieSpecRegistry);
 
         final HttpRequestInterceptor interceptor = RequestAddCookies.INSTANCE;
         interceptor.process(request, null, context);
@@ -171,9 +171,9 @@ public class TestRequestAddCookies {
         final HttpRoute route = new HttpRoute(this.target, null, false);
 
         final HttpClientContext context = HttpClientContext.create();
-        context.setAttribute(HttpClientContext.HTTP_ROUTE, route);
-        context.setAttribute(HttpClientContext.COOKIE_STORE, this.cookieStore);
-        context.setAttribute(HttpClientContext.COOKIESPEC_REGISTRY, null);
+        context.setRoute(route);
+        context.setCookieStore(this.cookieStore);
+        context.setCookieSpecRegistry(null);
 
         final HttpRequestInterceptor interceptor = RequestAddCookies.INSTANCE;
         interceptor.process(request, null, context);
@@ -189,8 +189,8 @@ public class TestRequestAddCookies {
 
         final HttpClientContext context = HttpClientContext.create();
         context.setEndpointDetails(null);
-        context.setAttribute(HttpClientContext.COOKIE_STORE, this.cookieStore);
-        context.setAttribute(HttpClientContext.COOKIESPEC_REGISTRY, this.cookieSpecRegistry);
+        context.setCookieStore(this.cookieStore);
+        context.setCookieSpecRegistry(this.cookieSpecRegistry);
 
         final HttpRequestInterceptor interceptor = RequestAddCookies.INSTANCE;
         interceptor.process(request, null, context);
@@ -209,10 +209,10 @@ public class TestRequestAddCookies {
         final HttpRoute route = new HttpRoute(this.target, null, false);
 
         final HttpClientContext context = HttpClientContext.create();
-        context.setAttribute(HttpClientContext.HTTP_ROUTE, route);
-        context.setAttribute(HttpClientContext.REQUEST_CONFIG, config);
-        context.setAttribute(HttpClientContext.COOKIE_STORE, this.cookieStore);
-        context.setAttribute(HttpClientContext.COOKIESPEC_REGISTRY, this.cookieSpecRegistry);
+        context.setRoute(route);
+        context.setRequestConfig(config);
+        context.setCookieStore(this.cookieStore);
+        context.setCookieSpecRegistry(this.cookieSpecRegistry);
 
         final HttpRequestInterceptor interceptor = RequestAddCookies.INSTANCE;
         interceptor.process(request, null, context);
@@ -233,9 +233,9 @@ public class TestRequestAddCookies {
         final HttpRoute route = new HttpRoute(this.target, null, false);
 
         final HttpClientContext context = HttpClientContext.create();
-        context.setAttribute(HttpClientContext.HTTP_ROUTE, route);
-        context.setAttribute(HttpClientContext.COOKIE_STORE, this.cookieStore);
-        context.setAttribute(HttpClientContext.COOKIESPEC_REGISTRY, this.cookieSpecRegistry);
+        context.setRoute(route);
+        context.setCookieStore(this.cookieStore);
+        context.setCookieSpecRegistry(this.cookieSpecRegistry);
 
         final HttpRequestInterceptor interceptor = RequestAddCookies.INSTANCE;
         interceptor.process(request, null, context);
@@ -249,9 +249,9 @@ public class TestRequestAddCookies {
         final HttpRoute route = new HttpRoute(new HttpHost("localhost.local", 1234), null, false);
 
         final HttpClientContext context = HttpClientContext.create();
-        context.setAttribute(HttpClientContext.HTTP_ROUTE, route);
-        context.setAttribute(HttpClientContext.COOKIE_STORE, this.cookieStore);
-        context.setAttribute(HttpClientContext.COOKIESPEC_REGISTRY, this.cookieSpecRegistry);
+        context.setRoute(route);
+        context.setCookieStore(this.cookieStore);
+        context.setCookieSpecRegistry(this.cookieSpecRegistry);
 
         final HttpRequestInterceptor interceptor = RequestAddCookies.INSTANCE;
         interceptor.process(request, null, context);
@@ -273,9 +273,9 @@ public class TestRequestAddCookies {
                 new HttpHost("localhost.local", 80), null, new HttpHost("localhost", 8888), false);
 
         final HttpClientContext context = HttpClientContext.create();
-        context.setAttribute(HttpClientContext.HTTP_ROUTE, route);
-        context.setAttribute(HttpClientContext.COOKIE_STORE, this.cookieStore);
-        context.setAttribute(HttpClientContext.COOKIESPEC_REGISTRY, this.cookieSpecRegistry);
+        context.setRoute(route);
+        context.setCookieStore(this.cookieStore);
+        context.setCookieSpecRegistry(this.cookieSpecRegistry);
 
         final HttpRequestInterceptor interceptor = RequestAddCookies.INSTANCE;
         interceptor.process(request, null, context);
@@ -298,9 +298,9 @@ public class TestRequestAddCookies {
                 new HttpHost("http", "localhost", 8888), true, TunnelType.TUNNELLED, LayerType.LAYERED);
 
         final HttpClientContext context = HttpClientContext.create();
-        context.setAttribute(HttpClientContext.HTTP_ROUTE, route);
-        context.setAttribute(HttpClientContext.COOKIE_STORE, this.cookieStore);
-        context.setAttribute(HttpClientContext.COOKIESPEC_REGISTRY, this.cookieSpecRegistry);
+        context.setRoute(route);
+        context.setCookieStore(this.cookieStore);
+        context.setCookieSpecRegistry(this.cookieSpecRegistry);
 
         final HttpRequestInterceptor interceptor = RequestAddCookies.INSTANCE;
         interceptor.process(request, null, context);
@@ -330,9 +330,9 @@ public class TestRequestAddCookies {
         final HttpRoute route = new HttpRoute(this.target, null, false);
 
         final HttpClientContext context = HttpClientContext.create();
-        context.setAttribute(HttpClientContext.HTTP_ROUTE, route);
-        context.setAttribute(HttpClientContext.COOKIE_STORE, this.cookieStore);
-        context.setAttribute(HttpClientContext.COOKIESPEC_REGISTRY, this.cookieSpecRegistry);
+        context.setRoute(route);
+        context.setCookieStore(this.cookieStore);
+        context.setCookieSpecRegistry(this.cookieSpecRegistry);
 
         // Make sure the third cookie expires
         Thread.sleep(200);
@@ -361,9 +361,9 @@ public class TestRequestAddCookies {
         final HttpRoute route = new HttpRoute(this.target, null, false);
 
         final HttpClientContext context = HttpClientContext.create();
-        context.setAttribute(HttpClientContext.HTTP_ROUTE, route);
-        context.setAttribute(HttpClientContext.COOKIE_STORE, this.cookieStore);
-        context.setAttribute(HttpClientContext.COOKIESPEC_REGISTRY, this.cookieSpecRegistry);
+        context.setRoute(route);
+        context.setCookieStore(this.cookieStore);
+        context.setCookieSpecRegistry(this.cookieSpecRegistry);
 
         final HttpRequestInterceptor interceptor = RequestAddCookies.INSTANCE;
         interceptor.process(request, null, context);
@@ -396,9 +396,9 @@ public class TestRequestAddCookies {
         final HttpRoute route = new HttpRoute(this.target, null, false);
 
         final HttpClientContext context = HttpClientContext.create();
-        context.setAttribute(HttpClientContext.HTTP_ROUTE, route);
-        context.setAttribute(HttpClientContext.COOKIE_STORE, this.cookieStore);
-        context.setAttribute(HttpClientContext.COOKIESPEC_REGISTRY, this.cookieSpecRegistry);
+        context.setRoute(route);
+        context.setCookieStore(this.cookieStore);
+        context.setCookieSpecRegistry(this.cookieSpecRegistry);
 
         final HttpRequestInterceptor interceptor = RequestAddCookies.INSTANCE;
         interceptor.process(request, null, context);

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/protocol/TestRequestClientConnControl.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/protocol/TestRequestClientConnControl.java
@@ -68,7 +68,7 @@ public class TestRequestClientConnControl {
         final HttpHost target = new HttpHost("http", "localhost", 80);
         final HttpRoute route = new HttpRoute(target, null, false);
 
-        context.setAttribute(HttpClientContext.HTTP_ROUTE, route);
+        context.setRoute(route);
 
         final HttpRequestInterceptor interceptor = new RequestClientConnControl();
         interceptor.process(request, null, context);
@@ -88,7 +88,7 @@ public class TestRequestClientConnControl {
         final HttpRoute route = new HttpRoute(target, null, proxy, true,
                 TunnelType.TUNNELLED, LayerType.LAYERED);
 
-        context.setAttribute(HttpClientContext.HTTP_ROUTE, route);
+        context.setRoute(route);
 
         final HttpRequestInterceptor interceptor = new RequestClientConnControl();
         interceptor.process(request, null, context);
@@ -108,7 +108,7 @@ public class TestRequestClientConnControl {
         final HttpRoute route = new HttpRoute(target, null, proxy, false,
                 TunnelType.PLAIN, LayerType.PLAIN);
 
-        context.setAttribute(HttpClientContext.HTTP_ROUTE, route);
+        context.setRoute(route);
 
         final HttpRequestInterceptor interceptor = new RequestClientConnControl();
         interceptor.process(request, null, context);
@@ -128,7 +128,7 @@ public class TestRequestClientConnControl {
         final HttpRoute route = new HttpRoute(target, null, proxy, true,
                 TunnelType.TUNNELLED, LayerType.LAYERED);
 
-        context.setAttribute(HttpClientContext.HTTP_ROUTE, route);
+        context.setRoute(route);
 
         final HttpRequestInterceptor interceptor = new RequestClientConnControl();
         interceptor.process(request, null, context);

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/protocol/TestRequestDefaultHeaders.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/protocol/TestRequestDefaultHeaders.java
@@ -42,7 +42,7 @@ public class TestRequestDefaultHeaders {
 
     @Test
     public void testRequestParameterCheck() throws Exception {
-        final HttpContext context = new HttpClientContext();
+        final HttpContext context = HttpClientContext.create();
         final HttpRequestInterceptor interceptor = RequestDefaultHeaders.INSTANCE;
         Assertions.assertThrows(NullPointerException.class, () ->
                 interceptor.process(null, null, context));
@@ -53,7 +53,7 @@ public class TestRequestDefaultHeaders {
         final HttpRequest request = new BasicHttpRequest("CONNECT", "www.somedomain.com");
         final List<Header> defheaders = new ArrayList<>();
         defheaders.add(new BasicHeader("custom", "stuff"));
-        final HttpContext context = new HttpClientContext();
+        final HttpContext context = HttpClientContext.create();
 
         final HttpRequestInterceptor interceptor = new RequestDefaultHeaders(defheaders);
         interceptor.process(request, null, context);
@@ -67,7 +67,7 @@ public class TestRequestDefaultHeaders {
         request.addHeader("custom", "stuff");
         final List<Header> defheaders = new ArrayList<>();
         defheaders.add(new BasicHeader("custom", "other stuff"));
-        final HttpContext context = new HttpClientContext();
+        final HttpContext context = HttpClientContext.create();
 
         final HttpRequestInterceptor interceptor = new RequestDefaultHeaders(defheaders);
         interceptor.process(request, null, context);

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/protocol/TestRequestExpectContinue.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/protocol/TestRequestExpectContinue.java
@@ -46,7 +46,7 @@ public class TestRequestExpectContinue {
     public void testRequestExpectContinueGenerated() throws Exception {
         final HttpClientContext context = HttpClientContext.create();
         final RequestConfig config = RequestConfig.custom().setExpectContinueEnabled(true).build();
-        context.setAttribute(HttpClientContext.REQUEST_CONFIG, config);
+        context.setRequestConfig(config);
         final ClassicHttpRequest request = new BasicClassicHttpRequest("POST", "/");
         final String s = "whatever";
         final StringEntity entity = new StringEntity(s, StandardCharsets.US_ASCII);
@@ -62,7 +62,7 @@ public class TestRequestExpectContinue {
     public void testRequestExpectContinueNotGenerated() throws Exception {
         final HttpClientContext context = new HttpClientContext();
         final RequestConfig config = RequestConfig.custom().setExpectContinueEnabled(false).build();
-        context.setAttribute(HttpClientContext.REQUEST_CONFIG, config);
+        context.setRequestConfig(config);
         final ClassicHttpRequest request = new BasicClassicHttpRequest("POST", "/");
         final String s = "whatever";
         final StringEntity entity = new StringEntity(s, StandardCharsets.US_ASCII);
@@ -77,7 +77,7 @@ public class TestRequestExpectContinue {
     public void testRequestExpectContinueHTTP10() throws Exception {
         final HttpClientContext context = new HttpClientContext();
         final RequestConfig config = RequestConfig.custom().setExpectContinueEnabled(true).build();
-        context.setAttribute(HttpClientContext.REQUEST_CONFIG, config);
+        context.setRequestConfig(config);
         final ClassicHttpRequest request = new BasicClassicHttpRequest("POST", "/");
         request.setVersion(HttpVersion.HTTP_1_0);
         final String s = "whatever";
@@ -93,7 +93,7 @@ public class TestRequestExpectContinue {
     public void testRequestExpectContinueZeroContent() throws Exception {
         final HttpClientContext context = new HttpClientContext();
         final RequestConfig config = RequestConfig.custom().setExpectContinueEnabled(true).build();
-        context.setAttribute(HttpClientContext.REQUEST_CONFIG, config);
+        context.setRequestConfig(config);
         final ClassicHttpRequest request = new BasicClassicHttpRequest("POST", "/");
         final String s = "";
         final StringEntity entity = new StringEntity(s, StandardCharsets.US_ASCII);

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/protocol/TestRequestExpectContinue.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/protocol/TestRequestExpectContinue.java
@@ -60,7 +60,7 @@ public class TestRequestExpectContinue {
 
     @Test
     public void testRequestExpectContinueNotGenerated() throws Exception {
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
         final RequestConfig config = RequestConfig.custom().setExpectContinueEnabled(false).build();
         context.setRequestConfig(config);
         final ClassicHttpRequest request = new BasicClassicHttpRequest("POST", "/");
@@ -75,7 +75,7 @@ public class TestRequestExpectContinue {
 
     @Test
     public void testRequestExpectContinueHTTP10() throws Exception {
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
         final RequestConfig config = RequestConfig.custom().setExpectContinueEnabled(true).build();
         context.setRequestConfig(config);
         final ClassicHttpRequest request = new BasicClassicHttpRequest("POST", "/");
@@ -91,7 +91,7 @@ public class TestRequestExpectContinue {
 
     @Test
     public void testRequestExpectContinueZeroContent() throws Exception {
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
         final RequestConfig config = RequestConfig.custom().setExpectContinueEnabled(true).build();
         context.setRequestConfig(config);
         final ClassicHttpRequest request = new BasicClassicHttpRequest("POST", "/");
@@ -112,7 +112,7 @@ public class TestRequestExpectContinue {
 
     @Test
     public void testRequestExpectContinueIgnoreNonenclosingRequests() throws Exception {
-        final HttpClientContext context = new HttpClientContext();
+        final HttpClientContext context = HttpClientContext.create();
         final ClassicHttpRequest request = new BasicClassicHttpRequest("POST", "/");
         final RequestExpectContinue interceptor = new RequestExpectContinue();
         interceptor.process(request, null, context);

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/protocol/TestRequestValidateTrace.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/protocol/TestRequestValidateTrace.java
@@ -53,7 +53,7 @@ class TestRequestValidateTrace {
     @BeforeEach
     void setUp() {
         interceptor = new RequestValidateTrace();
-        context = new HttpClientContext();
+        context = HttpClientContext.create();
     }
 
     @Test

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/protocol/TestResponseProcessCookies.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/protocol/TestResponseProcessCookies.java
@@ -76,9 +76,9 @@ public class TestResponseProcessCookies {
         response.addHeader("Set-Cookie", "name1=value1");
 
         final HttpClientContext context = HttpClientContext.create();
-        context.setAttribute(HttpClientContext.COOKIE_ORIGIN, this.cookieOrigin);
-        context.setAttribute(HttpClientContext.COOKIE_SPEC, this.cookieSpec);
-        context.setAttribute(HttpClientContext.COOKIE_STORE, this.cookieStore);
+        context.setCookieOrigin(this.cookieOrigin);
+        context.setCookieSpec(this.cookieSpec);
+        context.setCookieStore(this.cookieStore);
 
         final HttpResponseInterceptor interceptor = ResponseProcessCookies.INSTANCE;
         interceptor.process(response, null, context);
@@ -99,9 +99,9 @@ public class TestResponseProcessCookies {
         response.addHeader("Set-Cookie", "name1=value1");
 
         final HttpClientContext context = HttpClientContext.create();
-        context.setAttribute(HttpClientContext.COOKIE_ORIGIN, null);
-        context.setAttribute(HttpClientContext.COOKIE_SPEC, this.cookieSpec);
-        context.setAttribute(HttpClientContext.COOKIE_STORE, this.cookieStore);
+        context.setCookieOrigin(null);
+        context.setCookieSpec(this.cookieSpec);
+        context.setCookieStore(this.cookieStore);
 
         final HttpResponseInterceptor interceptor = ResponseProcessCookies.INSTANCE;
         interceptor.process(response, null, context);
@@ -117,9 +117,9 @@ public class TestResponseProcessCookies {
         response.addHeader("Set-Cookie", "name1=value1");
 
         final HttpClientContext context = HttpClientContext.create();
-        context.setAttribute(HttpClientContext.COOKIE_ORIGIN, this.cookieOrigin);
-        context.setAttribute(HttpClientContext.COOKIE_SPEC, null);
-        context.setAttribute(HttpClientContext.COOKIE_STORE, this.cookieStore);
+        context.setCookieOrigin(this.cookieOrigin);
+        context.setCookieSpec(null);
+        context.setCookieStore(this.cookieStore);
 
         final HttpResponseInterceptor interceptor = ResponseProcessCookies.INSTANCE;
         interceptor.process(response, null, context);
@@ -135,9 +135,9 @@ public class TestResponseProcessCookies {
         response.addHeader("Set-Cookie", "name1=value1");
 
         final HttpClientContext context = HttpClientContext.create();
-        context.setAttribute(HttpClientContext.COOKIE_ORIGIN, this.cookieOrigin);
-        context.setAttribute(HttpClientContext.COOKIE_SPEC, this.cookieSpec);
-        context.setAttribute(HttpClientContext.COOKIE_STORE, null);
+        context.setCookieOrigin(this.cookieOrigin);
+        context.setCookieSpec(this.cookieSpec);
+        context.setCookieStore(null);
 
         final HttpResponseInterceptor interceptor = ResponseProcessCookies.INSTANCE;
         interceptor.process(response, null, context);


### PR DESCRIPTION
* Aligns client context APIs with those in core
* Context classes are now plain beans
* Backward compatibility with older versions (through internal Delegate classes)
* Javadoc imprvements