### PR TITLE
TestValidateAfterInactivity: Set maxConns to 1

### DIFF
--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/TestValidateAfterInactivity.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/TestValidateAfterInactivity.java
@@ -260,6 +260,8 @@ class AbstractTestValidateAfterInactivity {
     private CloseableHttpAsyncClient asyncClient(final boolean validateAfterInactivity) {
         final PoolingAsyncClientConnectionManager connManager = new PoolingAsyncClientConnectionManager();
         connManager.setDefaultConnectionConfig(getConnectionConfig(validateAfterInactivity));
+        connManager.setDefaultMaxPerRoute(1);
+        connManager.setMaxTotal(1);
         final CloseableHttpAsyncClient client = HttpAsyncClients.custom()
             .setConnectionManager(connManager)
             .disableAutomaticRetries()


### PR DESCRIPTION
The test server only supports a single connection at a time, and the async client can apparently attempt to establish a second connection, possibly due to a benign race condition in how leased connections are returned to the pool.