### PR TITLE
Fix NTLMv2 auth problems for AD 2012 and above

### DIFF
--- a/httpclient/src/main/java/org/apache/http/impl/auth/NTLMEngineImpl.java
+++ b/httpclient/src/main/java/org/apache/http/impl/auth/NTLMEngineImpl.java
@@ -1285,6 +1285,7 @@ final class NTLMEngineImpl implements NTLMEngine {
                 //FLAG_REQUEST_LAN_MANAGER_KEY |
                 FLAG_REQUEST_NTLMv1 |
                 FLAG_REQUEST_NTLM2_SESSION |
+                FLAG_REQUEST_TARGET |
 
                 // Protocol version request
                 FLAG_REQUEST_VERSION |


### PR DESCRIPTION
Without this flag actual code will be using NTLMv2Session response instead of NTLMv2 response.