### PR TITLE
DeflateInputStream extends FilterInputStream

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/entity/DeflateInputStream.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/entity/DeflateInputStream.java
@@ -26,23 +26,23 @@
  */
 package org.apache.hc.client5.http.entity;
 
+import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PushbackInputStream;
+import java.util.zip.Deflater;
 import java.util.zip.Inflater;
 import java.util.zip.InflaterInputStream;
 import java.util.zip.ZipException;
 
 /**
- * Deflate input stream. This class includes logic needed for various Rfc's in order
- * to reasonably implement the "deflate" compression style.
+ * Deflates an input stream. This class includes logic needed for various RFCs in order
+ * to reasonably implement the "deflate" compression algorithm.
  */
-public class DeflateInputStream extends InputStream {
-
-    private final InputStream sourceStream;
+public class DeflateInputStream extends FilterInputStream {
 
     public DeflateInputStream(final InputStream wrapped) throws IOException {
-
+        super(null);
         final PushbackInputStream pushback = new PushbackInputStream(wrapped, 2);
         final int i1 = pushback.read();
         final int i2 = pushback.read();
@@ -58,89 +58,17 @@ public class DeflateInputStream extends InputStream {
         final int compressionMethod = b1 & 0xF;
         final int compressionInfo = b1 >> 4 & 0xF;
         final int b2 = i2 & 0xFF;
-        if (compressionMethod == 8 && compressionInfo <= 7 && ((b1 << 8) | b2) % 31 == 0) {
+        if (compressionMethod == Deflater.DEFLATED && compressionInfo <= 7 && ((b1 << 8) | b2) % 31 == 0) {
             nowrap = false;
         }
-        sourceStream = new DeflateStream(pushback, new Inflater(nowrap));
+        in = new DeflateStream(pushback, new Inflater(nowrap));
     }
 
-    /**
-     * Read a byte.
-     */
-    @Override
-    public int read() throws IOException {
-        return sourceStream.read();
-    }
-
-    /**
-     * Read lots of bytes.
-     */
-    @Override
-    public int read(final byte[] b) throws IOException {
-        return sourceStream.read(b);
-    }
-
-    /**
-     * Read lots of specific bytes.
-     */
-    @Override
-    public int read(final byte[] b, final int off, final int len) throws IOException {
-        return sourceStream.read(b, off, len);
-    }
-
-    /**
-     * Skip
-     */
-    @Override
-    public long skip(final long n) throws IOException {
-        return sourceStream.skip(n);
-    }
-
-    /**
-     * Get available.
-     */
-    @Override
-    public int available() throws IOException {
-        return sourceStream.available();
-    }
-
-    /**
-     * Mark.
-     */
-    @Override
-    public void mark(final int readLimit) {
-        sourceStream.mark(readLimit);
-    }
-
-    /**
-     * Reset.
-     */
-    @Override
-    public void reset() throws IOException {
-        sourceStream.reset();
-    }
-
-    /**
-     * Check if mark is supported.
-     */
-    @Override
-    public boolean markSupported() {
-        return sourceStream.markSupported();
-    }
-
-    /**
-     * Close.
-     */
-    @Override
-    public void close() throws IOException {
-        sourceStream.close();
-    }
-
-    static class DeflateStream extends InflaterInputStream {
+    private static class DeflateStream extends InflaterInputStream {
 
         private boolean closed;
 
-        public DeflateStream(final InputStream in, final Inflater inflater) {
+        private DeflateStream(final InputStream in, final Inflater inflater) {
             super(in, inflater);
         }
 
@@ -157,4 +85,3 @@ public class DeflateInputStream extends InputStream {
     }
 
 }
-


### PR DESCRIPTION
Let `DeflateInputStream` extends `FilterInputStream`

- Reduces boilerplate
- Improve Javadoc
- Internal static class can be private
- Reuse constant Deflater.DEFLATED