### PR TITLE
DNS host / identity normalization should be performed only once per public API call

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/utils/DnsUtils.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/utils/DnsUtils.java
@@ -27,6 +27,8 @@
 
 package org.apache.hc.client5.http.utils;
 
+import java.net.IDN;
+
 /**
  * A collection of utilities relating to Domain Name System.
  *
@@ -70,6 +72,23 @@ public class DnsUtils {
             return buf.toString();
         }
         return s;
+    }
+
+    /**
+     * Decodes to Unicode and normalizes the given DNS name.
+     * @since 5.5
+     */
+    public static String normalizeUnicode(final String s) {
+        if (s == null) {
+            return null;
+        }
+        String decoded;
+        try {
+            decoded = IDN.toUnicode(s);
+        } catch (final IllegalArgumentException ignore) {
+            decoded = s;
+        }
+        return normalize(decoded);
     }
 
 }


### PR DESCRIPTION
Presently DNS normalization is performed inconsistently and often multiple times over the same input

This change-set 
1. Optimizes DNS normalization and ensures it is performed once per API call
2. Ensures DNS hames / identities always get represented in Unicode

@arturobernalg Please review.