### PR TITLE
Undeprecate InputStreamFactory and restore contentDecoderMap functionality in HttpClientBuilder

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/entity/InputStreamFactory.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/entity/InputStreamFactory.java
@@ -31,10 +31,9 @@ import java.io.InputStream;
 
 /**
  * Factory for decorated {@link InputStream}s.
- * @deprecated Replaced by {@link org.apache.hc.client5.http.entity.compress.Decoder}.
  * @since 4.4
  */
-@Deprecated
+@FunctionalInterface
 public interface InputStreamFactory {
 
     InputStream create(InputStream inputStream) throws IOException;


### PR DESCRIPTION
@arturobernalg I realized you should not have deprecated `InputStreamFactory`. It was still perfectly useful at the HttpClientBuilder level for plugging in custom decoders.

How about this change-set?