### PR TITLE
Bug fix: connections managers to ensure open connections have socket timeout set based on ConnectionConfig upon lease

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/BasicHttpClientConnectionManager.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/BasicHttpClientConnectionManager.java
@@ -401,6 +401,9 @@ public class BasicHttpClientConnectionManager implements HttpClientConnectionMan
                 this.created = System.currentTimeMillis();
             } else {
                 this.conn.activate();
+                if (connectionConfig.getSocketTimeout() != null) {
+                    conn.setSocketTimeout(connectionConfig.getSocketTimeout());
+                }
             }
             this.leased = true;
             if (LOG.isDebugEnabled()) {

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java
@@ -386,6 +386,9 @@ public class PoolingHttpClientConnectionManager
                         final ManagedHttpClientConnection conn = poolEntry.getConnection();
                         if (conn != null) {
                             conn.activate();
+                            if (connectionConfig.getSocketTimeout() != null) {
+                                conn.setSocketTimeout(connectionConfig.getSocketTimeout());
+                            }
                         } else {
                             poolEntry.assignConnection(connFactory.createConnection(null));
                         }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java
@@ -326,6 +326,9 @@ public class PoolingAsyncClientConnectionManager implements AsyncClientConnectio
                             final ManagedAsyncClientConnection connection = poolEntry.getConnection();
                             if (connection != null) {
                                 connection.activate();
+                                if (connectionConfig.getSocketTimeout() != null) {
+                                    connection.setSocketTimeout(connectionConfig.getSocketTimeout());
+                                }
                             }
                             if (LOG.isDebugEnabled()) {
                                 LOG.debug("{} endpoint leased {}", id, ConnPoolSupport.formatStats(route, state, pool));


### PR DESCRIPTION
I was looking at the pooled connection activation / passivation logic and found out that connections do not reset the socket timeout on leased open connections, which can lead to some random timeout setting from the previous and likely completely unrelated message exchange. This is a defect the way I see it.

@rschmitt Please take a look and let me know if you disagree.

@arturobernalg Could you please double-check?