### PR TITLE
Return builder from setHostnameVerificationPolicy

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/ClientTlsStrategyBuilder.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/ClientTlsStrategyBuilder.java
@@ -134,8 +134,9 @@ public class ClientTlsStrategyBuilder {
     /**
      * Sets {@link HostnameVerificationPolicy} value.
      */
-    public void setHostnameVerificationPolicy(final HostnameVerificationPolicy hostnameVerificationPolicy) {
+    public final ClientTlsStrategyBuilder setHostnameVerificationPolicy(final HostnameVerificationPolicy hostnameVerificationPolicy) {
         this.hostnameVerificationPolicy = hostnameVerificationPolicy;
+        return this;
     }
 
     /**


### PR DESCRIPTION
Currently, it is impossible to add  `setHostnameVerificationPolicy` to a call chain