### PR TITLE
HTTPCLIENT-2379 - Handle duplicate release() safely in H2SharingConnPool

### DIFF
--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/nio/H2SharingPerRoutePoolTest.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/nio/H2SharingPerRoutePoolTest.java
@@ -98,7 +98,7 @@ public class H2SharingPerRoutePoolTest {
         pool.track(poolEntry1);
         pool.track(poolEntry1);
 
-        Assertions.assertEquals(0, pool.release(poolEntry1, false));
+        Assertions.assertEquals(2, pool.release(poolEntry1, false)); // 3 → 2
     }
 
     @Test
@@ -114,7 +114,7 @@ public class H2SharingPerRoutePoolTest {
         pool.track(poolEntry1);
 
         Mockito.when(poolEntry1.getConnection().isOpen()).thenReturn(false);
-        Assertions.assertEquals(0, pool.release(poolEntry1, true));
+        Assertions.assertEquals(2, pool.release(poolEntry1, true));  // 3 → 2
     }
 
     @Test
@@ -124,7 +124,7 @@ public class H2SharingPerRoutePoolTest {
         pool.track(poolEntry1);
 
         poolEntry1.discardConnection(CloseMode.IMMEDIATE);
-        Assertions.assertEquals(0, pool.release(poolEntry1, true));
+        Assertions.assertEquals(2, pool.release(poolEntry1, true));  // 3 → 2
     }
 
 }


### PR DESCRIPTION
Return early in H2SharingConnPool#release when the entry’s lease count is zero, so duplicate releases become no-ops and the underlying pool no longer throws `IllegalStateException`.

tested with https://github.com/yhzdys/httpcomponents-client/commit/c8256b33c3adb45cfa2a49efb2dacfb611da9ac1