### PR TITLE
HTTPCLIENT-2343 -  Enhance `HttpClientContext` user token management for improved compatibility

### DIFF
--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/classic/TestHttpClientContext.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/classic/TestHttpClientContext.java
@@ -1,0 +1,49 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.hc.client5.http.impl.classic;
+
+import org.apache.hc.client5.http.protocol.HttpClientContext;
+import org.apache.hc.core5.http.protocol.BasicHttpContext;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("deprecation")
+class TestHttpClientContext {
+
+    @Test
+    void testDeprecatedSetAttributes() {
+        final HttpClientContext context1 = HttpClientContext.cast(new BasicHttpContext());
+        context1.setAttribute(HttpClientContext.USER_TOKEN, "blah");
+        Assertions.assertEquals("blah", context1.getUserToken());
+
+        final HttpClientContext context2 = HttpClientContext.create();
+        context2.setAttribute(HttpClientContext.USER_TOKEN, "blah");
+        Assertions.assertEquals("blah", context2.getUserToken());
+    }
+
+}

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/classic/TestMainClientExec.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/classic/TestMainClientExec.java
@@ -344,4 +344,48 @@ class TestMainClientExec {
         Mockito.verify(execRuntime).discardEndpoint();
     }
 
+    @Test
+    void testGetUserTokenNewWay() {
+        // Set user token using the new method
+        final HttpClientContext context = HttpClientContext.create();
+        final String expectedToken = "nwe token way";
+        context.setUserToken(expectedToken);
+
+        // Retrieve using the getter
+        final Object actualToken = context.getUserToken();
+
+        // Validate that the token is set and retrieved correctly
+        Assertions.assertEquals(expectedToken, actualToken, "The user token should match the one set by setUserToken().");
+    }
+
+    @Test
+    void testGetUserTokenOldWay() {
+        // Set user token using context attributes (old way)
+        final HttpClientContext context = HttpClientContext.create();
+        final String expectedToken = "old token way";
+        context.setAttribute(HttpClientContext.USER_TOKEN, expectedToken);
+
+        // Retrieve using the getter
+        final Object actualToken = context.getUserToken();
+
+        // Validate that the token is retrieved correctly for backward compatibility
+        Assertions.assertEquals(expectedToken, actualToken, "The user token should match the one set by context attribute for backward compatibility.");
+    }
+
+    @Test
+    void testGetUserTokenBothSet() {
+        // Set user token using both the new and old methods
+        final HttpClientContext context = HttpClientContext.create();
+        final String newToken = "new token way";
+        final String oldToken = "old token way";
+        context.setUserToken(newToken);
+        context.setAttribute(HttpClientContext.USER_TOKEN, oldToken);
+
+        // Retrieve using the getter
+        final Object actualToken = context.getUserToken();
+
+        // Validate that the new method takes precedence over the old one
+        Assertions.assertEquals(newToken, actualToken, "The user token should match the one set by setUserToken(), taking precedence over the context attribute.");
+    }
+
 }


### PR DESCRIPTION
This PR refines the way user tokens are managed within `HttpClientContext`. Specifically, the `getUserToken()` method has been enhanced to first check the internal `userToken` field, and only fall back to context attributes for backward compatibility. A warning log has been added to notify developers when this fallback occurs, strongly encouraging the preferred usage of `setUserToken(Object)` for setting user tokens.