### PR TITLE
Fix HTTPCLIENT-2331: Skip cookie header generation if a Cookie header is present

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/protocol/RequestAddCookies.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/protocol/RequestAddCookies.java
@@ -45,6 +45,7 @@ import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.http.EntityDetails;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpException;
+import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.HttpRequestInterceptor;
 import org.apache.hc.core5.http.Method;
@@ -89,6 +90,17 @@ public class RequestAddCookies implements HttpRequestInterceptor {
         if (Method.CONNECT.isSame(method) || Method.TRACE.isSame(method)) {
             return;
         }
+
+        final Header cookieHeader = request.getHeader(HttpHeaders.COOKIE);
+        // Check if a Cookie header is already present
+        if (cookieHeader != null) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Skipping cookie addition, Cookie header already present in the request");
+            }
+            // Skip adding cookies if the Cookie header is already present
+            return;
+        }
+
 
         final HttpClientContext clientContext = HttpClientContext.cast(context);
         final String exchangeId = clientContext.getExchangeId();

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/protocol/TestRequestAddCookies.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/protocol/TestRequestAddCookies.java
@@ -410,4 +410,27 @@ public class TestRequestAddCookies {
         Assertions.assertEquals("name1=value; name2=value; name3=value", headers1[0].getValue());
     }
 
+    @Test
+    public void testSkipAddingCookiesWhenCookieHeaderPresent() throws Exception {
+        // Prepare a request with an existing Cookie header
+        final HttpRequest request = new BasicHttpRequest("GET", "/");
+        request.addHeader("Cookie", "existingCookie=existingValue");
+
+        final HttpRoute route = new HttpRoute(this.target, null, false);
+
+        final HttpClientContext context = HttpClientContext.create();
+        context.setRoute(route);
+        context.setCookieStore(this.cookieStore);
+        context.setCookieSpecRegistry(this.cookieSpecRegistry);
+
+        final HttpRequestInterceptor interceptor = RequestAddCookies.INSTANCE;
+        interceptor.process(request, null, context);
+
+        // Check that no additional cookies were added
+        final Header[] headers = request.getHeaders("Cookie");
+        Assertions.assertNotNull(headers);
+        Assertions.assertEquals(1, headers.length);
+        Assertions.assertEquals("existingCookie=existingValue", headers[0].getValue());
+    }
+
 }


### PR DESCRIPTION
Fix for [HTTPCLIENT-2331:](https://issues.apache.org/jira/browse/HTTPCLIENT-2331) Single Cookie Header for Multiple Cookies

When an explicit Cookie header is added using `setHeader()` and multiple cookies exist in the `BasicCookieStore`, `HttpClient` was sending separate Cookie headers for the manually set cookies and the cookies in the store. This fix ensures that if a Cookie header is already present in the request, `HttpClient` skips adding additional Cookie headers from the `BasicCookieStore`. 
This change conforms to the expectation that a single Cookie header should be sent where all cookies are separated by a semicolon, as per [RFC6265](https://www.rfc-editor.org/rfc/rfc6265).
