### PR TITLE
Omit cookie spec registry when cookie management is disabled

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/H2AsyncClientBuilder.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/H2AsyncClientBuilder.java
@@ -901,7 +901,7 @@ public class H2AsyncClientBuilder {
                     .build();
         }
         Lookup<CookieSpecFactory> cookieSpecRegistryCopy = this.cookieSpecRegistry;
-        if (cookieSpecRegistryCopy == null) {
+        if (cookieSpecRegistryCopy == null && !cookieManagementDisabled) {
             cookieSpecRegistryCopy = CookieSpecSupport.createDefault();
         }
 

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncClientBuilder.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncClientBuilder.java
@@ -1118,7 +1118,7 @@ public class HttpAsyncClientBuilder {
                     .build();
         }
         Lookup<CookieSpecFactory> cookieSpecRegistryCopy = this.cookieSpecRegistry;
-        if (cookieSpecRegistryCopy == null) {
+        if (cookieSpecRegistryCopy == null && !cookieManagementDisabled) {
             cookieSpecRegistryCopy = CookieSpecSupport.createDefault();
         }
 

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/HttpClientBuilder.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/HttpClientBuilder.java
@@ -1066,7 +1066,7 @@ public class HttpClientBuilder {
                 .build();
         }
         Lookup<CookieSpecFactory> cookieSpecRegistryCopy = this.cookieSpecRegistry;
-        if (cookieSpecRegistryCopy == null) {
+        if (cookieSpecRegistryCopy == null && !this.cookieManagementDisabled) {
             cookieSpecRegistryCopy = CookieSpecSupport.createDefault();
         }
 

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/examples/PublicSuffixLoaderBenchmark.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/examples/PublicSuffixLoaderBenchmark.java
@@ -1,0 +1,57 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.hc.client5.http.examples;
+
+import org.apache.hc.client5.http.psl.PublicSuffixMatcherLoader;
+
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+public class PublicSuffixLoaderBenchmark {
+    public static void main(final String[] args) {
+        benchmarkGarbageCollection();
+        loadPublicSuffixList();
+        benchmarkGarbageCollection();
+    }
+
+    private static void loadPublicSuffixList() {
+        final long start = System.nanoTime();
+        System.out.print("Loading public suffix list...");
+        PublicSuffixMatcherLoader.getDefault();
+        final long end = System.nanoTime();
+        System.out.printf(" done (took %,d ms)%n", NANOSECONDS.toMillis(end - start));
+    }
+
+    private static void benchmarkGarbageCollection() {
+        for (int i = 0; i < 3; i++) {
+            final long start = System.nanoTime();
+            System.gc();
+            final long end = System.nanoTime();
+            System.out.printf("GC took %,d ms%n", NANOSECONDS.toMillis(end - start));
+        }
+    }
+}


### PR DESCRIPTION
The HTTP client builders always construct a client with a non-null cookie spec registry; if a custom instance is not specified, then the builders will use `CookieSpecSupport.createDefault()`, which loads the full public suffix list. The PSL rules are stored on the heap as a `ConcurrentHashMap`, i.e. a giant array (16,384 on my machine) containing map entries, each of which is also allocated as a separate object on the heap. This is a considerable number of live objects that the garbage collector may need to trace. I ran a simple microbenchmark to show the effects of loading the PSL on garbage collection (these numbers are from JDK 1.8):

    GC took 2 ms
    GC took 2 ms
    GC took 2 ms
    Loading public suffix list... done (took 193 ms)
    GC took 11 ms
    GC took 8 ms
    GC took 7 ms

This is potentially a significant amount of tail latency for use cases that don't require cookie management, such as RPC calls. With this change, it is now simpler to configure and construct a client that does not load the PSL into memory.