### PR TITLE
HTTPCLIENT-2365, regression: corrected handling of private domains by PublicSuffixMatcher

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/psl/PublicSuffixMatcher.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/psl/PublicSuffixMatcher.java
@@ -34,6 +34,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.hc.client5.http.utils.DnsUtils;
 import org.apache.hc.core5.annotation.Contract;
+import org.apache.hc.core5.annotation.Internal;
 import org.apache.hc.core5.annotation.ThreadingBehavior;
 import org.apache.hc.core5.util.Args;
 
@@ -137,6 +138,24 @@ public final class PublicSuffixMatcher {
         if (domain.startsWith(".")) {
             return null;
         }
+        final DomainRootInfo match = resolveDomainRoot(domain, expectedType);
+        return match != null ? match.root : null;
+    }
+
+    static final class DomainRootInfo {
+
+        final String root;
+        final String matchingKey;
+        final DomainType domainType;
+
+        DomainRootInfo(final String root, final String matchingKey, final DomainType domainType) {
+            this.root = root;
+            this.matchingKey = matchingKey;
+            this.domainType = domainType;
+        }
+    }
+
+    DomainRootInfo resolveDomainRoot(final String domain, final DomainType expectedType) {
         String segment = DnsUtils.normalize(domain);
         String result = null;
         while (segment != null) {
@@ -144,14 +163,11 @@ public final class PublicSuffixMatcher {
             final String key = IDN.toUnicode(segment);
             final DomainType exceptionRule = findEntry(exceptions, key);
             if (match(exceptionRule, expectedType)) {
-                return segment;
+                return new DomainRootInfo(segment, key, exceptionRule);
             }
             final DomainType domainRule = findEntry(rules, key);
             if (match(domainRule, expectedType)) {
-                // Prior to version 5.4 the result for "private" rules was different. However, the
-                // PSL algorithm doesn't have any rules changing the result based on "domain type"
-                // see https://github.com/publicsuffix/list/wiki/Format#formal-algorithm
-                return result;
+                return new DomainRootInfo(result, key, domainRule);
             }
 
             final int nextdot = segment.indexOf('.');
@@ -161,7 +177,7 @@ public final class PublicSuffixMatcher {
             final String wildcardKey = (nextSegment == null) ? "*" : "*." + IDN.toUnicode(nextSegment);
             final DomainType wildcardDomainRule = findEntry(rules, wildcardKey);
             if (match(wildcardDomainRule, expectedType)) {
-                return result;
+                return new DomainRootInfo(result, wildcardKey, wildcardDomainRule);
             }
 
             // If we're out of segments, and we're not looking for a specific type of entry,
@@ -169,7 +185,7 @@ public final class PublicSuffixMatcher {
             // This wildcard rule means any final segment in a domain is a public suffix,
             // so the current `result` is the desired public suffix plus 1
             if (nextSegment == null && (expectedType == null || expectedType == DomainType.UNKNOWN)) {
-                return result;
+                return new DomainRootInfo(result, null, null);
             }
 
             result = segment;
@@ -178,7 +194,7 @@ public final class PublicSuffixMatcher {
 
         // If no expectations then this result is good.
         if (expectedType == null || expectedType == DomainType.UNKNOWN) {
-            return result;
+            return new DomainRootInfo(result, null, null);
         }
 
         // If we did have expectations apparently there was no match
@@ -208,6 +224,40 @@ public final class PublicSuffixMatcher {
         final String domainRoot = getDomainRoot(
                 domain.startsWith(".") ? domain.substring(1) : domain, expectedType);
         return domainRoot == null;
+    }
+
+    /**
+     * Verifies if the given domain does not represent a public domain root and is
+     * allowed to set cookies, have an identity represented by a certificate, etc.
+     * <p>
+     * This method tolerates a leading dot in the domain name, for example '.example.com'
+     * which will be automatically stripped.
+     * </p>
+     */
+     @Internal
+     public boolean verify(final String domain) {
+         if (domain == null) {
+             return false;
+         }
+         return verifyStrict(domain.startsWith(".") ? domain.substring(1) : domain);
+     }
+
+    /**
+     * Verifies if the given domain does not represent a public domain root and is
+     * allowed to set cookies, have an identity represented by a certificate, etc.
+     */
+    @Internal
+    public boolean verifyStrict(final String domain) {
+        Args.notNull(domain, "Domain");
+        if (domain.startsWith(".")) {
+            return false;
+        }
+        final DomainRootInfo domainRootInfo = resolveDomainRoot(domain, null);
+        if (domainRootInfo == null) {
+            return false;
+        }
+        return domainRootInfo.root != null ||
+                (domainRootInfo.domainType == DomainType.PRIVATE && domainRootInfo.matchingKey != null);
     }
 
 }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/DefaultHostnameVerifier.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/DefaultHostnameVerifier.java
@@ -44,7 +44,6 @@ import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
 import javax.security.auth.x500.X500Principal;
 
-import org.apache.hc.client5.http.psl.DomainType;
 import org.apache.hc.client5.http.psl.PublicSuffixMatcher;
 import org.apache.hc.client5.http.utils.DnsUtils;
 import org.apache.hc.core5.annotation.Contract;
@@ -227,7 +226,6 @@ public final class DefaultHostnameVerifier implements HttpClientHostnameVerifier
 
     private static boolean matchIdentity(final String host, final String identity,
                                          final PublicSuffixMatcher publicSuffixMatcher,
-                                         final DomainType domainType,
                                          final boolean strict) {
 
         final String normalizedIdentity;
@@ -240,7 +238,10 @@ public final class DefaultHostnameVerifier implements HttpClientHostnameVerifier
 
         // Public suffix check on the Unicode identity
         if (publicSuffixMatcher != null && host.contains(".")) {
-            if (publicSuffixMatcher.getDomainRoot(normalizedIdentity, domainType) == null) {
+            if (!publicSuffixMatcher.verifyStrict(normalizedIdentity)) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Public Suffix List verification failed for identity '{}'", identity);
+                }
                 return false;
             }
         }
@@ -278,32 +279,20 @@ public final class DefaultHostnameVerifier implements HttpClientHostnameVerifier
 
     static boolean matchIdentity(final String host, final String identity,
                                  final PublicSuffixMatcher publicSuffixMatcher) {
-        return matchIdentity(host, identity, publicSuffixMatcher, null, false);
+        return matchIdentity(host, identity, publicSuffixMatcher, false);
     }
 
     static boolean matchIdentity(final String host, final String identity) {
-        return matchIdentity(host, identity, null, null, false);
+        return matchIdentity(host, identity, null, false);
     }
 
     static boolean matchIdentityStrict(final String host, final String identity,
                                        final PublicSuffixMatcher publicSuffixMatcher) {
-        return matchIdentity(host, identity, publicSuffixMatcher, null, true);
+        return matchIdentity(host, identity, publicSuffixMatcher, true);
     }
 
     static boolean matchIdentityStrict(final String host, final String identity) {
-        return matchIdentity(host, identity, null, null, true);
-    }
-
-    static boolean matchIdentity(final String host, final String identity,
-                                 final PublicSuffixMatcher publicSuffixMatcher,
-                                 final DomainType domainType) {
-        return matchIdentity(host, identity, publicSuffixMatcher, domainType, false);
-    }
-
-    static boolean matchIdentityStrict(final String host, final String identity,
-                                       final PublicSuffixMatcher publicSuffixMatcher,
-                                       final DomainType domainType) {
-        return matchIdentity(host, identity, publicSuffixMatcher, domainType, true);
+        return matchIdentity(host, identity, null, true);
     }
 
     static String extractCN(final String subjectPrincipal) throws SSLException {

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/psl/TestPublicSuffixMatcher.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/psl/TestPublicSuffixMatcher.java
@@ -43,12 +43,6 @@ class TestPublicSuffixMatcher {
     private PublicSuffixMatcher matcher;
     private PublicSuffixMatcher pslMatcher;
 
-    /**
-     * Create a matcher using the public suffix list file provided by publicsuffix.org (Mozilla).
-     *
-     * This test uses a copy of https://publicsuffix.org/list/effective_tld_names.dat in
-     * src/main/resources/org/publicsuffix/list/effective_tld_names.dat
-     */
     @BeforeEach
     void setUp() throws Exception {
         final ClassLoader classLoader = getClass().getClassLoader();
@@ -58,6 +52,7 @@ class TestPublicSuffixMatcher {
             final List<PublicSuffixList> lists = PublicSuffixListParser.INSTANCE.parseByType(new InputStreamReader(in, StandardCharsets.UTF_8));
             matcher = new PublicSuffixMatcher(lists);
         }
+        // Create a matcher using the public suffix list file provided by publicsuffix.org (Mozilla).
         pslMatcher = PublicSuffixMatcherLoader.getDefault();
     }
 
@@ -87,6 +82,8 @@ class TestPublicSuffixMatcher {
         Assertions.assertEquals("example.xx", matcher.getDomainRoot("www.blah.blah.example.XX"));
         Assertions.assertEquals(null, matcher.getDomainRoot("appspot.com"));
         Assertions.assertEquals("example.appspot.com", matcher.getDomainRoot("example.appspot.com"));
+        Assertions.assertEquals(null, matcher.getDomainRoot("s3.amazonaws.com"));
+        Assertions.assertEquals(null, matcher.getDomainRoot("blah.s3.amazonaws.com"));
         // Too short
         Assertions.assertNull(matcher.getDomainRoot("jp"));
         Assertions.assertNull(matcher.getDomainRoot("ac.jp"));
@@ -122,6 +119,8 @@ class TestPublicSuffixMatcher {
         Assertions.assertNull(matcher.getDomainRoot("garbage.garbage", DomainType.PRIVATE));
         Assertions.assertNull(matcher.getDomainRoot("*.garbage.garbage", DomainType.PRIVATE));
         Assertions.assertNull(matcher.getDomainRoot("*.garbage.garbage.garbage", DomainType.PRIVATE));
+        Assertions.assertNull(matcher.getDomainRoot("s3.amazonaws.com"));
+        Assertions.assertNull(matcher.getDomainRoot("blah.s3.amazonaws.com"));
     }
 
     @Test
@@ -144,6 +143,33 @@ class TestPublicSuffixMatcher {
         Assertions.assertNull(matcher.getDomainRoot("garbage.garbage", DomainType.ICANN));
         Assertions.assertNull(matcher.getDomainRoot("*.garbage.garbage", DomainType.ICANN));
         Assertions.assertNull(matcher.getDomainRoot("*.garbage.garbage.garbage", DomainType.ICANN));
+    }
+
+    @Test
+    void testMaySetCookies() {
+        Assertions.assertTrue(matcher.verify("foo.com"));
+
+        Assertions.assertFalse(matcher.verify("bar.foo.com"));
+        Assertions.assertTrue(matcher.verify("example.bar.foo.com"));
+
+        Assertions.assertTrue(matcher.verify("foo.bar.jp"));
+        Assertions.assertFalse(matcher.verify("bar.jp"));
+
+        Assertions.assertTrue(matcher.verify("foo.bar.hokkaido.jp"));
+        Assertions.assertFalse(matcher.verify("bar.hokkaido.jp"));
+
+        Assertions.assertTrue(matcher.verify("foo.bar.tokyo.jp"));
+        Assertions.assertFalse(matcher.verify("bar.tokyo.jp"));
+
+        Assertions.assertTrue(matcher.verify("pref.hokkaido.jp")); // exception from a wildcard rule
+        Assertions.assertTrue(matcher.verify("metro.tokyo.jp")); // exception from a wildcard rule
+    }
+
+    @Test
+    void testVerifyPrivate() {
+        Assertions.assertTrue(matcher.verify("s3.amazonaws.com"));
+        Assertions.assertTrue(matcher.verify("blah.s3.amazonaws.com"));
+        Assertions.assertTrue(matcher.verify("blah.xxx.uk"));
     }
 
     @Test

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/ssl/TestDefaultHostnameVerifier.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/ssl/TestDefaultHostnameVerifier.java
@@ -40,7 +40,6 @@ import java.util.List;
 
 import javax.net.ssl.SSLException;
 
-import org.apache.hc.client5.http.psl.DomainType;
 import org.apache.hc.client5.http.psl.PublicSuffixList;
 import org.apache.hc.client5.http.psl.PublicSuffixListParser;
 import org.apache.hc.client5.http.psl.PublicSuffixMatcher;
@@ -273,11 +272,11 @@ class TestDefaultHostnameVerifier {
         Assertions.assertTrue(DefaultHostnameVerifier.matchIdentity("a.b.xxx.uk", "*.b.xxx.uk", publicSuffixMatcher));
         Assertions.assertTrue(DefaultHostnameVerifier.matchIdentityStrict("a.b.xxx.uk", "*.b.xxx.uk", publicSuffixMatcher));
 
-        Assertions.assertFalse(DefaultHostnameVerifier.matchIdentity("b.xxx.uk", "b.xxx.uk", publicSuffixMatcher));
-        Assertions.assertFalse(DefaultHostnameVerifier.matchIdentityStrict("b.xxx.uk", "b.xxx.uk", publicSuffixMatcher));
+        Assertions.assertTrue(DefaultHostnameVerifier.matchIdentity("b.xxx.uk", "b.xxx.uk", publicSuffixMatcher));
+        Assertions.assertTrue(DefaultHostnameVerifier.matchIdentityStrict("b.xxx.uk", "b.xxx.uk", publicSuffixMatcher));
 
-        Assertions.assertFalse(DefaultHostnameVerifier.matchIdentity("b.xxx.uk", "*.xxx.uk", publicSuffixMatcher));
-        Assertions.assertFalse(DefaultHostnameVerifier.matchIdentityStrict("b.xxx.uk", "*.xxx.uk", publicSuffixMatcher));
+        Assertions.assertTrue(DefaultHostnameVerifier.matchIdentity("b.xxx.uk", "*.xxx.uk", publicSuffixMatcher));
+        Assertions.assertTrue(DefaultHostnameVerifier.matchIdentityStrict("b.xxx.uk", "*.xxx.uk", publicSuffixMatcher));
     }
 
     @Test
@@ -296,7 +295,7 @@ class TestDefaultHostnameVerifier {
     }
 
     @Test
-    void testHTTPCLIENT_1997_ANY() { // Only True on all domains
+    void testHTTPCLIENT_1997() {
         String domain;
         // Unknown
         domain = "dev.b.cloud.a";
@@ -318,63 +317,6 @@ class TestDefaultHostnameVerifier {
         Assertions.assertTrue(DefaultHostnameVerifier.matchIdentityStrict(  "service.apps." + domain, "*.apps." + domain));
         Assertions.assertTrue(DefaultHostnameVerifier.matchIdentity(        "service.apps." + domain, "*.apps." + domain, publicSuffixMatcher));
         Assertions.assertTrue(DefaultHostnameVerifier.matchIdentityStrict(  "service.apps." + domain, "*.apps." + domain, publicSuffixMatcher));
-    }
-
-    @Test
-    void testHTTPCLIENT_1997_ICANN() { // Only True on ICANN domains
-        String domain;
-        // Unknown
-        domain = "dev.b.cloud.a";
-        Assertions.assertFalse(DefaultHostnameVerifier.matchIdentity(        "service.apps." + domain, "*.apps." + domain, publicSuffixMatcher, DomainType.ICANN));
-        Assertions.assertFalse(DefaultHostnameVerifier.matchIdentityStrict(  "service.apps." + domain, "*.apps." + domain, publicSuffixMatcher, DomainType.ICANN));
-
-        // ICANN
-        domain = "dev.b.cloud.com";
-        Assertions.assertTrue(DefaultHostnameVerifier.matchIdentity(        "service.apps." + domain, "*.apps." + domain, publicSuffixMatcher, DomainType.ICANN));
-        Assertions.assertTrue(DefaultHostnameVerifier.matchIdentityStrict(  "service.apps." + domain, "*.apps." + domain, publicSuffixMatcher, DomainType.ICANN));
-
-        // PRIVATE
-        domain = "dev.b.cloud.lan";
-        Assertions.assertFalse(DefaultHostnameVerifier.matchIdentity(        "service.apps." + domain, "*.apps." + domain, publicSuffixMatcher, DomainType.ICANN));
-        Assertions.assertFalse(DefaultHostnameVerifier.matchIdentityStrict(  "service.apps." + domain, "*.apps." + domain, publicSuffixMatcher, DomainType.ICANN));
-    }
-
-    @Test
-    void testHTTPCLIENT_1997_PRIVATE() { // Only True on PRIVATE domains
-        String domain;
-        // Unknown
-        domain = "dev.b.cloud.a";
-        Assertions.assertFalse(DefaultHostnameVerifier.matchIdentity(        "service.apps." + domain, "*.apps." + domain, publicSuffixMatcher, DomainType.PRIVATE));
-        Assertions.assertFalse(DefaultHostnameVerifier.matchIdentityStrict(  "service.apps." + domain, "*.apps." + domain, publicSuffixMatcher, DomainType.PRIVATE));
-
-        // ICANN
-        domain = "dev.b.cloud.com";
-        Assertions.assertFalse(DefaultHostnameVerifier.matchIdentity(        "service.apps." + domain, "*.apps." + domain, publicSuffixMatcher, DomainType.PRIVATE));
-        Assertions.assertFalse(DefaultHostnameVerifier.matchIdentityStrict(  "service.apps." + domain, "*.apps." + domain, publicSuffixMatcher, DomainType.PRIVATE));
-
-        // PRIVATE
-        domain = "dev.b.cloud.lan";
-        Assertions.assertTrue(DefaultHostnameVerifier.matchIdentity(        "service.apps." + domain, "*.apps." + domain, publicSuffixMatcher, DomainType.PRIVATE));
-        Assertions.assertTrue(DefaultHostnameVerifier.matchIdentityStrict(  "service.apps." + domain, "*.apps." + domain, publicSuffixMatcher, DomainType.PRIVATE));
-    }
-
-    @Test
-    void testHTTPCLIENT_1997_UNKNOWN() { // Only True on all domains (same as ANY)
-        String domain;
-        // Unknown
-        domain = "dev.b.cloud.a";
-        Assertions.assertTrue(DefaultHostnameVerifier.matchIdentity(        "service.apps." + domain, "*.apps." + domain, publicSuffixMatcher, DomainType.UNKNOWN));
-        Assertions.assertTrue(DefaultHostnameVerifier.matchIdentityStrict(  "service.apps." + domain, "*.apps." + domain, publicSuffixMatcher, DomainType.UNKNOWN));
-
-        // ICANN
-        domain = "dev.b.cloud.com";
-        Assertions.assertTrue(DefaultHostnameVerifier.matchIdentity(        "service.apps." + domain, "*.apps." + domain, publicSuffixMatcher, DomainType.UNKNOWN));
-        Assertions.assertTrue(DefaultHostnameVerifier.matchIdentityStrict(  "service.apps." + domain, "*.apps." + domain, publicSuffixMatcher, DomainType.UNKNOWN));
-
-        // PRIVATE
-        domain = "dev.b.cloud.lan";
-        Assertions.assertTrue(DefaultHostnameVerifier.matchIdentity(        "service.apps." + domain, "*.apps." + domain, publicSuffixMatcher, DomainType.UNKNOWN));
-        Assertions.assertTrue(DefaultHostnameVerifier.matchIdentityStrict(  "service.apps." + domain, "*.apps." + domain, publicSuffixMatcher, DomainType.UNKNOWN));
     }
 
     @Test // Check compressed IPv6 hostname matching
@@ -461,14 +403,13 @@ class TestDefaultHostnameVerifier {
                 publicSuffixMatcher);
         Assertions.assertThrows(SSLException.class, () ->
             DefaultHostnameVerifier.matchDNSName(
-                    "ec2.compute-1.amazonaws.com",
-                    Collections.singletonList(SubjectName.DNS("ec2.compute-1.amazonaws.com")),
+                    "compute-1.amazonaws.com",
+                    Collections.singletonList(SubjectName.DNS("*.compute-1.amazonaws.com")),
                     publicSuffixMatcher));
-        Assertions.assertThrows(SSLException.class, () ->
-                DefaultHostnameVerifier.matchDNSName(
-                        "ec2.compute-1.amazonaws.com",
-                        Collections.singletonList(SubjectName.DNS("*.compute-1.amazonaws.com")),
-                        publicSuffixMatcher));
+        DefaultHostnameVerifier.matchDNSName(
+                "ec2.compute-1.amazonaws.com",
+                Collections.singletonList(SubjectName.DNS("*.compute-1.amazonaws.com")),
+                publicSuffixMatcher);
     }
 
     @Test

--- a/httpclient5/src/test/resources/suffixlistmatcher.txt
+++ b/httpclient5/src/test/resources/suffixlistmatcher.txt
@@ -27,6 +27,8 @@
 xx
 lan
 appspot.com
+s3.amazonaws.com
+*.s3.amazonaws.com
 s3.eu-central-1.amazonaws.com
 *.compute.amazonaws.com
 *.compute-1.amazonaws.com
@@ -38,15 +40,18 @@ us-east-1.amazonaws.com
 
 // ===BEGIN ICANN DOMAINS===
 
-jp
-*.jp
-*.tokyo.jp
-!metro.tokyo.jp
-
 com
+*.foo.com
+*.jp
+*.hokkaido.jp
+*.tokyo.jp
+!pref.hokkaido.jp
+!metro.tokyo.jp
+// Hosts in .hokkaido.jp can't set cookies below level 4...
+// ...except hosts in pref.hokkaido.jp, which can set cookies at level 3.
+
 co.jp
 gov.uk
-*.foo.com
 
 // unicode
 no


### PR DESCRIPTION
What a bloody mess has been done to `PublicSuffixMatcher` in 5.4!

This change-set corrects the immediate problem with handling of the private domains.

@arturobernalg  Please double-check.