### PR TITLE
Enhance filename encoding in multipart/form-data (HTTPCLIENT-2360)

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/entity/mime/MultipartEntityBuilder.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/entity/mime/MultipartEntityBuilder.java
@@ -289,7 +289,7 @@ import org.apache.hc.core5.util.Args;
                     if (charsetCopy == null) {
                         charsetCopy = StandardCharsets.UTF_8;
                     }
-                    form = new HttpRFC7578Multipart(charsetCopy, boundaryCopy, multipartPartsCopy, preamble, epilogue);
+                    form = new HttpRFC7578Multipart(charsetCopy, boundaryCopy, multipartPartsCopy, preamble, epilogue, modeCopy);
                 } else {
                     form = new HttpRFC6532Multipart(charsetCopy, boundaryCopy, multipartPartsCopy, preamble, epilogue);
                 }

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/entity/mime/TestMultipartForm.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/entity/mime/TestMultipartForm.java
@@ -295,11 +295,11 @@ class TestMultipartForm {
         @SuppressWarnings("resource")
         final FormBodyPart p1 = FormBodyPartBuilder.create(
                 "field1",
-                new InputStreamBody(new FileInputStream(tmpfile), s1 + ".tmp")).build();
+                new InputStreamBody(new FileInputStream(tmpfile), s1 + ".tmp"), HttpMultipartMode.LEGACY).build();
         @SuppressWarnings("resource")
         final FormBodyPart p2 = FormBodyPartBuilder.create(
                 "field2",
-                new InputStreamBody(new FileInputStream(tmpfile), s2 + ".tmp")).build();
+                new InputStreamBody(new FileInputStream(tmpfile), s2 + ".tmp"), HttpMultipartMode.LEGACY).build();
         final LegacyMultipart multipart = new LegacyMultipart(
                 StandardCharsets.UTF_8, "foo",
                 Arrays.asList(p1, p2));


### PR DESCRIPTION
Implements RFC 6266/5987 filename encoding in multipart/form-data. Adds mode-aware support in FormBodyPartBuilder and HttpRFC7578Multipart, propagates mode via MultipartEntityBuilder, and updates tests. Resolves https://issues.apache.org/jira/browse/HTTPCLIENT-2360.