### PR TITLE
fix(examples): Typo in ClientConfiguration example

### DIFF
--- a/httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClientConfiguration.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClientConfiguration.java
@@ -126,8 +126,8 @@ public class ClientConfiguration {
         };
         final HttpMessageWriterFactory<ClassicHttpRequest> requestWriterFactory = new DefaultHttpRequestWriterFactory();
 
-        // Create connection configuration
-        final CharCodingConfig connectionConfig = CharCodingConfig.custom()
+        // Create char coding configuration
+        final CharCodingConfig charCodingConfig = CharCodingConfig.custom()
                 .setMalformedInputAction(CodingErrorAction.IGNORE)
                 .setUnmappableInputAction(CodingErrorAction.IGNORE)
                 .setCharset(StandardCharsets.UTF_8)
@@ -138,7 +138,7 @@ public class ClientConfiguration {
         // configuration parameters HTTP connection factory can define message
         // parser / writer routines to be employed by individual connections.
         final HttpConnectionFactory<ManagedHttpClientConnection> connFactory = new ManagedHttpClientConnectionFactory(
-                h1Config, connectionConfig, requestWriterFactory, responseParserFactory);
+                h1Config, charCodingConfig, requestWriterFactory, responseParserFactory);
 
         // Client HTTP connection objects when fully initialized can be bound to
         // an arbitrary network socket. The process of network socket initialization,


### PR DESCRIPTION
This was forgotten in commit: [04594b97a9e61931d3af6847b8f8335f0f91c460](https://github.com/apache/httpcomponents-client/commit/04594b97a9e61931d3af6847b8f8335f0f91c460#diff-f16a6b22809dbe3a415d34c12d4e04b91f136e38334a76e51309a1be4c214bbcR123)