### PR TITLE
HTTPCLIENT-2375 Add first-class request-side compression support and pluggable encoders

### DIFF
--- a/httpclient5/pom.xml
+++ b/httpclient5/pom.xml
@@ -113,6 +113,11 @@
       <artifactId>commons-compress</artifactId>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>com.github.luben</groupId>
+      <artifactId>zstd-jni</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/entity/DeflateCompressingEntity.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/entity/DeflateCompressingEntity.java
@@ -1,0 +1,83 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.hc.client5.http.entity;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.zip.Deflater;
+import java.util.zip.DeflaterOutputStream;
+
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.io.entity.HttpEntityWrapper;
+import org.apache.hc.core5.util.Args;
+
+/**
+ * Entity wrapper that compresses the wrapped entity with
+ * <code>Content-Encoding: deflate</code> on write-out.
+ *
+ * @since 5.6
+ */
+public final class DeflateCompressingEntity extends HttpEntityWrapper {
+
+    private static final String DEFLATE_CODEC = "deflate";
+
+    public DeflateCompressingEntity(final HttpEntity entity) {
+        super(entity);
+    }
+
+    @Override
+    public String getContentEncoding() {
+        return DEFLATE_CODEC;
+    }
+
+    @Override
+    public long getContentLength() {
+        return -1;                // length unknown after compression
+    }
+
+    @Override
+    public boolean isChunked() {
+        return true;              // force chunked transfer-encoding
+    }
+
+    @Override
+    public InputStream getContent() throws IOException {
+        throw new UnsupportedOperationException("getContent() not supported");
+    }
+
+    @Override
+    public void writeTo(final OutputStream out) throws IOException {
+        Args.notNull(out, "Output stream");
+        // ‘false’ second arg = include zlib wrapper (= RFC 1950 = HTTP “deflate”)
+        try (DeflaterOutputStream deflater =
+                     new DeflaterOutputStream(out, new Deflater(Deflater.DEFAULT_COMPRESSION, /*nowrap*/ false))) {
+            super.writeTo(deflater);
+        }
+    }
+}

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/entity/compress/CommonsCompressSupport.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/entity/compress/CommonsCompressSupport.java
@@ -1,0 +1,66 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.hc.client5.http.entity.compress;
+
+
+import org.apache.hc.core5.annotation.Contract;
+import org.apache.hc.core5.annotation.Internal;
+import org.apache.hc.core5.annotation.ThreadingBehavior;
+
+/**
+ * Utility that answers the question “Is Apache Commons Compress
+ * on the class-path and in a usable state?”  Both the encoder and
+ * decoder registries rely on this information.
+ *
+ * @since 5.6
+ */
+@Internal
+@Contract(threading = ThreadingBehavior.STATELESS)
+final class CommonsCompressSupport {
+
+    private static final String CCSF =
+            "org.apache.commons.compress.compressors.CompressorStreamFactory";
+
+    /** Non-instantiable. */
+    private CommonsCompressSupport() { }
+
+    /**
+     * Returns {@code true} if the core Commons Compress class can be loaded
+     * with the current class-loader, {@code false} otherwise.
+     */
+    static boolean isPresent() {
+        try {
+            Class.forName(CCSF, false,
+                    CommonsCompressSupport.class.getClassLoader());
+            return true;
+        } catch (ClassNotFoundException | LinkageError ex) {
+            return false;
+        }
+    }
+}
+

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/entity/compress/CommonsCompressingEntity.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/entity/compress/CommonsCompressingEntity.java
@@ -1,0 +1,94 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.hc.client5.http.entity.compress;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Locale;
+
+import org.apache.commons.compress.compressors.CompressorException;
+import org.apache.commons.compress.compressors.CompressorStreamFactory;
+import org.apache.hc.core5.annotation.Contract;
+import org.apache.hc.core5.annotation.Internal;
+import org.apache.hc.core5.annotation.ThreadingBehavior;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.io.entity.HttpEntityWrapper;
+import org.apache.hc.core5.util.Args;
+
+/**
+ * Compresses the wrapped entity on-the-fly using Apache&nbsp;Commons Compress.
+ *
+ * <p>The codec is chosen by its IANA token (for example {@code "br"} or
+ * {@code "zstd"}).  The helper JAR must be present at run-time; otherwise
+ * {@link #writeTo(OutputStream)} will throw {@link IOException}.</p>
+ *
+ * @since 5.6
+ */
+@Internal
+@Contract(threading = ThreadingBehavior.STATELESS)
+public final class CommonsCompressingEntity extends HttpEntityWrapper {
+
+    private final String coding;                     // lower-case
+    private final CompressorStreamFactory factory = new CompressorStreamFactory();
+
+    CommonsCompressingEntity(final HttpEntity src, final String coding) {
+        super(src);
+        this.coding = coding.toLowerCase(Locale.ROOT);
+    }
+
+    @Override
+    public String getContentEncoding() {
+        return coding;
+    }
+
+    @Override
+    public long getContentLength() {
+        return -1;
+    }   // streaming
+
+    @Override
+    public boolean isChunked() {
+        return true;
+    }
+
+    @Override
+    public InputStream getContent() {          // Pull-mode is not supported
+        throw new UnsupportedOperationException("Compressed entity is write-only");
+    }
+
+    @Override
+    public void writeTo(final OutputStream out) throws IOException {
+        Args.notNull(out, "Output stream");
+        try (OutputStream cos = factory.createCompressorOutputStream(coding, out)) {
+            super.writeTo(cos);
+        } catch (final CompressorException | LinkageError ex) {
+            throw new IOException("Unable to compress using coding '" + coding + '\'', ex);
+        }
+    }
+}

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/entity/compress/ContentDecoderRegistry.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/entity/compress/ContentDecoderRegistry.java
@@ -68,9 +68,6 @@ import org.apache.hc.core5.annotation.ThreadingBehavior;
 @Contract(threading = ThreadingBehavior.STATELESS)
 public final class ContentDecoderRegistry {
 
-    private static final String CCSF =
-            "org.apache.commons.compress.compressors.CompressorStreamFactory";
-
 
     private static final Map<ContentCoding, InputStreamFactory> REGISTRY = buildRegistry();
 
@@ -91,9 +88,9 @@ public final class ContentDecoderRegistry {
         register(m, ContentCoding.DEFLATE, new DeflateInputStreamFactory());
 
         // 2. Commons-Compress (optional)
-        if (commonsCompressPresent()) {
+        if (CommonsCompressSupport.isPresent()) {
             for (final ContentCoding coding : Arrays.asList(
-                    ContentCoding.BROTLI,
+                    ContentCoding.BROTLI,     // note: will be skipped until CC ships an encoder
                     ContentCoding.ZSTD,
                     ContentCoding.XZ,
                     ContentCoding.LZMA,
@@ -125,16 +122,6 @@ public final class ContentDecoderRegistry {
                                    final ContentCoding coding) {
         if (CommonsCompressDecoderFactory.runtimeAvailable(coding.token())) {
             register(map, coding, new CommonsCompressDecoderFactory(coding.token()));
-        }
-    }
-
-    private static boolean commonsCompressPresent() {
-        try {
-            Class.forName(
-                    CCSF, false, ContentDecoderRegistry.class.getClassLoader());
-            return true;
-        } catch (final ClassNotFoundException | LinkageError ex) {
-            return false;
         }
     }
 

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/entity/compress/ContentEncoderRegistry.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/entity/compress/ContentEncoderRegistry.java
@@ -1,0 +1,95 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.hc.client5.http.entity.compress;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.Map;
+
+import org.apache.hc.client5.http.entity.DeflateCompressingEntity;
+import org.apache.hc.client5.http.entity.GzipCompressingEntity;
+import org.apache.hc.core5.annotation.Contract;
+import org.apache.hc.core5.annotation.Internal;
+import org.apache.hc.core5.annotation.ThreadingBehavior;
+import org.apache.hc.core5.http.HttpEntity;
+
+@Internal
+@Contract(threading = ThreadingBehavior.STATELESS)
+public final class ContentEncoderRegistry {
+
+    /**
+     * Map token → factory (immutable, thread-safe).
+     */
+    private static final Map<ContentCoding, EncoderFactory> REGISTRY = build();
+
+    public static EncoderFactory lookup(final ContentCoding coding) {
+        return REGISTRY.get(coding);
+    }
+
+
+    @FunctionalInterface
+    public interface EncoderFactory {
+        /**
+         * Wraps the source entity in its compressing counterpart.
+         */
+        HttpEntity wrap(HttpEntity src);
+    }
+
+    private static Map<ContentCoding, EncoderFactory> build() {
+        final Map<ContentCoding, EncoderFactory> m =
+                new EnumMap<>(ContentCoding.class);
+
+        /* 1. Built-ins – gzip + deflate use the existing wrappers */
+        m.put(ContentCoding.GZIP, GzipCompressingEntity::new);
+        m.put(ContentCoding.DEFLATE, DeflateCompressingEntity::new);
+
+        /* 2. Commons-Compress – only if the helper class is present */
+        if (CommonsCompressSupport.isPresent()) {
+            for (final ContentCoding c : Arrays.asList(
+                    ContentCoding.BROTLI,
+                    ContentCoding.ZSTD,
+                    ContentCoding.XZ,
+                    ContentCoding.LZMA,
+                    ContentCoding.LZ4_FRAMED,
+                    ContentCoding.LZ4_BLOCK,
+                    ContentCoding.BZIP2,
+                    ContentCoding.PACK200,
+                    ContentCoding.DEFLATE64)) {
+
+                if (CommonsCompressDecoderFactory.runtimeAvailable(c.token())) {
+                    m.put(c, e -> new CommonsCompressingEntity(e, c.token()));
+                }
+            }
+        }
+        return Collections.unmodifiableMap(m);
+    }
+
+    private ContentEncoderRegistry() {
+    } // no-instantiation
+}

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/entity/TestEntityBuilder.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/entity/TestEntityBuilder.java
@@ -30,6 +30,7 @@ package org.apache.hc.client5.http.entity;
 import java.io.File;
 import java.io.InputStream;
 
+import org.apache.hc.client5.http.entity.compress.ContentCoding;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
@@ -115,13 +116,13 @@ class TestEntityBuilder {
     }
 
     @Test
-    void testBuildGZipped() {
-        final HttpEntity entity = EntityBuilder.create().setText("stuff").gzipCompressed().build();
+    void testBuildCompressed() {
+        final HttpEntity entity = EntityBuilder.create().setText("stuff").compressed(ContentCoding.GZIP).build();
         Assertions.assertNotNull(entity);
         Assertions.assertNotNull(entity.getContentType());
         Assertions.assertEquals("text/plain; charset=UTF-8", entity.getContentType());
-        Assertions.assertNotNull(entity.getContentEncoding());
         Assertions.assertEquals("gzip", entity.getContentEncoding());
+        Assertions.assertTrue(entity.isChunked());
     }
 
 }

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClientServerCompressionExample.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClientServerCompressionExample.java
@@ -1,0 +1,186 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+
+package org.apache.hc.client5.http.examples;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+
+import org.apache.commons.compress.compressors.CompressorStreamFactory;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.entity.EntityBuilder;
+import org.apache.hc.client5.http.entity.compress.ContentCoding;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+
+/**
+ * <h2>End-to-end “Zstandard” demo for HttpClient&nbsp;5.6 +</h2>
+ *
+ * <p>This standalone {@code main()} program shows how the new
+ * {@link org.apache.hc.client5.http.entity.EntityBuilder#compressed
+ * EntityBuilder#compressed(ContentCoding)} API can be used to
+ * transparently <strong>compress</strong> a request entity with
+ * Zstandard (<em>zstd</em>) on the client side and then
+ * <strong>decompress</strong> it on the server side—while the reverse
+ * happens for the response.</p>
+ *
+ * <h3>What the code does</h3>
+ * <ol>
+ *   <li>Spins up a tiny in-JVM {@code com.sun.net.httpserver.HttpServer}
+ *       bound to an ephemeral port.</li>
+ *   <li>The client sends a {@code POST /echo} whose body is compressed
+ *       with <em>zstd</em> simply by calling
+ *       {@code compressed(ContentCoding.ZSTD)}.</li>
+ *   <li>The server handler decodes the request body with Commons Compress
+ *       ({@link org.apache.commons.compress.compressors.CompressorStreamFactory}),
+ *       echoes the text back, re-encodes it with Zstandard, and sets
+ *       {@code Content-Encoding: zstd}.</li>
+ *   <li>The client receives the response—HttpClient 5.6+ notices the
+ *       header, automatically picks the decoder you registered via
+ *       {@link org.apache.hc.client5.http.entity.compress.ContentDecoderRegistry},
+ *       and hands the caller the already-decompressed text.</li>
+ * </ol>
+ *
+ * <h3>How to run</h3>
+ * <ul>
+ *   <li>Java 8-17 (only standard {@code com.sun.net.httpserver} API used).</li>
+ *   <li>Maven dependencies (all <em>compile + runtime</em>):<br>
+ *     ─ {@code httpclient5 ≥ 5.6-SNAPSHOT}<br>
+ *     ─ {@code commons-compress ≥ 1.21}<br>
+ *     ─ {@code com.github.luben:zstd-jni} (automatically pulled by
+ *       Commons Compress for the native codec)
+ *   </li>
+ *   <li>JDK 17+ users: you will see a one-time warning that
+ *       {@code zstd-jni} loads native code. Add<br>
+ *       {@code --enable-native-access=ALL-UNNAMED} to the VM options
+ *       if you want to silence it.</li>
+ *   <li>Launch from your IDE or:
+ *   <pre>{@code
+ *   mvn -q exec:java \
+ *       -Dexec.mainClass=org.apache.hc.client5.testing.classic.ZstdRoundTrip
+ *   }</pre></li>
+ * </ul>
+ *
+ * <h3>Why Zstandard and not GZIP?</h3>
+ * GZIP support has always been built-in.  This demo illustrates the
+ * new <em>pluggable</em> compression framework: as soon as
+ * Commons Compress + the native helper JAR are on the class-path,
+ * HttpClient discovers the codec and you can opt-in at the
+ * <cite>EntityBuilder</cite> call-site—no other code changes needed.
+ *
+ * @since 5.6
+ */
+public final class ClientServerCompressionExample {
+
+    private ClientServerCompressionExample() {
+    }
+
+    public static void main(final String[] args) throws Exception {
+
+        /* ──────────────────────────────────────────────
+           1. Tiny echo server that understands “br|zstd…”
+           ────────────────────────────────────────────── */
+        final HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/echo", new EchoHandler());
+        server.start();
+        final int port = server.getAddress().getPort();
+        System.out.println("Server   : http://localhost:" + port + "/echo");
+
+        /* ──────────────────────────────────────────────
+           2. Build and send a Zstd-compressed POST
+           ────────────────────────────────────────────── */
+        try (final CloseableHttpClient client = HttpClients.createDefault()) {
+
+            final HttpPost post = new HttpPost("http://localhost:" + port + "/echo");
+            post.setEntity(EntityBuilder.create()
+                    .setText("Hello Zstandard world!")
+                    .compressed(ContentCoding.ZSTD)   // ← NEW API
+                    .build());
+
+            System.out.println("Client → : sending request …");
+
+            final String reply = client.execute(post,
+                    rsp -> EntityUtils.toString(rsp.getEntity(), StandardCharsets.UTF_8));
+
+            System.out.println("Client ← : got reply  «" + reply + "»");
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    /* ──────────────────────────────────────────────
+       Server handler: decode-echo-encode
+       ────────────────────────────────────────────── */
+    private static final class EchoHandler implements HttpHandler {
+        @Override
+        public void handle(final HttpExchange ex) {
+            try {
+                /* ----- decode body (if any) ----- */
+                final InputStream in = new CompressorStreamFactory()
+                        .createCompressorInputStream("zstd", ex.getRequestBody());
+
+                final byte[] data = readAll(in);
+                final String text = new String(data, StandardCharsets.UTF_8);
+
+                System.out.println("Server   : received «" + text + "»");
+
+                /* ----- encode response ----- */
+                ex.getResponseHeaders().add("Content-Encoding", "zstd");
+                ex.sendResponseHeaders(200, 0); // chunked
+                final OutputStream raw = ex.getResponseBody();
+                try (final OutputStream zstdOut = new CompressorStreamFactory()
+                        .createCompressorOutputStream("zstd", raw)) {
+                    zstdOut.write(text.getBytes(StandardCharsets.UTF_8));
+                }
+            } catch (final Exception ignored) {
+
+            } finally {
+                ex.close();
+            }
+        }
+
+        private static byte[] readAll(final InputStream in) throws IOException {
+            final ByteArrayOutputStream buf = new ByteArrayOutputStream();
+            final byte[] tmp = new byte[8 * 1024];
+            int n;
+            while ((n = in.read(tmp)) != -1) {
+                buf.write(tmp, 0, n);
+            }
+            return buf.toByteArray();
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
     <api.comparison.version>5.3</api.comparison.version>
     <hc.animal-sniffer.signature.ignores>javax.net.ssl.SSLEngine,javax.net.ssl.SSLParameters,java.nio.ByteBuffer,java.nio.CharBuffer</hc.animal-sniffer.signature.ignores>
     <commons.compress.version>1.27.1</commons.compress.version>
+    <zstd.jni.version>1.5.7-3</zstd.jni.version>
   </properties>
 
   <dependencyManagement>
@@ -210,7 +211,11 @@
         <artifactId>commons-compress</artifactId>
         <version>${commons.compress.version}</version>
       </dependency>
-
+      <dependency>
+        <groupId>com.github.luben</groupId>
+        <artifactId>zstd-jni</artifactId>
+        <version>${zstd.jni.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
 Adds pluggable request-side compression. You can now call `EntityBuilder.compressed(ContentCoding)` to have any codec discovered at runtime—GZIP remains the default, but `Brotli`, `Zstandard`, `XZ`, and the rest are picked up automatically when Commons Compress and the relevant helper JARs are on the class-path. The change introduces a `ContentEncoderRegistry`, removes duplicate reflection probes via the new `CommonsCompressSupport`, keeps `gzipCompressed()` as a deprecated convenience alias, and ships a tiny `Zstd` round-trip demo plus unit tests. No new mandatory dependencies; everything stays lightweight unless you choose to add more codecs.