### PR TITLE
Add  `rspauth` in Digest authentication.

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/DigestScheme.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/DigestScheme.java
@@ -460,6 +460,7 @@ public class DigestScheme implements AuthScheme, Serializable {
             params.add(new BasicNameValuePair("qop", qop == QualityOfProtection.AUTH_INT ? "auth-int" : "auth"));
             params.add(new BasicNameValuePair("nc", nc));
             params.add(new BasicNameValuePair("cnonce", cnonce));
+            params.add(new BasicNameValuePair("rspauth", hasha2));
         }
         if (algorithm != null) {
             params.add(new BasicNameValuePair("algorithm", algorithm));

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestDigestScheme.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestDigestScheme.java
@@ -906,5 +906,26 @@ class TestDigestScheme {
         Assertions.assertTrue(authResponse.contains("username*"));
     }
 
+    @Test
+    void testRspAuthFieldAndQuoting() throws Exception {
+        final ClassicHttpRequest request = new BasicClassicHttpRequest("POST", "/");
+        final HttpHost host = new HttpHost("somehost", 80);
+        final CredentialsProvider credentialsProvider = CredentialsProviderBuilder.create()
+                .add(new AuthScope(host, "realm1", null), "username", "password".toCharArray())
+                .build();
+
+        // Challenge with qop set to "auth-int" to trigger rspauth field
+        final String challenge = StandardAuthScheme.DIGEST + " realm=\"realm1\", nonce=\"f2a3f18799759d4f1a1c068b92b573cb\", qop=\"auth-int\"";
+        final AuthChallenge authChallenge = parse(challenge);
+        final DigestScheme authscheme = new DigestScheme();
+        authscheme.processChallenge(authChallenge, null);
+
+        Assertions.assertTrue(authscheme.isResponseReady(host, credentialsProvider, null));
+        final String authResponse = authscheme.generateAuthResponse(host, request, null);
+
+        final Map<String, String> table = parseAuthResponse(authResponse);
+
+        Assertions.assertNotNull(table.get("rspauth"));
+    }
 
 }


### PR DESCRIPTION
  Updated the Digest authentication implementation to ensure compliance with RFC requirements for mutual authentication. Specifically, added support for rspauth.