### PR TITLE
Fix PublicSuffixMatcherLoader#getDefault

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/psl/PublicSuffixMatcherLoader.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/psl/PublicSuffixMatcherLoader.java
@@ -51,7 +51,7 @@ import org.slf4j.LoggerFactory;
 @Contract(threading = ThreadingBehavior.SAFE)
 public final class PublicSuffixMatcherLoader {
 
-    private static final String PUBLIC_SUFFIX_LIST = "org/publicsuffix/list/effective_tld_names.dat";
+    private static final String PUBLIC_SUFFIX_LIST = "/org/publicsuffix/list/effective_tld_names.dat";
 
     private static final Logger LOG = LoggerFactory.getLogger(PublicSuffixMatcherLoader.class);
 

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/psl/TestPublicSuffixMatcher.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/psl/TestPublicSuffixMatcher.java
@@ -29,7 +29,6 @@ package org.apache.hc.client5.http.psl;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
@@ -40,7 +39,6 @@ import org.junit.jupiter.api.Test;
 class TestPublicSuffixMatcher {
 
     private static final String SOURCE_FILE = "suffixlistmatcher.txt";
-    private static final String PUBLIC_SUFFIX_LIST_FILE = "org/publicsuffix/list/effective_tld_names.dat";
 
     private PublicSuffixMatcher matcher;
     private PublicSuffixMatcher pslMatcher;
@@ -60,9 +58,7 @@ class TestPublicSuffixMatcher {
             final List<PublicSuffixList> lists = PublicSuffixListParser.INSTANCE.parseByType(new InputStreamReader(in, StandardCharsets.UTF_8));
             matcher = new PublicSuffixMatcher(lists);
         }
-        final URL publicSuffixListUrl = classLoader.getResource(PUBLIC_SUFFIX_LIST_FILE);
-        Assertions.assertNotNull(publicSuffixListUrl, PUBLIC_SUFFIX_LIST_FILE);
-        pslMatcher = PublicSuffixMatcherLoader.load(publicSuffixListUrl);
+        pslMatcher = PublicSuffixMatcherLoader.getDefault();
     }
 
     @Test

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/psl/TestPublicSuffixMatcherLoader.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/psl/TestPublicSuffixMatcherLoader.java
@@ -27,6 +27,7 @@
 
 package org.apache.hc.client5.http.psl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.junit.jupiter.api.Test;
@@ -38,7 +39,10 @@ class TestPublicSuffixMatcherLoader {
 
     @Test
     void testGetDefault() {
-        assertNotNull(PublicSuffixMatcherLoader.getDefault());
+        final PublicSuffixMatcher defaultMatcher = PublicSuffixMatcherLoader.getDefault();
+        assertNotNull(defaultMatcher);
+        // check for an expected-to-be-stable entry in the PUBLIC_SUFFIX_LIST
+        assertEquals("example.net", defaultMatcher.getDomainRoot("example.net", DomainType.ICANN));
     }
 
 }


### PR DESCRIPTION
The code of `getDefault` reads like it's supposed to load the entries from `PUBLIC_SUFFIX_LIST` by default, but it doesn't actually work that way in practice. I think this is a bug. This works correctly on 4.x, but the list there already starts with a leading slash:

https://github.com/apache/httpcomponents-client/blob/54900db4653d7f207477e6ee40135b88e9bcf832/httpclient/src/main/java/org/apache/http/conn/util/PublicSuffixMatcherLoader.java#L86

This was sneaking past the tests, because the test for getDefault only checks that it isn't `null`, but a non-null nearly empty default PublicSuffixMatcher is still provided in the case of the url not existing, and the tests for PublicSuffixMatcher themselves reimplement the default loading logic (correctly, since they rely on `ClassLoader#getResource` rather than `Class#getResource`) and so they weren't running into the bug either.