### PR TITLE
HTTPCLIENT-1074: Hard request timeout (requestTimeout) for async & classic clients

### DIFF
--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestRequestTimeoutClassic.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestRequestTimeoutClassic.java
@@ -1,0 +1,194 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.client5.testing.sync;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.config.ConnectionConfig;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.impl.bootstrap.HttpServer;
+import org.apache.hc.core5.http.impl.bootstrap.ServerBootstrap;
+import org.apache.hc.core5.http.io.HttpRequestHandler;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.hc.core5.net.URIBuilder;
+import org.apache.hc.core5.util.Timeout;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TestRequestTimeoutClassic {
+
+    private static HttpServer server;
+    private static HttpHost target;
+
+    private CloseableHttpClient client;
+
+    private static final HttpRequestHandler DELAY_HANDLER = (request, response, context) -> {
+        int seconds = 1;
+        final String path = request.getPath(); // e.g. /delay/5
+        final int idx = path.lastIndexOf('/');
+        if (idx >= 0 && idx + 1 < path.length()) {
+            try {
+                seconds = Integer.parseInt(path.substring(idx + 1));
+            } catch (final NumberFormatException ignore) { /* default 1s */ }
+        }
+        try {
+            TimeUnit.SECONDS.sleep(seconds);
+        } catch (final InterruptedException ie) {
+            Thread.currentThread().interrupt();
+        }
+        response.setCode(200);
+        response.setEntity(new StringEntity("{\"ok\":true}", ContentType.APPLICATION_JSON));
+    };
+
+    @BeforeAll
+    static void startServer() throws Exception {
+        server = ServerBootstrap.bootstrap()
+                .setCanonicalHostName("localhost")
+                .register("/delay/*", DELAY_HANDLER)
+                .create();
+        server.start();
+        target = new HttpHost("http", "localhost", server.getLocalPort());
+    }
+
+    @AfterAll
+    static void stopServer() {
+        if (server != null) {
+            server.stop();
+        }
+    }
+
+    @BeforeEach
+    void createClient() {
+        final PoolingHttpClientConnectionManager cm =
+                PoolingHttpClientConnectionManagerBuilder.create()
+                        .setDefaultConnectionConfig(ConnectionConfig.custom()
+                                .setConnectTimeout(Timeout.ofSeconds(5))
+                                .setSocketTimeout(Timeout.ofSeconds(5))
+                                .build())
+                        .build();
+
+        client = HttpClients.custom()
+                .setConnectionManager(cm)
+                .build();
+    }
+
+    @AfterEach
+    void closeClient() throws IOException {
+        if (client != null) {
+            client.close();
+        }
+    }
+
+    @Test
+    @org.junit.jupiter.api.Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void timesOutHard() throws Exception {
+        final HttpGet req = new HttpGet(new URIBuilder()
+                .setScheme(target.getSchemeName())
+                .setHost(target.getHostName())
+                .setPort(target.getPort())
+                .setPath("/delay/5")
+                .build());
+        req.setConfig(RequestConfig.custom()
+                .setRequestTimeout(Timeout.ofSeconds(1))           // hard end-to-end deadline
+                .setConnectionRequestTimeout(Timeout.ofSeconds(2)) // pool lease cap
+                .build());
+
+        final IOException ex = assertThrows(IOException.class,
+                () -> client.execute(req, resp -> resp.getCode()));
+        assertTrue(ex instanceof java.io.InterruptedIOException,
+                "Expected InterruptedIOException, got: " + ex.getClass());
+    }
+
+    @Test
+    @org.junit.jupiter.api.Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void succeedsWithinBudget() throws Exception {
+        final HttpGet req = new HttpGet(new URIBuilder()
+                .setScheme(target.getSchemeName())
+                .setHost(target.getHostName())
+                .setPort(target.getPort())
+                .setPath("/delay/1")
+                .build());
+        req.setConfig(RequestConfig.custom()
+                .setRequestTimeout(Timeout.ofSeconds(5))           // enough for lease+connect+1s delay
+                .setConnectionRequestTimeout(Timeout.ofSeconds(2))
+                .build());
+
+        final int code = client.execute(req, resp -> resp.getCode());
+        assertEquals(200, code);
+    }
+
+    @Test
+    @org.junit.jupiter.api.Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void immediateExpirationFailsBeforeSend() throws Exception {
+        final HttpGet req = new HttpGet(new URIBuilder()
+                .setScheme(target.getSchemeName())
+                .setHost(target.getHostName())
+                .setPort(target.getPort())
+                .setPath("/delay/1")
+                .build());
+        req.setConfig(RequestConfig.custom()
+                .setRequestTimeout(Timeout.ofMilliseconds(1))      // near-immediate expiry
+                .setConnectionRequestTimeout(Timeout.ofSeconds(1))
+                .build());
+
+        assertThrows(java.io.InterruptedIOException.class,
+                () -> client.execute(req, resp -> resp.getCode()));
+    }
+
+    @Test
+    @org.junit.jupiter.api.Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void largeBudgetStillHonorsPerOpTimeouts() throws Exception {
+        final HttpGet req = new HttpGet(new URIBuilder()
+                .setScheme(target.getSchemeName())
+                .setHost(target.getHostName())
+                .setPort(target.getPort())
+                .setPath("/delay/1")
+                .build());
+        req.setConfig(RequestConfig.custom()
+                .setRequestTimeout(Timeout.ofSeconds(30))
+                .setConnectionRequestTimeout(Timeout.ofSeconds(2))
+                .build());
+
+        final int code = client.execute(req, resp -> resp.getCode());
+        assertEquals(200, code);
+    }
+}

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/examples/AsyncClientRequestTimeoutExample.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/examples/AsyncClientRequestTimeoutExample.java
@@ -1,0 +1,145 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.client5.http.examples;
+
+import java.io.InterruptedIOException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import org.apache.hc.client5.http.async.methods.SimpleHttpRequest;
+import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
+import org.apache.hc.client5.http.async.methods.SimpleRequestBuilder;
+import org.apache.hc.client5.http.async.methods.SimpleRequestProducer;
+import org.apache.hc.client5.http.async.methods.SimpleResponseConsumer;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.client5.http.impl.async.HttpAsyncClients;
+import org.apache.hc.core5.concurrent.FutureCallback;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.message.StatusLine;
+import org.apache.hc.core5.io.CloseMode;
+import org.apache.hc.core5.util.Timeout;
+
+/**
+ * Demonstrates per-request hard end-to-end timeout (query timeout / request deadline).
+ */
+public class AsyncClientRequestTimeoutExample {
+
+    public static void main(final String[] args) throws Exception {
+
+        // No default requestTimeout at the client level (leave it opt-in per request).
+        try (final CloseableHttpAsyncClient client = HttpAsyncClients.custom().build()) {
+
+            client.start();
+
+            final HttpHost host = new HttpHost("https", "httpbin.org");
+
+            // 1) This one should TIME OUT (server delays ~5s, our requestTimeout is 2s)
+            final SimpleHttpRequest willTimeout = SimpleRequestBuilder.get()
+                    .setHttpHost(host)
+                    .setPath("/delay/5")
+                    .build();
+            willTimeout.setConfig(RequestConfig.custom()
+                    .setRequestTimeout(Timeout.ofSeconds(2))
+                    .build());
+
+            System.out.println("Executing (expected timeout): " + willTimeout);
+
+            final Future<SimpleHttpResponse> f1 = client.execute(
+                    SimpleRequestProducer.create(willTimeout),
+                    SimpleResponseConsumer.create(),
+                    new FutureCallback<SimpleHttpResponse>() {
+                        @Override
+                        public void completed(final SimpleHttpResponse response) {
+                            System.out.println(willTimeout + " -> " + new StatusLine(response));
+                            System.out.println(response.getBodyText());
+                        }
+
+                        @Override
+                        public void failed(final Exception ex) {
+                            System.out.println(willTimeout + " -> FAILED: " + ex);
+                            if (ex instanceof InterruptedIOException) {
+                                System.out.println("As expected: hard request timeout triggered.");
+                            }
+                        }
+
+                        @Override
+                        public void cancelled() {
+                            System.out.println(willTimeout + " -> CANCELLED");
+                        }
+                    });
+
+            try {
+                f1.get(); // Will throw ExecutionException wrapping InterruptedIOException
+            } catch (final ExecutionException ee) {
+                final Throwable cause = ee.getCause();
+                if (cause instanceof InterruptedIOException) {
+                    System.out.println("Future failed with InterruptedIOException (OK): " + cause.getMessage());
+                } else {
+                    System.out.println("Unexpected failure type: " + cause);
+                }
+            }
+
+            // 2) This one should SUCCEED (server delays ~1s, our requestTimeout is 3s)
+            final SimpleHttpRequest willSucceed = SimpleRequestBuilder.get()
+                    .setHttpHost(host)
+                    .setPath("/delay/1")
+                    .build();
+            willSucceed.setConfig(RequestConfig.custom()
+                    .setRequestTimeout(Timeout.ofSeconds(3)) // <--- longer budget
+                    .build());
+
+            System.out.println("Executing (expected success): " + willSucceed);
+
+            final Future<SimpleHttpResponse> f2 = client.execute(
+                    SimpleRequestProducer.create(willSucceed),
+                    SimpleResponseConsumer.create(),
+                    new FutureCallback<SimpleHttpResponse>() {
+                        @Override
+                        public void completed(final SimpleHttpResponse response) {
+                            System.out.println(willSucceed + " -> " + new StatusLine(response));
+                            System.out.println(response.getBodyText());
+                        }
+
+                        @Override
+                        public void failed(final Exception ex) {
+                            System.out.println(willSucceed + " -> FAILED: " + ex);
+                        }
+
+                        @Override
+                        public void cancelled() {
+                            System.out.println(willSucceed + " -> CANCELLED");
+                        }
+                    });
+
+            f2.get(); // Should complete normally
+
+            System.out.println("Shutting down");
+            client.close(CloseMode.GRACEFUL);
+        }
+    }
+}

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClassicClientCallTimeoutExample.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClassicClientCallTimeoutExample.java
@@ -1,0 +1,91 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.client5.http.examples;
+
+import java.io.IOException;
+
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.config.ConnectionConfig;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.io.HttpClientResponseHandler;
+import org.apache.hc.core5.util.Timeout;
+
+public class ClassicClientCallTimeoutExample {
+
+    public static void main(final String[] args) throws Exception {
+
+        // Non-deprecated: set connect/socket timeouts via ConnectionConfig
+        final PoolingHttpClientConnectionManager cm =
+                PoolingHttpClientConnectionManagerBuilder.create()
+                        .setDefaultConnectionConfig(
+                                ConnectionConfig.custom()
+                                        .setConnectTimeout(Timeout.ofSeconds(10))
+                                        .setSocketTimeout(Timeout.ofSeconds(10))
+                                        .build())
+                        .build();
+
+        try (final CloseableHttpClient client = HttpClients.custom()
+                .setConnectionManager(cm)
+                .build()) {
+
+            // ---- Expected TIMEOUT (hard call deadline) ----
+            final HttpGet slow = new HttpGet("https://httpbin.org/delay/5");
+            slow.setConfig(RequestConfig.custom()
+                    .setRequestTimeout(Timeout.ofSeconds(2))      // hard end-to-end cap
+                    .setConnectionRequestTimeout(Timeout.ofSeconds(3)) // don't hang on pool lease
+                    .build());
+
+            final HttpClientResponseHandler<String> handler = (ClassicHttpResponse response) -> {
+                return response.getCode() + " " + response.getReasonPhrase();
+            };
+
+            System.out.println("Executing (expected timeout): " + slow.getPath());
+            try {
+                client.execute(slow, handler); // will throw by design
+                System.out.println("UNEXPECTED: completed");
+            } catch (final IOException ex) {
+                System.out.println("As expected: " + ex.getClass().getSimpleName() + " - " + ex.getMessage());
+            }
+
+            // ---- Expected SUCCESS within budget (use HTTP to avoid TLS variance) ----
+            final HttpGet fast = new HttpGet("http://httpbin.org/delay/1"); // HTTP on purpose
+            fast.setConfig(RequestConfig.custom()
+                    .setRequestTimeout(Timeout.ofSeconds(8))          // generous end-to-end budget
+                    .setConnectionRequestTimeout(Timeout.ofSeconds(2)) // quick fail if pool stuck
+                    .build());
+
+            System.out.println("Executing (expected success): " + fast.getPath());
+            final String ok = client.execute(fast, handler);
+            System.out.println("OK: " + ok);
+        }
+    }
+}


### PR DESCRIPTION
Introduce RequestConfig.requestTimeout: an opt-in, end-to-end call deadline that aborts the entire exchange with InterruptedIOException("Request timeout").