### PR TITLE
Add Unix domain socket support

### DIFF
--- a/httpclient5-testing/pom.xml
+++ b/httpclient5-testing/pom.xml
@@ -78,6 +78,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.kohlschutter.junixsocket</groupId>
+      <artifactId>junixsocket-core</artifactId>
+      <scope>test</scope>
+      <type>pom</type>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>

--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/sync/StandardTestClientBuilder.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/sync/StandardTestClientBuilder.java
@@ -27,6 +27,7 @@
 
 package org.apache.hc.client5.testing.extension.sync;
 
+import java.nio.file.Path;
 import java.util.Collection;
 
 import org.apache.hc.client5.http.AuthenticationStrategy;
@@ -36,6 +37,7 @@ import org.apache.hc.client5.http.auth.AuthSchemeFactory;
 import org.apache.hc.client5.http.auth.CredentialsProvider;
 import org.apache.hc.client5.http.classic.ExecChainHandler;
 import org.apache.hc.client5.http.config.ConnectionConfig;
+import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
@@ -154,6 +156,14 @@ final class StandardTestClientBuilder implements TestClientBuilder {
     @Override
     public TestClientBuilder setDefaultCredentialsProvider(final CredentialsProvider credentialsProvider) {
         this.clientBuilder.setDefaultCredentialsProvider(credentialsProvider);
+        return this;
+    }
+
+    @Override
+    public TestClientBuilder setUnixDomainSocket(final Path unixDomainSocket) {
+        this.clientBuilder.setDefaultRequestConfig(RequestConfig.custom()
+                .setUnixDomainSocket(unixDomainSocket)
+                .build());
         return this;
     }
 

--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/sync/TestClientBuilder.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/sync/TestClientBuilder.java
@@ -27,6 +27,7 @@
 
 package org.apache.hc.client5.testing.extension.sync;
 
+import java.nio.file.Path;
 import java.util.Collection;
 
 import org.apache.hc.client5.http.AuthenticationStrategy;
@@ -100,6 +101,10 @@ public interface TestClientBuilder {
     }
 
     default TestClientBuilder setDefaultCredentialsProvider(CredentialsProvider credentialsProvider) {
+        throw new UnsupportedOperationException("Operation not supported by " + getProtocolLevel());
+    }
+
+    default TestClientBuilder setUnixDomainSocket(Path unixDomainSocket) {
         throw new UnsupportedOperationException("Operation not supported by " + getProtocolLevel());
     }
 

--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/sync/TestClientResources.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/sync/TestClientResources.java
@@ -50,6 +50,7 @@ public class TestClientResources implements AfterEachCallback {
 
     private TestServer server;
     private TestClient client;
+    private UnixDomainProxyServer udsProxy;
 
     public TestClientResources(final URIScheme scheme, final ClientProtocolLevel clientProtocolLevel, final Timeout timeout) {
         this.scheme = scheme != null ? scheme : URIScheme.HTTP;
@@ -74,6 +75,9 @@ public class TestClientResources implements AfterEachCallback {
         if (client != null) {
             client.close(CloseMode.GRACEFUL);
         }
+        if (udsProxy != null) {
+            udsProxy.close();
+        }
         if (server != null) {
             server.shutdown(CloseMode.IMMEDIATE);
         }
@@ -97,6 +101,15 @@ public class TestClientResources implements AfterEachCallback {
             server = serverBootstrap.build();
         }
         return server;
+    }
+
+    public UnixDomainProxyServer udsProxy() throws Exception {
+        if (udsProxy == null) {
+            final TestServer testServer = server();
+            final int port = testServer.getServerAddress().getPort();
+            udsProxy = new UnixDomainProxyServer(port);
+        }
+        return udsProxy;
     }
 
     public void configureClient(final Consumer<TestClientBuilder> clientCustomizer) {

--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/sync/TestServer.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/sync/TestServer.java
@@ -43,6 +43,7 @@ public class TestServer {
     private final Http1Config http1Config;
     private final HttpProcessor httpProcessor;
     private final Decorator<HttpServerRequestHandler> exchangeHandlerDecorator;
+    private volatile InetSocketAddress serverAddress;
 
     TestServer(
             final ClassicTestServer server,
@@ -64,7 +65,14 @@ public class TestServer {
         server.configure(exchangeHandlerDecorator);
         server.configure(httpProcessor);
         server.start();
-        return new InetSocketAddress(server.getInetAddress(), server.getPort());
+        serverAddress = new InetSocketAddress(server.getInetAddress(), server.getPort());
+        return serverAddress;
     }
 
+    public InetSocketAddress getServerAddress() {
+        if (serverAddress == null) {
+            throw new IllegalStateException("Server has not been started");
+        }
+        return serverAddress;
+    }
 }

--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/sync/UnixDomainProxyServer.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/sync/UnixDomainProxyServer.java
@@ -1,0 +1,137 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.hc.client5.testing.extension.sync;
+
+import org.newsclub.net.unix.AFUNIXServerSocket;
+import org.newsclub.net.unix.AFUNIXSocket;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.concurrent.CompletableFuture.supplyAsync;
+
+public final class UnixDomainProxyServer {
+    private final int port;
+    private final ExecutorService executorService;
+    private final Path socketPath;
+    private final CountDownLatch serverReady = new CountDownLatch(1);
+    private volatile AFUNIXServerSocket serverSocket;
+
+    public UnixDomainProxyServer(final int port) {
+        this.port = port;
+        this.executorService = Executors.newCachedThreadPool();
+        this.socketPath = (new File("proxy.sock")).toPath();
+    }
+
+    public void start() {
+        executorService.submit(this::runUdsProxy);
+        try {
+            serverReady.await();
+        } catch (final InterruptedException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    public Path getSocketPath() {
+        return socketPath;
+    }
+
+    public void close() {
+        try {
+            serverSocket.close();
+            executorService.shutdownNow();
+            if (!executorService.awaitTermination(5, TimeUnit.SECONDS)) {
+                throw new RuntimeException("Failed to shut down");
+            }
+            Files.deleteIfExists(socketPath);
+        } catch (final InterruptedException | IOException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    private void runUdsProxy() {
+        try {
+            Files.deleteIfExists(socketPath);
+        } catch (final IOException ignore) {
+        }
+
+        try {
+            try (final AFUNIXServerSocket server = AFUNIXServerSocket.bindOn(socketPath, true)) {
+                this.serverSocket = server;
+                serverReady.countDown();
+                serveRequests(server);
+            } catch (final Throwable ignore) {
+            }
+        } catch (final Throwable t) {
+            serverReady.countDown();
+            throw t;
+        }
+    }
+
+    private void serveRequests(final AFUNIXServerSocket server) throws IOException {
+        while (true) {
+            final AFUNIXSocket udsClient = server.accept();
+            final Socket tcpSocket = new Socket("localhost", port);
+            final CompletableFuture<Void> f1 = supplyAsync(() -> pipe(udsClient, tcpSocket), executorService);
+            final CompletableFuture<Void> f2 = supplyAsync(() -> pipe(tcpSocket, udsClient), executorService);
+            CompletableFuture.allOf(f1, f2).whenComplete((result, ex) -> {
+                try {
+                    udsClient.close();
+                    tcpSocket.close();
+                } catch (final IOException ignore) {
+                }
+            });
+        }
+    }
+
+    private Void pipe(final Socket inputSocket, final Socket outputSocket) {
+        try (
+            final InputStream in = inputSocket.getInputStream();
+            final OutputStream out = outputSocket.getOutputStream()
+        ) {
+            final byte[] buf = new byte[8192];
+            int len;
+            while ((len = in.read(buf)) != -1) {
+                out.write(buf, 0, len);
+                out.flush();
+            }
+        } catch (final IOException ignore) {
+        }
+        return null;
+    }
+}

--- a/httpclient5/pom.xml
+++ b/httpclient5/pom.xml
@@ -83,6 +83,12 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>com.kohlschutter.junixsocket</groupId>
+      <artifactId>junixsocket-core</artifactId>
+      <scope>test</scope>
+      <type>pom</type>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/RouteInfo.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/RouteInfo.java
@@ -28,6 +28,7 @@
 package org.apache.hc.client5.http;
 
 import java.net.InetAddress;
+import java.nio.file.Path;
 
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.net.NamedEndpoint;
@@ -88,6 +89,15 @@ public interface RouteInfo {
      *          or {@code null}
      */
     InetAddress getLocalAddress();
+
+    /**
+     * Obtains the Unix domain socket through which to connect to the target host.
+     *
+     * @return  the path to the Unix domain socket, or {@code null} if none
+     */
+    default Path getUnixDomainSocket() {
+        return null;
+    }
 
     /**
      * Obtains the number of hops in this route.

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/config/RequestConfig.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/config/RequestConfig.java
@@ -27,6 +27,7 @@
 
 package org.apache.hc.client5.http.config;
 
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 
@@ -63,13 +64,14 @@ public class RequestConfig implements Cloneable {
     private final boolean contentCompressionEnabled;
     private final boolean hardCancellationEnabled;
     private final boolean protocolUpgradeEnabled;
+    private final Path unixDomainSocket;
 
     /**
      * Intended for CDI compatibility
     */
     protected RequestConfig() {
         this(false, null, null, false, false, 0, false, null, null,
-                DEFAULT_CONNECTION_REQUEST_TIMEOUT, null, null, DEFAULT_CONN_KEEP_ALIVE, false, false, false);
+                DEFAULT_CONNECTION_REQUEST_TIMEOUT, null, null, DEFAULT_CONN_KEEP_ALIVE, false, false, false, null);
     }
 
     RequestConfig(
@@ -88,7 +90,8 @@ public class RequestConfig implements Cloneable {
             final TimeValue connectionKeepAlive,
             final boolean contentCompressionEnabled,
             final boolean hardCancellationEnabled,
-            final boolean protocolUpgradeEnabled) {
+            final boolean protocolUpgradeEnabled,
+            final Path unixDomainSocket) {
         super();
         this.expectContinueEnabled = expectContinueEnabled;
         this.proxy = proxy;
@@ -106,6 +109,7 @@ public class RequestConfig implements Cloneable {
         this.contentCompressionEnabled = contentCompressionEnabled;
         this.hardCancellationEnabled = hardCancellationEnabled;
         this.protocolUpgradeEnabled = protocolUpgradeEnabled;
+        this.unixDomainSocket = unixDomainSocket;
     }
 
     /**
@@ -227,6 +231,13 @@ public class RequestConfig implements Cloneable {
         return protocolUpgradeEnabled;
     }
 
+    /**
+     * @see Builder#setUnixDomainSocket(Path)
+     */
+    public Path getUnixDomainSocket() {
+        return unixDomainSocket;
+    }
+
     @Override
     protected RequestConfig clone() throws CloneNotSupportedException {
         return (RequestConfig) super.clone();
@@ -252,6 +263,7 @@ public class RequestConfig implements Cloneable {
         builder.append(", contentCompressionEnabled=").append(contentCompressionEnabled);
         builder.append(", hardCancellationEnabled=").append(hardCancellationEnabled);
         builder.append(", protocolUpgradeEnabled=").append(protocolUpgradeEnabled);
+        builder.append(", unixDomainSocket=").append(unixDomainSocket);
         builder.append("]");
         return builder.toString();
     }
@@ -277,7 +289,8 @@ public class RequestConfig implements Cloneable {
             .setConnectionKeepAlive(config.getConnectionKeepAlive())
             .setContentCompressionEnabled(config.isContentCompressionEnabled())
             .setHardCancellationEnabled(config.isHardCancellationEnabled())
-            .setProtocolUpgradeEnabled(config.isProtocolUpgradeEnabled());
+            .setProtocolUpgradeEnabled(config.isProtocolUpgradeEnabled())
+            .setUnixDomainSocket(config.getUnixDomainSocket());
     }
 
     public static class Builder {
@@ -298,6 +311,7 @@ public class RequestConfig implements Cloneable {
         private boolean contentCompressionEnabled;
         private boolean hardCancellationEnabled;
         private boolean protocolUpgradeEnabled;
+        private Path unixDomainSocket;
 
         Builder() {
             super();
@@ -629,6 +643,25 @@ public class RequestConfig implements Cloneable {
             return this;
         }
 
+        /**
+         * Sets the Unix Domain Socket path to use for the connection.
+         * <p>
+         * When set, the connection will use the specified Unix Domain Socket
+         * instead of a TCP socket. This is useful for communicating with local
+         * services like Docker or systemd.
+         * </p>
+         * <p>
+         * Default: {@code null}
+         * </p>
+         *
+         * @return this instance.
+         * @since 5.6
+         */
+        public Builder setUnixDomainSocket(final Path unixDomainSocket) {
+            this.unixDomainSocket = unixDomainSocket;
+            return this;
+        }
+
         public RequestConfig build() {
             return new RequestConfig(
                     expectContinueEnabled,
@@ -646,7 +679,8 @@ public class RequestConfig implements Cloneable {
                     connectionKeepAlive != null ? connectionKeepAlive : DEFAULT_CONN_KEEP_ALIVE,
                     contentCompressionEnabled,
                     hardCancellationEnabled,
-                    protocolUpgradeEnabled);
+                    protocolUpgradeEnabled,
+                    unixDomainSocket);
         }
 
     }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java
@@ -27,6 +27,7 @@
 package org.apache.hc.client5.http.impl.io;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -479,6 +480,7 @@ public class PoolingHttpClientConnectionManager
             poolEntry.assignConnection(connFactory.createConnection(null));
         }
         final HttpRoute route = poolEntry.getRoute();
+        final Path unixDomainSocket = route.getUnixDomainSocket();
         final HttpHost firstHop = route.getProxyHost() != null ? route.getProxyHost() : route.getTargetHost();
         final SocketConfig socketConfig = resolveSocketConfig(route);
         final ConnectionConfig connectionConfig = resolveConnectionConfig(route);
@@ -491,6 +493,7 @@ public class PoolingHttpClientConnectionManager
                 conn,
                 firstHop,
                 route.getTargetName(),
+                unixDomainSocket,
                 route.getLocalSocketAddress(),
                 connectTimeout,
                 socketConfig,

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/DefaultAsyncClientConnectionOperator.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/DefaultAsyncClientConnectionOperator.java
@@ -27,9 +27,11 @@
 
 package org.apache.hc.client5.http.impl.nio;
 
+import java.lang.reflect.Method;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.nio.file.Path;
 import java.util.concurrent.Future;
 
 import org.apache.hc.client5.http.DnsResolver;
@@ -92,8 +94,23 @@ public class DefaultAsyncClientConnectionOperator implements AsyncClientConnecti
 
     @Override
     public Future<ManagedAsyncClientConnection> connect(
+        final ConnectionInitiator connectionInitiator,
+        final HttpHost endpointHost,
+        final NamedEndpoint endpointName,
+        final SocketAddress localAddress,
+        final Timeout connectTimeout,
+        final Object attachment,
+        final HttpContext context,
+        final FutureCallback<ManagedAsyncClientConnection> callback) {
+        return connect(connectionInitiator, endpointHost, null, endpointName, localAddress, connectTimeout, attachment,
+            context, callback);
+    }
+
+    @Override
+    public Future<ManagedAsyncClientConnection> connect(
             final ConnectionInitiator connectionInitiator,
             final HttpHost endpointHost,
+            final Path unixDomainSocket,
             final NamedEndpoint endpointName,
             final SocketAddress localAddress,
             final Timeout connectTimeout,
@@ -104,7 +121,14 @@ public class DefaultAsyncClientConnectionOperator implements AsyncClientConnecti
         Args.notNull(endpointHost, "Host");
         final ComplexFuture<ManagedAsyncClientConnection> future = new ComplexFuture<>(callback);
         final HttpHost remoteEndpoint = RoutingSupport.normalize(endpointHost, schemePortResolver);
-        final InetAddress remoteAddress = endpointHost.getAddress();
+        final SocketAddress remoteAddress;
+        if (unixDomainSocket == null) {
+            final InetAddress remoteInetAddress = endpointHost.getAddress();
+            remoteAddress = remoteInetAddress != null ?
+                new InetSocketAddress(remoteInetAddress, remoteEndpoint.getPort()) : null;
+        } else {
+            remoteAddress = createUnixSocketAddress(unixDomainSocket);
+        }
         final TlsConfig tlsConfig = attachment instanceof TlsConfig ? (TlsConfig) attachment : TlsConfig.DEFAULT;
 
         onBeforeSocketConnect(context, endpointHost);
@@ -115,7 +139,7 @@ public class DefaultAsyncClientConnectionOperator implements AsyncClientConnecti
         final Future<IOSession> sessionFuture = sessionRequester.connect(
                 connectionInitiator,
                 remoteEndpoint,
-                remoteAddress != null ? new InetSocketAddress(remoteAddress, remoteEndpoint.getPort()) : null,
+                remoteAddress,
                 localAddress,
                 connectTimeout,
                 tlsConfig.getHttpVersionPolicy(),
@@ -178,6 +202,18 @@ public class DefaultAsyncClientConnectionOperator implements AsyncClientConnecti
                 });
         future.setDependency(sessionFuture);
         return future;
+    }
+
+    // The IOReactor does not support AFUNIXSocketChannel from JUnixSocket, so if a Unix domain socket was configured,
+    // we must use JEP 380 sockets and addresses.
+    private static SocketAddress createUnixSocketAddress(final Path socketPath) {
+        try {
+            final Class<?> addressClass = Class.forName("java.net.UnixDomainSocketAddress");
+            final Method ofMethod = addressClass.getMethod("of", Path.class);
+            return (SocketAddress) ofMethod.invoke(null, socketPath);
+        } catch (final ReflectiveOperationException ex) {
+            throw new UnsupportedOperationException("Async Unix domain socket support requires Java 16 or later", ex);
+        }
     }
 
     @Override

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java
@@ -27,6 +27,7 @@
 
 package org.apache.hc.client5.http.impl.nio;
 
+import java.nio.file.Path;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -446,6 +447,7 @@ public class PoolingAsyncClientConnectionManager implements AsyncClientConnectio
         }
         final PoolEntry<HttpRoute, ManagedAsyncClientConnection> poolEntry = internalEndpoint.getPoolEntry();
         final HttpRoute route = poolEntry.getRoute();
+        final Path unixDomainSocket = route.getUnixDomainSocket();
         final HttpHost firstHop = route.getProxyHost() != null ? route.getProxyHost() : route.getTargetHost();
         final ConnectionConfig connectionConfig = resolveConnectionConfig(route);
         final Timeout connectTimeout = timeout != null ? timeout : connectionConfig.getConnectTimeout();
@@ -456,6 +458,7 @@ public class PoolingAsyncClientConnectionManager implements AsyncClientConnectio
         final Future<ManagedAsyncClientConnection> connectFuture = connectionOperator.connect(
                 connectionInitiator,
                 firstHop,
+                unixDomainSocket,
                 route.getTargetName(),
                 route.getLocalSocketAddress(),
                 connectTimeout,

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/routing/DefaultRoutePlanner.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/routing/DefaultRoutePlanner.java
@@ -28,6 +28,7 @@
 package org.apache.hc.client5.http.impl.routing;
 
 import java.net.InetAddress;
+import java.nio.file.Path;
 import java.util.Objects;
 
 import org.apache.hc.client5.http.HttpRoute;
@@ -94,8 +95,17 @@ public class DefaultRoutePlanner implements HttpRoutePlanner {
         } else {
             authority = null;
         }
-        final InetAddress inetAddress = determineLocalAddress(target, context);
 
+        final Path unixDomainSocket = config.getUnixDomainSocket();
+        if (unixDomainSocket != null) {
+            if (proxy != null) {
+                throw new UnsupportedOperationException("Proxies are not supported over Unix domain sockets");
+            } else if (secure) {
+                throw new UnsupportedOperationException("HTTPS is not supported over Unix domain sockets");
+            }
+            return new HttpRoute(target, unixDomainSocket);
+        }
+        final InetAddress inetAddress = determineLocalAddress(target, context);
         if (proxy == null) {
             return new HttpRoute(target, authority, inetAddress, secure);
         }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/io/HttpClientConnectionOperator.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/io/HttpClientConnectionOperator.java
@@ -29,6 +29,7 @@ package org.apache.hc.client5.http.io;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.nio.file.Path;
 
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.Internal;
@@ -95,6 +96,38 @@ public interface HttpClientConnectionOperator {
     }
 
     /**
+     * Connect the given managed connection to the remote endpoint.
+     *
+     * @param conn the managed connection.
+     * @param endpointHost the address of the remote endpoint.
+     * @param unixDomainSocket the path to the Unix domain socket, or {@code null} if none.
+     * @param endpointName the name of the remote endpoint, if different from the endpoint host name,
+     *                   {@code null} otherwise. Usually taken from the request URU authority.
+     * @param localAddress the address of the local endpoint.
+     * @param connectTimeout the timeout of the connect operation.
+     * @param socketConfig the socket configuration.
+     * @param attachment connect request attachment.
+     * @param context the execution context.
+     *
+     * @since 5.6
+     */
+    default void connect(
+        ManagedHttpClientConnection conn,
+        HttpHost endpointHost,
+        NamedEndpoint endpointName,
+        Path unixDomainSocket,
+        InetSocketAddress localAddress,
+        Timeout connectTimeout,
+        SocketConfig socketConfig,
+        Object attachment,
+        HttpContext context) throws IOException {
+        if (unixDomainSocket != null) {
+            throw new UnsupportedOperationException(getClass().getName() + " does not support Unix domain sockets");
+        }
+        connect(conn, endpointHost, localAddress, connectTimeout, socketConfig, context);
+    }
+
+    /**
      * Upgrades transport security of the given managed connection
      * by using the TLS security protocol.
      *
@@ -128,5 +161,4 @@ public interface HttpClientConnectionOperator {
             HttpContext context) throws IOException {
         upgrade(conn, endpointHost, context);
     }
-
 }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/nio/AsyncClientConnectionOperator.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/nio/AsyncClientConnectionOperator.java
@@ -28,6 +28,7 @@
 package org.apache.hc.client5.http.nio;
 
 import java.net.SocketAddress;
+import java.nio.file.Path;
 import java.util.concurrent.Future;
 
 import org.apache.hc.core5.annotation.Contract;
@@ -94,6 +95,40 @@ public interface AsyncClientConnectionOperator {
             Object attachment,
             HttpContext context,
             FutureCallback<ManagedAsyncClientConnection> callback) {
+        return connect(connectionInitiator, endpointHost, localAddress, connectTimeout,
+            attachment, callback);
+    }
+
+    /**
+     * Initiates operation to create a connection to the remote endpoint using
+     * the provided {@link ConnectionInitiator}.
+     *
+     * @param connectionInitiator the connection initiator.
+     * @param endpointHost the address of the remote endpoint.
+     * @param unixDomainSocket the path to the UDS through which to connect, or {@code null}.
+     * @param endpointName the name of the remote endpoint, if different from the endpoint host name,
+     *                   {@code null} otherwise. Usually taken from the request URU authority.
+     * @param localAddress the address of the local endpoint.
+     * @param connectTimeout the timeout of the connect operation.
+     * @param attachment the attachment, which can be any object representing custom parameter
+     *                    of the operation.
+     * @param context the execution context.
+     * @param callback the future result callback.
+     * @since 5.6
+     */
+    default Future<ManagedAsyncClientConnection> connect(
+            ConnectionInitiator connectionInitiator,
+            HttpHost endpointHost,
+            Path unixDomainSocket,
+            NamedEndpoint endpointName,
+            SocketAddress localAddress,
+            Timeout connectTimeout,
+            Object attachment,
+            HttpContext context,
+            FutureCallback<ManagedAsyncClientConnection> callback) {
+        if (unixDomainSocket != null) {
+            throw new UnsupportedOperationException(getClass().getName() + " does not support Unix domain sockets");
+        }
         return connect(connectionInitiator, endpointHost, localAddress, connectTimeout,
             attachment, callback);
     }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/socket/UnixDomainSocketFactory.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/socket/UnixDomainSocketFactory.java
@@ -1,0 +1,179 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.hc.client5.http.socket;
+
+import org.apache.hc.core5.annotation.Contract;
+import org.apache.hc.core5.annotation.Internal;
+import org.apache.hc.core5.annotation.ThreadingBehavior;
+import org.apache.hc.core5.util.Args;
+import org.apache.hc.core5.util.TimeValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.nio.file.Path;
+
+/**
+ * A factory for Unix domain sockets.
+ * <p>
+ * This implementation supports both the JDK16+ standard library implementation (JEP 380) and the JUnixSocket library.
+ * It will automatically detect which implementation is available and use it. JUnixSocket is preferred, since it
+ * supports the {@link java.net.Socket} API used by the classic client.
+ * </p>
+ *
+ * @since 5.6
+ */
+@Contract(threading = ThreadingBehavior.STATELESS)
+@Internal
+public final class UnixDomainSocketFactory {
+    private static final Logger LOG = LoggerFactory.getLogger(UnixDomainSocketFactory.class);
+
+    private static final String JDK_UNIX_SOCKET_ADDRESS_CLASS = "java.net.UnixDomainSocketAddress";
+    private static final String JUNIXSOCKET_SOCKET_CLASS = "org.newsclub.net.unix.AFUNIXSocket";
+    private static final String JUNIXSOCKET_ADDRESS_CLASS = "org.newsclub.net.unix.AFUNIXSocketAddress";
+
+    private enum Implementation {
+        JDK,
+        JUNIXSOCKET,
+        NONE
+    }
+
+    private static final Implementation IMPLEMENTATION = detectImplementation();
+
+    private static Implementation detectImplementation() {
+        try {
+            Class.forName(JUNIXSOCKET_SOCKET_CLASS);
+            LOG.debug("Using JUnixSocket Unix Domain Socket implementation");
+            return Implementation.JUNIXSOCKET;
+        } catch (final ClassNotFoundException e) {
+            try {
+                Class.forName(JDK_UNIX_SOCKET_ADDRESS_CLASS);
+                LOG.debug("Using JDK Unix Domain Socket implementation");
+                return Implementation.JDK;
+            } catch (final ClassNotFoundException e2) {
+                LOG.debug("No Unix Domain Socket implementation found");
+                return Implementation.NONE;
+            }
+        }
+    }
+
+    /**
+     * Checks if Unix Domain Socket support is available.
+     *
+     * @return true if Unix Domain Socket support is available, false otherwise
+     */
+    public static boolean isAvailable() {
+        return IMPLEMENTATION != Implementation.NONE;
+    }
+
+    /**
+     * Default instance of {@link UnixDomainSocketFactory}.
+     */
+    private static final UnixDomainSocketFactory INSTANCE = new UnixDomainSocketFactory();
+
+    /**
+     * Gets the singleton instance of {@link UnixDomainSocketFactory}.
+     *
+     * @return the singleton instance
+     */
+    public static UnixDomainSocketFactory getSocketFactory() {
+        return INSTANCE;
+    }
+
+    public SocketAddress createSocketAddress(final Path socketPath) {
+        if (!isAvailable()) {
+            throw new UnsupportedOperationException("Unix Domain Socket support is not available");
+        }
+        Args.notNull(socketPath, "Unix domain socket path");
+
+        try {
+            if (IMPLEMENTATION == Implementation.JDK) {
+                // JDK implementation
+                final Class<?> addressClass = Class.forName(JDK_UNIX_SOCKET_ADDRESS_CLASS);
+                final Method ofMethod = addressClass.getMethod("of", Path.class);
+                return (SocketAddress) ofMethod.invoke(null, socketPath);
+            } else {
+                // JUnixSocket implementation
+                final Class<?> addressClass = Class.forName(JUNIXSOCKET_ADDRESS_CLASS);
+                final Method ofMethod = addressClass.getMethod("of", Path.class);
+                return (SocketAddress) ofMethod.invoke(null, socketPath);
+            }
+        } catch (final ReflectiveOperationException ex) {
+            throw new RuntimeException("Could not create UDS SocketAddress", ex);
+        }
+    }
+
+    public Socket createSocket() throws IOException {
+        if (!isAvailable()) {
+            throw new UnsupportedOperationException("Unix Domain Socket support is not available");
+        }
+
+        try {
+            if (IMPLEMENTATION == Implementation.JDK) {
+                // Java 16+ only supports UDS through the SocketChannel API, but the sync client is coupled
+                // to the legacy Socket API. In order to use Java sockets, we first need to write an
+                // adapter, similar to the one provided by JUnixSocket.
+                throw new UnsupportedOperationException("JEP 380 Unix domain sockets are not supported; use "
+                        + "JUnixSocket");
+            } else {
+                // JUnixSocket implementation
+                final Class<?> socketClass = Class.forName(JUNIXSOCKET_SOCKET_CLASS);
+                final Method newInstanceMethod = socketClass.getMethod("newInstance");
+                return (Socket) newInstanceMethod.invoke(null);
+            }
+        } catch (final Exception e) {
+            throw new IOException("Failed to create Unix domain socket", e);
+        }
+    }
+
+    public Socket connectSocket(
+        final Socket socket,
+        final Path socketPath,
+        final TimeValue connectTimeout
+    ) throws IOException {
+        Args.notNull(socketPath, "Unix domain socket path");
+
+        final Socket sock = socket != null ? socket : createSocket();
+        final SocketAddress address = createSocketAddress(socketPath);
+        final int connTimeoutMs = TimeValue.isPositive(connectTimeout) ? connectTimeout.toMillisecondsIntBound() : 0;
+
+        try {
+            sock.connect(address, connTimeoutMs);
+            return sock;
+        } catch (final IOException ex) {
+            try {
+                sock.close();
+            } catch (final IOException ignore) {
+            }
+            throw ex;
+        }
+    }
+}

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/examples/UnixDomainSocket.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/examples/UnixDomainSocket.java
@@ -1,0 +1,75 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.client5.http.examples;
+
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.nio.file.Path;
+
+public class UnixDomainSocket {
+    public static void main(final String[] args) throws IOException {
+        if (args.length == 0 || "-h".equals(args[0]) || "--help".equals(args[0])) {
+            usage(System.out);
+            return;
+        } else if (args.length != 2) {
+            usage(System.err);
+            return;
+        }
+
+        final Path unixDomainSocket = new File(args[0]).toPath();
+        final String uri = args[1];
+
+        try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
+            final HttpGet httpGet = new HttpGet(uri);
+            httpGet.setConfig(RequestConfig.custom().setUnixDomainSocket(unixDomainSocket).build());
+            client.execute(httpGet, classicHttpResponse -> {
+                final InputStream inputStream = classicHttpResponse.getEntity().getContent();
+                final byte[] buf = new byte[8192];
+                int len;
+                while ((len = inputStream.read(buf)) > 0) {
+                    System.out.write(buf, 0, len);
+                }
+                return null;
+            });
+        }
+    }
+
+    private static void usage(final PrintStream printStream) {
+        printStream.println("Usage: UnixDomainSocket [path] [uri]");
+        printStream.println();
+        printStream.println("Examples:");
+        printStream.println("UnixDomainSocket /var/run/docker.sock 'http://localhost/info'");
+        printStream.println("UnixDomainSocket /var/run/docker.sock 'http://localhost/containers/json?all=1'");
+    }
+}

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/examples/UnixDomainSocketAsync.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/examples/UnixDomainSocketAsync.java
@@ -1,0 +1,93 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.client5.http.examples;
+
+import io.reactivex.Observable;
+import org.apache.hc.client5.http.async.methods.SimpleHttpRequest;
+import org.apache.hc.client5.http.async.methods.SimpleRequestProducer;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.client5.http.impl.async.HttpAsyncClientBuilder;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.Message;
+import org.apache.hc.core5.http.Method;
+import org.apache.hc.core5.reactive.ReactiveResponseConsumer;
+import org.reactivestreams.Publisher;
+
+import java.io.File;
+import java.io.PrintStream;
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+public class UnixDomainSocketAsync {
+    public static void main(final String[] args) throws Exception {
+        if (args.length == 0 || "-h".equals(args[0]) || "--help".equals(args[0])) {
+            usage(System.out);
+            return;
+        } else if (args.length != 2) {
+            usage(System.err);
+            return;
+        }
+
+        final Path unixDomainSocket = new File(args[0]).toPath();
+        final String uri = args[1];
+
+        final RequestConfig requestConfig = RequestConfig.custom().setUnixDomainSocket(unixDomainSocket).build();
+        try (CloseableHttpAsyncClient client = HttpAsyncClientBuilder.create()
+                .setDefaultRequestConfig(requestConfig)
+                .build()) {
+            client.start();
+
+            final SimpleHttpRequest httpGet = SimpleHttpRequest.create(Method.GET.name(), uri);
+            httpGet.setConfig(requestConfig);
+
+            final ReactiveResponseConsumer consumer = new ReactiveResponseConsumer();
+            client.execute(SimpleRequestProducer.create(httpGet), consumer, null).get(10, TimeUnit.SECONDS);
+            final Message<HttpResponse, Publisher<ByteBuffer>> message = consumer.getResponseFuture()
+                .get(10, TimeUnit.SECONDS);
+            final List<ByteBuffer> bufs = Observable.fromPublisher(message.getBody())
+                .collectInto(new ArrayList<ByteBuffer>(), List::add)
+                .blockingGet();
+            for (final ByteBuffer buf : bufs) {
+                final byte[] bytes = new byte[buf.remaining()];
+                buf.get(bytes);
+                System.out.write(bytes);
+            }
+        }
+    }
+
+    private static void usage(final PrintStream printStream) {
+        printStream.println("Usage: UnixDomainSocketAsync [path] [uri]");
+        printStream.println();
+        printStream.println("Examples:");
+        printStream.println("UnixDomainSocketAsync /var/run/docker.sock 'http://localhost/info'");
+        printStream.println("UnixDomainSocketAsync /var/run/docker.sock 'http://localhost/containers/json?all=1'");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
     <hc.stylecheck.version>1</hc.stylecheck.version>
     <rxjava.version>2.2.21</rxjava.version>
     <testcontainers.version>1.21.1</testcontainers.version>
+    <junixsocket.version>2.10.1</junixsocket.version>
     <api.comparison.version>5.3</api.comparison.version>
     <hc.animal-sniffer.signature.ignores>javax.net.ssl.SSLEngine,javax.net.ssl.SSLParameters,java.nio.ByteBuffer,java.nio.CharBuffer</hc.animal-sniffer.signature.ignores>
   </properties>
@@ -162,6 +163,12 @@
         <artifactId>rxjava</artifactId>
         <version>${rxjava.version}</version>
         <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.kohlschutter.junixsocket</groupId>
+        <artifactId>junixsocket-core</artifactId>
+        <version>${junixsocket.version}</version>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.junit</groupId>


### PR DESCRIPTION
This change adds Unix domain socket support. The sync client uses JUnixSocket, which provides synchronous UDS support through the legacy `java.net.Socket` API; the async client uses the JEP 380 implementation of UDS through the `java.nio.channels.SocketChannel` API (requires JDK16 or later).

Since the synchronous client is tightly coupled to the `Socket` API, we can't trivially use JEP 380 UDS support. We would first have to write an adapter to implement the `Socket` API, backed by a JEP 380 UDS `SocketChannel`. This would require us to implement features like socket option configuration, connection timeouts, and socket timeouts; we would also have to implement APIs like `getInetAddress()` which don't actually make sense in a UDS context. This is probably doable (JUnixSocket does it, albeit with a different implementation strategy based on native code), but it's not trivial.

The asynchronous client is the other way around: it supports JEP 380, but not JUnixSocket. The issue here is more subtle: JDK and JUnixDomain channels cannot be mixed in the same selector, and since JUnixDomain does not provide an implementation of TCP/IP channels, supporting JUnixSocket in the async client would require substantial rework in the IO reactor. Since JDK8 is end-of-life next year, I doubt this is worth doing unless we can find some clever way of integrating the new channel type with minimal churn.

Unix domain socket support is exposed through the `RequestConfig` API. A path to a Unix domain socket can be provided as a client-wide default through `setDefaultRequestConfig`, or on a per-request basis through `setConfig`. Currently, proxies and TLS are not supported through UDS. The former feature seems unnecessary, but the latter is likely worth adding at some point, since contacting an HTTPS endpoint over UDS (sometimes denoted by the URI scheme `https+unix`) is not unheard of.