### PR TITLE
HttpsSupport: Omit public suffix matcher from default hostname verifier

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/HttpsSupport.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/HttpsSupport.java
@@ -32,7 +32,6 @@ import java.security.PrivilegedAction;
 
 import javax.net.ssl.HostnameVerifier;
 
-import org.apache.hc.client5.http.psl.PublicSuffixMatcherLoader;
 import org.apache.hc.core5.util.TextUtils;
 
 /**
@@ -62,7 +61,7 @@ public final class HttpsSupport {
     }
 
     public static HostnameVerifier getDefaultHostnameVerifier() {
-        return new DefaultHostnameVerifier(PublicSuffixMatcherLoader.getDefault());
+        return new DefaultHostnameVerifier();
     }
 
 }


### PR DESCRIPTION
The use of public suffix matching as part of hostname verification is nonstandard. I can't find anything in the TLS specifications that prescribe or even mention this behavior, having checked:

* RFC 8446: The Transport Layer Security (TLS) Protocol Version 1.3
* RFC 9110: HTTP Semantics
* RFC 9525: Service Identity in TLS

There are of course rules for wildcard matching, but ultimately the question of whether to trust a certificate for `*.com` is up to the CAs in your trust store. Given the oddity of the PSL matching behavior and the non-trivial runtime overhead of loading and querying the PSL, I think it makes more sense for the default `HostnameVerifier` to not use this behavior.