### PR TITLE
Add socket timeout integration tests

### DIFF
--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/TestAsyncSocketTimeout.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/TestAsyncSocketTimeout.java
@@ -1,0 +1,166 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.hc.client5.testing.async;
+
+import org.apache.hc.client5.http.async.methods.SimpleHttpRequest;
+import org.apache.hc.client5.http.config.ConnectionConfig;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManager;
+import org.apache.hc.client5.testing.extension.async.ClientProtocolLevel;
+import org.apache.hc.client5.testing.extension.async.ServerProtocolLevel;
+import org.apache.hc.client5.testing.extension.async.TestAsyncClient;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.Method;
+import org.apache.hc.core5.http.URIScheme;
+import org.apache.hc.core5.io.CloseMode;
+import org.apache.hc.core5.util.VersionInfo;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.net.SocketTimeoutException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static java.lang.String.format;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.apache.hc.core5.util.ReflectionUtils.determineJRELevel;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+abstract class AbstractTestSocketTimeout extends AbstractIntegrationTestBase {
+    protected AbstractTestSocketTimeout(final URIScheme scheme, final ClientProtocolLevel clientProtocolLevel,
+                                        final ServerProtocolLevel serverProtocolLevel, final boolean useUnixDomainSocket) {
+        super(scheme, clientProtocolLevel, serverProtocolLevel, useUnixDomainSocket);
+    }
+
+    @Timeout(5)
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "150,0,150,false",
+        "0,150,150,false",
+        "150,0,150,true",
+        "0,150,150,true",
+        // ResponseTimeout overrides socket timeout
+        "2000,150,150,false",
+        "2000,150,150,true"
+    })
+    void testReadTimeouts(final String param) throws Throwable {
+        checkAssumptions();
+        final String[] params = param.split(",");
+        final int connConfigTimeout = Integer.parseInt(params[0]);
+        final long responseTimeout = Integer.parseInt(params[1]);
+        final long expectedDelayMs = Long.parseLong(params[2]);
+        final boolean drip = Boolean.parseBoolean(params[3]);
+        configureServer(bootstrap -> bootstrap
+                .register("/random/*", AsyncRandomHandler::new));
+        final HttpHost target = startServer();
+
+        final TestAsyncClient client = startClient();
+        final PoolingAsyncClientConnectionManager connManager = client.getConnectionManager();
+        if (connConfigTimeout > 0) {
+            connManager.setDefaultConnectionConfig(ConnectionConfig.custom()
+                .setSocketTimeout(connConfigTimeout, MILLISECONDS)
+                .build());
+        }
+        final SimpleHttpRequest request = SimpleHttpRequest.create(Method.GET, target,
+            "/random/10240?delay=500&drip=" + (drip ? 1 : 0));
+        if (responseTimeout > 0) {
+            request.setConfig(RequestConfig.custom()
+                .setUnixDomainSocket(getUnixDomainSocket())
+                .setResponseTimeout(responseTimeout, MILLISECONDS).build());
+        }
+
+        final long startTime = System.nanoTime();
+        final Throwable cause = assertThrows(ExecutionException.class, () -> client.execute(request, null).get())
+            .getCause();
+        final long actualDelayMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime);
+
+        assertInstanceOf(SocketTimeoutException.class, cause);
+        assertTrue(actualDelayMs > expectedDelayMs / 2,
+            format("Socket read timed out too soon (only %,d out of %,d ms)", actualDelayMs, expectedDelayMs));
+        assertTrue(actualDelayMs < expectedDelayMs * 2,
+            format("Socket read timed out too late (%,d out of %,d ms)", actualDelayMs, expectedDelayMs));
+
+        closeClient(client);
+    }
+
+    void checkAssumptions() {
+    }
+
+    void closeClient(final TestAsyncClient client) {
+        client.close(CloseMode.GRACEFUL);
+    }
+}
+
+public class TestAsyncSocketTimeout {
+    @Nested
+    class Http extends AbstractTestSocketTimeout {
+        public Http() {
+            super(URIScheme.HTTP, ClientProtocolLevel.STANDARD, ServerProtocolLevel.STANDARD, false);
+        }
+    }
+
+    @Nested
+    class Https extends AbstractTestSocketTimeout {
+        public Https() {
+            super(URIScheme.HTTPS, ClientProtocolLevel.STANDARD, ServerProtocolLevel.STANDARD, false);
+        }
+    }
+
+    @Nested
+    class Uds extends AbstractTestSocketTimeout {
+        public Uds() {
+            super(URIScheme.HTTP, ClientProtocolLevel.STANDARD, ServerProtocolLevel.STANDARD, true);
+        }
+
+        @Override
+        void checkAssumptions() {
+            assumeTrue(determineJRELevel() >= 16, "Async UDS requires Java 16+");
+            final String[] components = VersionInfo
+                .loadVersionInfo("org.apache.hc.core5", getClass().getClassLoader())
+                .getRelease()
+                .split("[-.]");
+            final int majorVersion = Integer.parseInt(components[0]);
+            final int minorVersion = Integer.parseInt(components[1]);
+            assumeFalse(majorVersion <= 5 && minorVersion <= 3, "Async UDS requires HttpCore 5.4+");
+        }
+
+        @Override
+        void closeClient(final TestAsyncClient client) {
+            // TODO: Why does `CloseMode.GRACEFUL` (the test client default)
+            //  block until the IOReactor shutdown timeout when using UDS?
+            client.close(CloseMode.IMMEDIATE);
+        }
+    }
+}
+

--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/async/StandardTestClientBuilder.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/async/StandardTestClientBuilder.java
@@ -27,6 +27,7 @@
 
 package org.apache.hc.client5.testing.extension.async;
 
+import java.nio.file.Path;
 import java.util.Collection;
 
 import org.apache.hc.client5.http.AuthenticationStrategy;
@@ -35,6 +36,7 @@ import org.apache.hc.client5.http.UserTokenHandler;
 import org.apache.hc.client5.http.auth.AuthSchemeFactory;
 import org.apache.hc.client5.http.auth.CredentialsProvider;
 import org.apache.hc.client5.http.config.ConnectionConfig;
+import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.config.TlsConfig;
 import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
 import org.apache.hc.client5.http.impl.async.HttpAsyncClientBuilder;
@@ -50,6 +52,7 @@ import org.apache.hc.core5.http.config.Lookup;
 import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
 import org.apache.hc.core5.http2.config.H2Config;
 import org.apache.hc.core5.reactor.IOReactorConfig;
+import org.apache.hc.core5.util.TimeValue;
 import org.apache.hc.core5.util.Timeout;
 
 final class StandardTestClientBuilder implements TestAsyncClientBuilder {
@@ -167,6 +170,14 @@ final class StandardTestClientBuilder implements TestAsyncClientBuilder {
     }
 
     @Override
+    public TestAsyncClientBuilder setUnixDomainSocket(final Path unixDomainSocket) {
+        this.clientBuilder.setDefaultRequestConfig(RequestConfig.custom()
+            .setUnixDomainSocket(unixDomainSocket)
+            .build());
+        return this;
+    }
+
+    @Override
     public TestAsyncClient build() throws Exception {
         final PoolingAsyncClientConnectionManager connectionManager = connectionManagerBuilder
                 .setTlsStrategy(tlsStrategy != null ? tlsStrategy : new DefaultClientTlsStrategy(SSLTestContexts.createClientSSLContext()))
@@ -177,6 +188,7 @@ final class StandardTestClientBuilder implements TestAsyncClientBuilder {
                 .build();
         final CloseableHttpAsyncClient client = clientBuilder
                 .setIOReactorConfig(IOReactorConfig.custom()
+                        .setSelectInterval(TimeValue.ofMilliseconds(10))
                         .setSoTimeout(timeout)
                         .build())
                 .setConnectionManager(connectionManager)

--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/async/TestAsyncClientBuilder.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/async/TestAsyncClientBuilder.java
@@ -27,6 +27,7 @@
 
 package org.apache.hc.client5.testing.extension.async;
 
+import java.nio.file.Path;
 import java.util.Collection;
 
 import org.apache.hc.client5.http.AuthenticationStrategy;
@@ -107,6 +108,10 @@ public interface TestAsyncClientBuilder {
     }
 
     default TestAsyncClientBuilder setDefaultCredentialsProvider(CredentialsProvider credentialsProvider) {
+        throw new UnsupportedOperationException("Operation not supported by " + getProtocolLevel());
+    }
+
+    default TestAsyncClientBuilder setUnixDomainSocket(Path unixDomainSocket) {
         throw new UnsupportedOperationException("Operation not supported by " + getProtocolLevel());
     }
 

--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/async/TestAsyncResources.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/async/TestAsyncResources.java
@@ -30,6 +30,7 @@ package org.apache.hc.client5.testing.extension.async;
 import java.util.function.Consumer;
 
 import org.apache.hc.client5.testing.extension.sync.TestClientResources;
+import org.apache.hc.client5.testing.extension.sync.UnixDomainProxyServer;
 import org.apache.hc.core5.http.URIScheme;
 import org.apache.hc.core5.io.CloseMode;
 import org.apache.hc.core5.util.Asserts;
@@ -52,6 +53,7 @@ public class TestAsyncResources implements AfterEachCallback {
 
     private TestAsyncServer server;
     private TestAsyncClient client;
+    private UnixDomainProxyServer udsProxy;
 
     public TestAsyncResources(final URIScheme scheme, final ClientProtocolLevel clientProtocolLevel, final ServerProtocolLevel serverProtocolLevel, final Timeout timeout) {
         this.scheme = scheme != null ? scheme : URIScheme.HTTP;
@@ -84,9 +86,21 @@ public class TestAsyncResources implements AfterEachCallback {
         if (client != null) {
             client.close(CloseMode.GRACEFUL);
         }
+        if (udsProxy != null) {
+            udsProxy.close();
+        }
         if (server != null) {
             server.shutdown(TimeValue.ofSeconds(5));
         }
+    }
+
+    public UnixDomainProxyServer udsProxy() throws Exception {
+        if (udsProxy == null) {
+            final TestAsyncServer testServer = server();
+            final int port = testServer.getServerAddress().getPort();
+            udsProxy = new UnixDomainProxyServer(port);
+        }
+        return udsProxy;
     }
 
     public URIScheme scheme() {

--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/async/TestAsyncServer.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/async/TestAsyncServer.java
@@ -48,6 +48,7 @@ public class TestAsyncServer {
     private final Http1Config http1Config;
     private final HttpProcessor httpProcessor;
     private final Decorator<AsyncServerExchangeHandler> exchangeHandlerDecorator;
+    private volatile InetSocketAddress serverAddress;
 
     TestAsyncServer(
             final H2TestServer server,
@@ -98,7 +99,14 @@ public class TestAsyncServer {
         }
         server.configure(exchangeHandlerDecorator);
         server.configure(httpProcessor);
-        return server.start();
+        serverAddress = server.start();
+        return serverAddress;
     }
 
+    public InetSocketAddress getServerAddress() {
+        if (serverAddress == null) {
+            throw new IllegalStateException("Server has not been started");
+        }
+        return serverAddress;
+    }
 }

--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/AbstractIntegrationTestBase.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/AbstractIntegrationTestBase.java
@@ -87,7 +87,7 @@ abstract class AbstractIntegrationTestBase {
 
     public TestClient client() throws Exception {
         if (useUnixDomainSocket) {
-            final Path socketPath = testResources.udsProxy().getSocketPath();
+            final Path socketPath = getUnixDomainSocket();
             testResources.configureClient(builder -> {
                 builder.setUnixDomainSocket(socketPath);
             });
@@ -95,4 +95,10 @@ abstract class AbstractIntegrationTestBase {
         return testResources.client();
     }
 
+    public Path getUnixDomainSocket() throws Exception {
+        if (useUnixDomainSocket) {
+            return testResources.udsProxy().getSocketPath();
+        }
+        return null;
+    }
 }

--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestSocketTimeout.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestSocketTimeout.java
@@ -1,0 +1,142 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.hc.client5.testing.sync;
+
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.config.ConnectionConfig;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.BasicHttpClientResponseHandler;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.client5.testing.classic.RandomHandler;
+import org.apache.hc.client5.testing.extension.sync.ClientProtocolLevel;
+import org.apache.hc.client5.testing.extension.sync.TestClient;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.URIScheme;
+import org.apache.hc.core5.http.io.SocketConfig;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.net.SocketTimeoutException;
+import java.net.URI;
+import java.util.concurrent.TimeUnit;
+
+import static java.lang.String.format;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+abstract class AbstractTestSocketTimeout extends AbstractIntegrationTestBase {
+    protected AbstractTestSocketTimeout(final URIScheme scheme, final ClientProtocolLevel clientProtocolLevel,
+                               final boolean useUnixDomainSocket) {
+        super(scheme, clientProtocolLevel, useUnixDomainSocket);
+    }
+
+    @Timeout(5)
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "150,0,0,150,false",
+        "0,150,0,150,false",
+        "150,0,0,150,true",
+        "0,150,0,150,true",
+        // ConnectionConfig overrides SocketConfig
+        "50,150,0,150,false",
+        "1000,150,0,150,false",
+        "50,150,0,150,true",
+        "1000,150,0,150,true",
+        // ResponseTimeout overrides socket timeout
+        "2000,2000,150,150,false",
+        "2000,2000,150,150,true"
+    })
+    void testReadTimeouts(final String param) throws Exception {
+        final String[] params = param.split(",");
+        final int socketConfigTimeout = Integer.parseInt(params[0]);
+        final int connConfigTimeout = Integer.parseInt(params[1]);
+        final long responseTimeout = Integer.parseInt(params[2]);
+        final long expectedDelayMs = Long.parseLong(params[3]);
+        final boolean drip = Boolean.parseBoolean(params[4]);
+        configureServer(bootstrap -> bootstrap
+                .register("/random/*", new RandomHandler()));
+        final HttpHost target = startServer();
+
+        final TestClient client = client();
+        final PoolingHttpClientConnectionManager connManager = client.getConnectionManager();
+        if (socketConfigTimeout > 0) {
+            connManager.setDefaultSocketConfig(SocketConfig.custom()
+                .setSoTimeout(socketConfigTimeout, MILLISECONDS)
+                .build());
+        }
+        if (connConfigTimeout > 0) {
+            connManager.setDefaultConnectionConfig(ConnectionConfig.custom()
+                .setSocketTimeout(connConfigTimeout, MILLISECONDS)
+                .build());
+        }
+        final HttpGet request = new HttpGet(new URI("/random/10240?delay=1000&drip=" + (drip ? 1 : 0)));
+        if (responseTimeout > 0) {
+            request.setConfig(RequestConfig.custom()
+                .setUnixDomainSocket(getUnixDomainSocket())
+                .setResponseTimeout(responseTimeout, MILLISECONDS)
+                .build());
+        }
+
+        final long startTime = System.nanoTime();
+        assertThrows(SocketTimeoutException.class, () ->
+            client.execute(target, request, new BasicHttpClientResponseHandler()));
+        final long actualDelayMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime);
+
+        assertTrue(actualDelayMs > expectedDelayMs / 2,
+            format("Socket read timed out too soon (only %,d out of %,d ms)", actualDelayMs, expectedDelayMs));
+        assertTrue(actualDelayMs < expectedDelayMs * 2,
+            format("Socket read timed out too late (%,d out of %,d ms)", actualDelayMs, expectedDelayMs));
+    }
+}
+
+public class TestSocketTimeout {
+    @Nested
+    class Http extends AbstractTestSocketTimeout {
+        public Http() {
+            super(URIScheme.HTTP, ClientProtocolLevel.STANDARD, false);
+        }
+    }
+
+    @Nested
+    class Https extends AbstractTestSocketTimeout {
+        public Https() {
+            super(URIScheme.HTTP, ClientProtocolLevel.STANDARD, false);
+        }
+    }
+
+    @Nested
+    class Uds extends AbstractTestSocketTimeout {
+        public Uds() {
+            super(URIScheme.HTTP, ClientProtocolLevel.STANDARD, true);
+        }
+    }
+}
+


### PR DESCRIPTION
This change adds integration test coverage for various types of read timeouts. The test coverage includes HTTP, HTTPS, and HTTP over UDS if available. The `/random` request handlers have been augmented with delay support, so that the clients can read the response headers and then time out while reading the entity. The tests make use of `ConnectionConfig`, `ResponseTimeout`, and (on the sync client only) `SocketConfig`, and demonstrate the precedence among these config options when more than one is supplied.

One issue uncovered by these tests is that graceful closure of the async client does not work when UDS socket timeouts have fired. To work around this until the issue can be root caused, the async UDS tests use `CloseMode.IMMEDIATE`.