### PR TITLE
Bug fix: Correct the issue with connection state detection in DefaultManagedAsyncClientConnection#isOpen().

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/DefaultManagedAsyncClientConnection.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/DefaultManagedAsyncClientConnection.java
@@ -98,7 +98,17 @@ final class DefaultManagedAsyncClientConnection implements ManagedAsyncClientCon
 
     @Override
     public boolean isOpen() {
-        return ioSession.isOpen();
+        final IOSession ioSession = this.ioSession;
+        if (ioSession.isOpen()) {
+            final IOEventHandler handler = ioSession.getHandler();
+            if (handler instanceof HttpConnection) {
+                return ((HttpConnection) handler).isOpen();
+            } else {
+                return true;
+            }
+        } else {
+            return false;
+        }
     }
 
     @Override


### PR DESCRIPTION
Invoke method ClientH2IOEventHandler#isOpen() to ensure that the streamMultiplexer is open, because receiving the GOAWAY frame only updates the ClientH2StreamMultiplexer's connState.