### PR TITLE
HTTPCLIENT-2393 - remove rspauth from Authorization

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/DigestScheme.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/DigestScheme.java
@@ -471,7 +471,6 @@ public class DigestScheme implements AuthScheme, Serializable {
             params.add(new BasicNameValuePair("qop", qop == QualityOfProtection.AUTH_INT ? "auth-int" : "auth"));
             params.add(new BasicNameValuePair("nc", nc));
             params.add(new BasicNameValuePair("cnonce", cnonce));
-            params.add(new BasicNameValuePair("rspauth", hasha2));
         }
         if (algorithm != null) {
             params.add(new BasicNameValuePair("algorithm", algorithm));

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestDigestScheme.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestDigestScheme.java
@@ -903,7 +903,7 @@ class TestDigestScheme {
     }
 
     @Test
-    void testRspAuthFieldAndQuoting() throws Exception {
+    void testRspAuthFieldNotPresentClient() throws Exception {
         final ClassicHttpRequest request = new BasicClassicHttpRequest("POST", "/");
         final HttpHost host = new HttpHost("somehost", 80);
         final CredentialsProvider credentialsProvider = CredentialsProviderBuilder.create()
@@ -921,7 +921,8 @@ class TestDigestScheme {
 
         final Map<String, String> table = parseAuthResponse(authResponse);
 
-        Assertions.assertNotNull(table.get("rspauth"));
+        Assertions.assertNotNull(table);
+        Assertions.assertNull(table.get("rspauth"));
     }
 
     @Test


### PR DESCRIPTION
Fix Digest compliance: stop emitting rspauth in Authorization. Parse/validate rspauth only from Authentication-Info (RFC 7616 §3.5). rollback for [ef73836](https://github.com/apache/httpcomponents-client/pull/594/commits/ef73836e4205b393ffe2bb63ed2780448e79b010) 