### PR TITLE
Bug-fix: Corrected DecompressingEntity to return null Content-Encoding (no encoding)

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/entity/compress/DecompressingEntity.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/entity/compress/DecompressingEntity.java
@@ -82,14 +82,12 @@ public class DecompressingEntity extends HttpEntityWrapper {
         return -1;
     }
 
+    /**
+     * Content is no longer encoded
+     */
     @Override
-    public boolean isRepeatable() {
-        return super.isRepeatable();
-    }
-
-    @Override
-    public boolean isStreaming() {
-        return super.isStreaming();
+    public String getContentEncoding() {
+        return null;
     }
 
     /**


### PR DESCRIPTION
@arturobernalg I overlooked the problem with `Content-Encoding` property value returned by DecompressingEntity, Please double-check.