### PR TITLE
TestSocketTimeout: Increase upper bound assertion for actual delay

### DIFF
--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestSocketTimeout.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestSocketTimeout.java
@@ -112,7 +112,7 @@ abstract class AbstractTestSocketTimeout extends AbstractIntegrationTestBase {
 
         assertTrue(actualDelayMs > expectedDelayMs / 2,
             format("Socket read timed out too soon (only %,d out of %,d ms)", actualDelayMs, expectedDelayMs));
-        assertTrue(actualDelayMs < expectedDelayMs * 2,
+        assertTrue(actualDelayMs < expectedDelayMs * 3,
             format("Socket read timed out too late (%,d out of %,d ms)", actualDelayMs, expectedDelayMs));
     }
 }


### PR DESCRIPTION
These test cases are intermittently failing in the build environment on macos-latest using JDK11, because some of the calls seem to be taking slightly more than twice as long as they ought to before timing out. I'm not able to reproduce the issue, but it's safe to increase the upper bound: we'll still know if one of the socket timeout config options stops working, since the `assertThrows` assertion will fail.