### PR TITLE
HTTPCLIENT-2327: Propagate CancellationExceptions from MemcachedClient operations as ResourceIOExceptions

### DIFF
--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/memcached/MemcachedHttpAsyncCacheStorage.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/memcached/MemcachedHttpAsyncCacheStorage.java
@@ -163,7 +163,7 @@ public class MemcachedHttpAsyncCacheStorage extends AbstractBinaryAsyncCacheStor
             } catch (final ExecutionException ex) {
                 if (ex.getCause() instanceof Exception) {
                     if (ex.getCause() instanceof CancellationException) {
-                        callback.failed(new ResourceIOException("Cache operation was cancelled mid-flight", ex.getCause()));
+                        callback.failed(new MemcachedOperationCancellationException(ex.getCause()));
                     } else {
                         callback.failed((Exception) ex.getCause());
                     }
@@ -189,7 +189,7 @@ public class MemcachedHttpAsyncCacheStorage extends AbstractBinaryAsyncCacheStor
             } catch (final ExecutionException ex) {
                 if (ex.getCause() instanceof Exception) {
                     if (ex.getCause() instanceof CancellationException) {
-                        callback.failed(new ResourceIOException("Cache operation was cancelled mid-flight", ex.getCause()));
+                        callback.failed(new MemcachedOperationCancellationException(ex.getCause()));
                     } else {
                         callback.failed((Exception) ex.getCause());
                     }

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/memcached/MemcachedHttpAsyncCacheStorage.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/memcached/MemcachedHttpAsyncCacheStorage.java
@@ -31,6 +31,7 @@ import java.net.InetSocketAddress;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 
 import org.apache.hc.client5.http.cache.HttpCacheEntrySerializer;
@@ -161,7 +162,11 @@ public class MemcachedHttpAsyncCacheStorage extends AbstractBinaryAsyncCacheStor
                 callback.completed(operationFuture.get());
             } catch (final ExecutionException ex) {
                 if (ex.getCause() instanceof Exception) {
-                    callback.failed((Exception) ex.getCause());
+                    if (ex.getCause() instanceof CancellationException) {
+                        callback.failed(new ResourceIOException("Cache operation was cancelled mid-flight", ex.getCause()));
+                    } else {
+                        callback.failed((Exception) ex.getCause());
+                    }
                 } else {
                     callback.failed(ex);
                 }
@@ -183,7 +188,11 @@ public class MemcachedHttpAsyncCacheStorage extends AbstractBinaryAsyncCacheStor
                 callback.completed(castAsByteArray(getFuture.get()));
             } catch (final ExecutionException ex) {
                 if (ex.getCause() instanceof Exception) {
-                    callback.failed((Exception) ex.getCause());
+                    if (ex.getCause() instanceof CancellationException) {
+                        callback.failed(new ResourceIOException("Cache operation was cancelled mid-flight", ex.getCause()));
+                    } else {
+                        callback.failed((Exception) ex.getCause());
+                    }
                 } else {
                     callback.failed(ex);
                 }

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/memcached/MemcachedHttpCacheStorage.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/memcached/MemcachedHttpCacheStorage.java
@@ -173,7 +173,7 @@ public class MemcachedHttpCacheStorage extends AbstractBinaryCacheStorage<CASVal
         try {
             client.set(storageKey, 0, storageObject);
         } catch (final CancellationException ex) {
-            throw new ResourceIOException("Cache operation was cancelled mid-flight", ex);
+            throw new MemcachedOperationCancellationException(ex);
         }
     }
 
@@ -192,7 +192,7 @@ public class MemcachedHttpCacheStorage extends AbstractBinaryCacheStorage<CASVal
         try {
             return castAsByteArray(client.get(storageKey));
         } catch (final CancellationException ex) {
-            throw new ResourceIOException("Cache operation was cancelled mid-flight", ex);
+            throw new MemcachedOperationCancellationException(ex);
         } catch (final OperationTimeoutException ex) {
             throw new MemcachedOperationTimeoutException(ex);
         }
@@ -203,7 +203,7 @@ public class MemcachedHttpCacheStorage extends AbstractBinaryCacheStorage<CASVal
         try {
             return client.gets(storageKey);
         } catch (final CancellationException ex) {
-            throw new ResourceIOException("Cache operation was cancelled mid-flight", ex);
+            throw new MemcachedOperationCancellationException(ex);
         } catch (final OperationTimeoutException ex) {
             throw new MemcachedOperationTimeoutException(ex);
         }
@@ -221,7 +221,7 @@ public class MemcachedHttpCacheStorage extends AbstractBinaryCacheStorage<CASVal
             final CASResponse casResult = client.cas(storageKey, casValue.getCas(), storageObject);
             return casResult == CASResponse.OK;
         } catch (final CancellationException ex) {
-            throw new ResourceIOException("Cache operation was cancelled mid-flight", ex);
+            throw new MemcachedOperationCancellationException(ex);
         } catch (final OperationTimeoutException ex) {
             throw new MemcachedOperationTimeoutException(ex);
         }
@@ -232,7 +232,7 @@ public class MemcachedHttpCacheStorage extends AbstractBinaryCacheStorage<CASVal
         try {
             client.delete(storageKey);
         } catch (final CancellationException ex) {
-            throw new ResourceIOException("Cache operation was cancelled mid-flight", ex);
+            throw new MemcachedOperationCancellationException(ex);
         }
     }
 
@@ -246,7 +246,7 @@ public class MemcachedHttpCacheStorage extends AbstractBinaryCacheStorage<CASVal
             }
             return resultMap;
         } catch (final CancellationException ex) {
-            throw new ResourceIOException("Cache operation was cancelled mid-flight", ex);
+            throw new MemcachedOperationCancellationException(ex);
         } catch (final OperationTimeoutException ex) {
             throw new MemcachedOperationTimeoutException(ex);
         }

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/memcached/MemcachedOperationCancellationException.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/memcached/MemcachedOperationCancellationException.java
@@ -1,0 +1,42 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.client5.http.impl.cache.memcached;
+
+import org.apache.hc.client5.http.cache.ResourceIOException;
+
+/**
+ * Signals memcached operation cancellation.
+ */
+public class MemcachedOperationCancellationException extends ResourceIOException {
+
+    private static final long serialVersionUID = 1L;
+
+    public MemcachedOperationCancellationException(final Throwable cause) {
+        super(cause != null ? cause.getMessage() : null, cause);
+    }
+
+}

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/memcached/MemcachedOperationCancellationException.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/memcached/MemcachedOperationCancellationException.java
@@ -30,6 +30,8 @@ import org.apache.hc.client5.http.cache.ResourceIOException;
 
 /**
  * Signals memcached operation cancellation.
+ *
+ * @since 5.4
  */
 public class MemcachedOperationCancellationException extends ResourceIOException {
 


### PR DESCRIPTION
fixes https://issues.apache.org/jira/browse/HTTPCLIENT-2327