### PR TITLE
Bug fix: Use 1 second timeout when closing out connections inside a connection pool lock

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java
@@ -70,6 +70,7 @@ import org.apache.hc.core5.http.io.SocketConfig;
 import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.io.CloseMode;
 import org.apache.hc.core5.pool.ConnPoolControl;
+import org.apache.hc.core5.pool.DefaultDisposalCallback;
 import org.apache.hc.core5.pool.LaxConnPool;
 import org.apache.hc.core5.pool.ManagedConnPool;
 import org.apache.hc.core5.pool.PoolConcurrencyPolicy;
@@ -223,6 +224,7 @@ public class PoolingHttpClientConnectionManager
                         DEFAULT_MAX_TOTAL_CONNECTIONS,
                         timeToLive,
                         poolReusePolicy,
+                        new DefaultDisposalCallback<>(),
                         null) {
 
                     @Override

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java
@@ -77,6 +77,7 @@ import org.apache.hc.core5.http2.nio.support.BasicPingHandler;
 import org.apache.hc.core5.http2.ssl.ApplicationProtocol;
 import org.apache.hc.core5.io.CloseMode;
 import org.apache.hc.core5.pool.ConnPoolControl;
+import org.apache.hc.core5.pool.DefaultDisposalCallback;
 import org.apache.hc.core5.pool.LaxConnPool;
 import org.apache.hc.core5.pool.ManagedConnPool;
 import org.apache.hc.core5.pool.PoolConcurrencyPolicy;
@@ -181,6 +182,7 @@ public class PoolingAsyncClientConnectionManager implements AsyncClientConnectio
                         DEFAULT_MAX_TOTAL_CONNECTIONS,
                         timeToLive,
                         poolReusePolicy,
+                        new DefaultDisposalCallback<>(),
                         null) {
 
                     @Override


### PR DESCRIPTION
There was a [report](https://lists.apache.org/thread/ll2q7kh0jtffq8j95v5w17w2zty7g6yb) on the dev list recently about clients getting stuck trying to close out a TLS connection while holding a lock on the connection pool, effectively rendering those clients completely disabled. I thought it should not never happen and it turned out I was wrong. The issue was known and got fixed in `core` but the fix never got applied to `client`.

Basically this change-set makes sure the socket timeout is set to 1 second before connections get closed out inside the pool lock.

@arturobernalg  Please double-check.