### PR TITLE
Input streams returned by DecompressingEntity.getContent() should support mark(int) and reset()

### DIFF
--- a/httpclient5/src/test/java/org/apache/hc/client5/http/entity/TestDecompressingEntity.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/entity/TestDecompressingEntity.java
@@ -77,6 +77,22 @@ class TestDecompressingEntity {
     }
 
     @Test
+    void testStreamingMarking() throws Exception {
+        final CRC32 crc32 = new CRC32();
+        final ByteArrayInputStream in = new ByteArrayInputStream("1234567890".getBytes(StandardCharsets.US_ASCII));
+        final InputStreamEntity wrapped = new InputStreamEntity(in, -1, ContentType.DEFAULT_TEXT);
+        final ChecksumEntity entity = new ChecksumEntity(wrapped, crc32);
+        final InputStream in1 = entity.getContent();
+        Assertions.assertEquals('1', in1.read());
+        Assertions.assertEquals('2', in1.read());
+        in1.mark(1);
+        Assertions.assertEquals('3', in1.read());
+        in1.reset();
+        Assertions.assertEquals('3', in1.read());
+        EntityUtils.consume(entity);
+    }
+
+    @Test
     void testWriteToStream() throws Exception {
         final CRC32 crc32 = new CRC32();
         final StringEntity wrapped = new StringEntity("1234567890", StandardCharsets.US_ASCII);
@@ -101,3 +117,4 @@ class TestDecompressingEntity {
     }
 
 }
+


### PR DESCRIPTION
Input streams returned by DecompressingEntity.getContent() should support mark(int) and reset() if the underlying stream does

- Pass calls to the underlying InputStream for mark(int)
- Pass calls to the underlying InputStream for reset()
- LazyDecompressingInputStream extends FilterInputStream
- Reimplement internals fluently
- Reuse Closer.close(Closeable)
- Tested locally with git master 5.3-beta2-SNAPSHOT