### PR TITLE
Jep380SocketChannelAdapter: Connect in blocking mode

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/socket/Jep380SocketChannelAdapter.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/socket/Jep380SocketChannelAdapter.java
@@ -51,11 +51,13 @@ final class Jep380SocketChannelAdapter extends Socket {
     @Override
     public void connect(final SocketAddress endpoint, final int timeout) throws IOException {
         channel.connect(endpoint);
+        channel.configureBlocking(false);
     }
 
     @Override
     public void connect(final SocketAddress endpoint) throws IOException {
         channel.connect(endpoint);
+        channel.configureBlocking(false);
     }
 
     @Override

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/socket/Jep380SocketChannelImplAdapter.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/socket/Jep380SocketChannelImplAdapter.java
@@ -49,7 +49,6 @@ final class Jep380SocketChannelImplAdapter extends SocketImpl {
 
     public Jep380SocketChannelImplAdapter(final SocketChannel channel) throws IOException {
         this.channel = channel;
-        channel.configureBlocking(false);
     }
 
     @Override


### PR DESCRIPTION
This fixes UDS integration test failures on Windows and Java 17+.