### PR TITLE
HTTPCLIENT-2261 - Enable HTTP/2 CONNECT tunneling for HTTP/2 clients …

### DIFF
--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/compatibility/ApacheHTTPDCaddyH2CompatibilityIT.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/compatibility/ApacheHTTPDCaddyH2CompatibilityIT.java
@@ -1,0 +1,96 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.client5.testing.compatibility;
+
+import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
+import org.apache.hc.client5.testing.compatibility.async.H2OverH2TunnelCompatibilityTest;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.URIScheme;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers(disabledWithoutDocker = true)
+class ApacheHTTPDCaddyH2CompatibilityIT {
+
+    private static final Network NETWORK = Network.newNetwork();
+    static final GenericContainer<?> HTTPD_CONTAINER = ContainerImages.apacheHttpD(NETWORK);
+    static final GenericContainer<?> CADDY = ContainerImages.caddyH2Proxy(NETWORK);
+
+    @BeforeAll
+    static void startContainers() {
+        HTTPD_CONTAINER.start();
+        CADDY.start();
+    }
+
+    static HttpHost targetInternalTlsHost() {
+        return new HttpHost(URIScheme.HTTPS.id, ContainerImages.WEB_SERVER, ContainerImages.HTTPS_PORT);
+    }
+
+    static HttpHost h2ProxyContainerHost() {
+        return new HttpHost(URIScheme.HTTPS.id, CADDY.getHost(), CADDY.getMappedPort(ContainerImages.H2_PROXY_PORT));
+    }
+
+    static HttpHost h2ProxyPwProtectedContainerHost() {
+        return new HttpHost(URIScheme.HTTPS.id, CADDY.getHost(), CADDY.getMappedPort(ContainerImages.H2_PROXY_PW_PROTECTED_PORT));
+    }
+
+    @AfterAll
+    static void cleanup() {
+        CADDY.close();
+        HTTPD_CONTAINER.close();
+        NETWORK.close();
+    }
+
+    @Nested
+    @DisplayName("H2 client: TLS, connection via H2 proxy (H2-over-H2 tunnel)")
+    class AsyncViaH2Proxy extends H2OverH2TunnelCompatibilityTest {
+
+        public AsyncViaH2Proxy() throws Exception {
+            super(targetInternalTlsHost(), h2ProxyContainerHost(), null);
+        }
+
+    }
+
+    @Nested
+    @DisplayName("H2 client: TLS, connection via password protected H2 proxy (H2-over-H2 tunnel)")
+    class AsyncViaPwProtectedH2Proxy extends H2OverH2TunnelCompatibilityTest {
+
+        public AsyncViaPwProtectedH2Proxy() throws Exception {
+            super(
+                    targetInternalTlsHost(),
+                    h2ProxyPwProtectedContainerHost(),
+                    new UsernamePasswordCredentials("caddy", "nopassword".toCharArray()));
+        }
+
+    }
+
+}

--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/compatibility/ContainerImages.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/compatibility/ContainerImages.java
@@ -48,6 +48,9 @@ public final class ContainerImages {
     public final static String PROXY = "test-proxy";
     public final static int PROXY_PORT = 8888;
     public final static int PROXY_PW_PROTECTED_PORT = 8889;
+    public final static String H2_PROXY = "test-h2-proxy";
+    public final static int H2_PROXY_PORT = 8443;
+    public final static int H2_PROXY_PW_PROTECTED_PORT = 8444;
 
     static final byte[] BYTES = "0123456789ABCDEF".getBytes(StandardCharsets.UTF_8);
 
@@ -114,6 +117,33 @@ public final class ContainerImages {
                 .withLogConsumer(new Slf4jLogConsumer(LOG))
                 .withExposedPorts(PROXY_PORT, PROXY_PW_PROTECTED_PORT);
 
+    }
+
+    /**
+     * Caddy 2 with the {@code forwardproxy} plugin. Provides a TLS-terminated HTTP/2
+     * forward proxy that supports the CONNECT method on two ports: an open one and a
+     * Basic-auth protected one (user {@code caddy}, password {@code nopassword}).
+     */
+    public static GenericContainer<?> caddyH2Proxy(final Network network) {
+        return new GenericContainer<>(new ImageFromDockerfile()
+                .withFileFromClasspath("Caddyfile", "docker/caddy/Caddyfile")
+                .withFileFromClasspath("server-cert.pem", "docker/server-cert.pem")
+                .withFileFromClasspath("server-key.pem", "docker/server-key.pem")
+                .withFileFromString("Dockerfile",
+                        "FROM caddy:2-builder AS builder\n"
+                                + "RUN xcaddy build --with github.com/caddyserver/forwardproxy@caddy2\n"
+                                + "\n"
+                                + "FROM caddy:2\n"
+                                + "COPY --from=builder /usr/bin/caddy /usr/bin/caddy\n"
+                                + "COPY Caddyfile /etc/caddy/Caddyfile\n"
+                                + "COPY server-cert.pem /etc/caddy/server-cert.pem\n"
+                                + "COPY server-key.pem /etc/caddy/server-key.pem\n"
+                                + "EXPOSE " + H2_PROXY_PORT + " " + H2_PROXY_PW_PROTECTED_PORT + "\n"
+                                + "ENTRYPOINT [\"caddy\", \"run\", \"--config\", \"/etc/caddy/Caddyfile\", \"--adapter\", \"caddyfile\"]\n"))
+                .withNetwork(network)
+                .withNetworkAliases(H2_PROXY)
+                .withLogConsumer(new Slf4jLogConsumer(LOG))
+                .withExposedPorts(H2_PROXY_PORT, H2_PROXY_PW_PROTECTED_PORT);
     }
 
 }

--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/compatibility/async/H2OverH2TunnelCompatibilityTest.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/compatibility/async/H2OverH2TunnelCompatibilityTest.java
@@ -1,0 +1,195 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.client5.testing.compatibility.async;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+
+import org.apache.hc.client5.http.ContextBuilder;
+import org.apache.hc.client5.http.async.methods.SimpleHttpRequest;
+import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
+import org.apache.hc.client5.http.async.methods.SimpleRequestBuilder;
+import org.apache.hc.client5.http.auth.AuthScope;
+import org.apache.hc.client5.http.auth.Credentials;
+import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
+import org.apache.hc.client5.testing.Result;
+import org.apache.hc.client5.testing.extension.async.H2AsyncClientResource;
+import org.apache.hc.core5.concurrent.FutureCallback;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.HttpVersion;
+import org.apache.hc.core5.http.RequestNotExecutedException;
+import org.apache.hc.core5.util.Timeout;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public abstract class H2OverH2TunnelCompatibilityTest {
+
+    static final Timeout TIMEOUT = Timeout.ofSeconds(30);
+    static final Timeout LONG_TIMEOUT = Timeout.ofSeconds(60);
+
+    private final HttpHost target;
+    @RegisterExtension
+    private final H2AsyncClientResource clientResource;
+    private final BasicCredentialsProvider credentialsProvider;
+
+    public H2OverH2TunnelCompatibilityTest(
+            final HttpHost target,
+            final HttpHost proxy,
+            final Credentials proxyCreds) throws Exception {
+        this.target = target;
+        this.clientResource = new H2AsyncClientResource(proxy);
+        this.credentialsProvider = new BasicCredentialsProvider();
+        if (proxy != null && proxyCreds != null) {
+            this.credentialsProvider.setCredentials(new AuthScope(proxy), proxyCreds);
+        }
+        this.clientResource.configure(builder -> builder.setDefaultCredentialsProvider(credentialsProvider));
+    }
+
+    CloseableHttpAsyncClient client() {
+        return clientResource.client();
+    }
+
+    HttpClientContext context() {
+        return ContextBuilder.create()
+                .useCredentialsProvider(credentialsProvider)
+                .build();
+    }
+
+    void addCredentials(final AuthScope authScope, final Credentials credentials) {
+        credentialsProvider.setCredentials(authScope, credentials);
+    }
+
+    @Test
+    void test_sequential_gets() throws Exception {
+        final CloseableHttpAsyncClient client = client();
+        final HttpClientContext context = context();
+
+        final String[] requestUris = new String[] {"/111", "/222", "/333"};
+        for (final String requestUri : requestUris) {
+            final SimpleHttpRequest httpGet = SimpleRequestBuilder.get()
+                    .setHttpHost(target)
+                    .setPath(requestUri)
+                    .build();
+            final Future<SimpleHttpResponse> future = client.execute(httpGet, context, null);
+            final SimpleHttpResponse response = future.get(TIMEOUT.getDuration(), TIMEOUT.getTimeUnit());
+            Assertions.assertEquals(HttpStatus.SC_OK, response.getCode());
+            Assertions.assertEquals(HttpVersion.HTTP_2, context.getProtocolVersion());
+        }
+    }
+
+    @Test
+    void test_concurrent_gets() throws Exception {
+        final CloseableHttpAsyncClient client = client();
+
+        final String[] requestUris = new String[] {"/111", "/222", "/333"};
+        final int n = 10;
+        final Queue<Result<Void>> queue = new ConcurrentLinkedQueue<>();
+        final CountDownLatch latch = new CountDownLatch(requestUris.length * n);
+
+        for (int i = 0; i < n; i++) {
+            for (final String requestUri : requestUris) {
+                final SimpleHttpRequest request = SimpleRequestBuilder.get()
+                        .setHttpHost(target)
+                        .setPath(requestUri)
+                        .build();
+                final HttpClientContext context = context();
+                client.execute(request, context, new FutureCallback<SimpleHttpResponse>() {
+
+                    @Override
+                    public void completed(final SimpleHttpResponse response) {
+                        queue.add(new Result<>(request, response, null));
+                        latch.countDown();
+                    }
+
+                    @Override
+                    public void failed(final Exception ex) {
+                        queue.add(new Result<>(request, ex));
+                        latch.countDown();
+                    }
+
+                    @Override
+                    public void cancelled() {
+                        queue.add(new Result<>(request, new RequestNotExecutedException()));
+                        latch.countDown();
+                    }
+
+                });
+            }
+        }
+        Assertions.assertTrue(latch.await(LONG_TIMEOUT.getDuration(), LONG_TIMEOUT.getTimeUnit()));
+        Assertions.assertEquals(requestUris.length * n, queue.size());
+        for (final Result<Void> result : queue) {
+            if (result.isOK()) {
+                Assertions.assertEquals(HttpStatus.SC_OK, result.response.getCode());
+            }
+        }
+    }
+
+    @Test
+    void test_auth_failure_wrong_credentials() throws Exception {
+        addCredentials(
+                new AuthScope(target),
+                new UsernamePasswordCredentials("testuser", "wrong password".toCharArray()));
+        final CloseableHttpAsyncClient client = client();
+        final HttpClientContext context = context();
+
+        final SimpleHttpRequest httpGetSecret = SimpleRequestBuilder.get()
+                .setHttpHost(target)
+                .setPath("/private/big-secret.txt")
+                .build();
+        final Future<SimpleHttpResponse> future = client.execute(httpGetSecret, context, null);
+        final SimpleHttpResponse response = future.get(TIMEOUT.getDuration(), TIMEOUT.getTimeUnit());
+        Assertions.assertEquals(HttpStatus.SC_UNAUTHORIZED, response.getCode());
+        Assertions.assertEquals(HttpVersion.HTTP_2, context.getProtocolVersion());
+    }
+
+    @Test
+    void test_auth_success() throws Exception {
+        addCredentials(
+                new AuthScope(target),
+                new UsernamePasswordCredentials("testuser", "nopassword".toCharArray()));
+        final CloseableHttpAsyncClient client = client();
+        final HttpClientContext context = context();
+
+        final SimpleHttpRequest httpGetSecret = SimpleRequestBuilder.get()
+                .setHttpHost(target)
+                .setPath("/private/big-secret.txt")
+                .build();
+        final Future<SimpleHttpResponse> future = client.execute(httpGetSecret, context, null);
+        final SimpleHttpResponse response = future.get(TIMEOUT.getDuration(), TIMEOUT.getTimeUnit());
+        Assertions.assertEquals(HttpStatus.SC_OK, response.getCode());
+        Assertions.assertEquals(HttpVersion.HTTP_2, context.getProtocolVersion());
+    }
+
+}

--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/async/H2AsyncClientResource.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/async/H2AsyncClientResource.java
@@ -1,0 +1,89 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.hc.client5.testing.extension.async;
+
+import java.io.IOException;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.util.function.Consumer;
+
+import org.apache.hc.client5.http.HttpRoute;
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.client5.http.impl.async.H2AsyncClientBuilder;
+import org.apache.hc.client5.http.routing.HttpRoutePlanner;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.URIScheme;
+import org.apache.hc.core5.http2.ssl.H2ClientTlsStrategy;
+import org.apache.hc.core5.io.CloseMode;
+import org.apache.hc.core5.ssl.SSLContexts;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class H2AsyncClientResource implements AfterEachCallback {
+
+    private final H2AsyncClientBuilder clientBuilder;
+    private CloseableHttpAsyncClient client;
+
+    public H2AsyncClientResource(final HttpHost proxy) throws IOException {
+        try {
+            this.clientBuilder = H2AsyncClientBuilder.create()
+                    .setTlsStrategy(new H2ClientTlsStrategy(SSLContexts.custom()
+                            .loadTrustMaterial(getClass().getResource("/test-ca.keystore"), "nopassword".toCharArray())
+                            .build()));
+        } catch (final CertificateException | NoSuchAlgorithmException | KeyStoreException | KeyManagementException ex) {
+            throw new IllegalStateException(ex);
+        }
+        if (proxy != null) {
+            final HttpRoutePlanner routePlanner = (target, context) ->
+                    new HttpRoute(target, null, proxy, URIScheme.HTTPS.same(target.getSchemeName()));
+            this.clientBuilder.setRoutePlanner(routePlanner);
+        }
+    }
+
+    public void configure(final Consumer<H2AsyncClientBuilder> customizer) {
+        customizer.accept(clientBuilder);
+    }
+
+    @Override
+    public void afterEach(final ExtensionContext extensionContext) {
+        if (client != null) {
+            client.close(CloseMode.GRACEFUL);
+        }
+    }
+
+    public CloseableHttpAsyncClient client() {
+        if (client == null) {
+            client = clientBuilder.build();
+            client.start();
+        }
+        return client;
+    }
+
+}

--- a/httpclient5-testing/src/test/resources/docker/caddy/Caddyfile
+++ b/httpclient5-testing/src/test/resources/docker/caddy/Caddyfile
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==========================================================================
+
+{
+    auto_https off
+    order forward_proxy before file_server
+}
+
+# Open HTTP/2 forward proxy
+:8443 {
+    tls /etc/caddy/server-cert.pem /etc/caddy/server-key.pem
+    forward_proxy {
+        ports 8080 8443
+        acl {
+            allow all
+        }
+    }
+}
+
+# HTTP/2 forward proxy guarded by Basic auth (caddy:nopassword)
+:8444 {
+    tls /etc/caddy/server-cert.pem /etc/caddy/server-key.pem
+    forward_proxy {
+        basic_auth caddy nopassword
+        ports 8080 8443
+        acl {
+            allow all
+        }
+    }
+}

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/async/AsyncExecRuntime.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/async/AsyncExecRuntime.java
@@ -176,6 +176,18 @@ public interface AsyncExecRuntime {
     void markConnectionNonReusable();
 
     /**
+     * Returns the route that has already been established by the connection pool,
+     * or {@code null} if route completion is not handled at the pool level.
+     *
+     * @return the established route, or {@code null}.
+     *
+     * @since 5.7
+     */
+    default HttpRoute getEstablishedRoute() {
+        return null;
+    }
+
+    /**
      * Forks this runtime for parallel execution.
      *
      * @return another runtime with the same configuration.

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/AsyncConnectExec.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/AsyncConnectExec.java
@@ -46,7 +46,6 @@ import org.apache.hc.client5.http.auth.AuthExchange;
 import org.apache.hc.client5.http.auth.AuthenticationException;
 import org.apache.hc.client5.http.auth.ChallengeType;
 import org.apache.hc.client5.http.auth.MalformedChallengeException;
-import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.auth.AuthCacheKeeper;
 import org.apache.hc.client5.http.impl.auth.AuthenticationHandler;
 import org.apache.hc.client5.http.impl.routing.BasicRouteDirector;
@@ -250,6 +249,15 @@ public final class AsyncConnectExec implements AsyncExecChainHandler {
                     public void completed(final AsyncExecRuntime execRuntime) {
                         final HttpHost proxy = route.getProxyHost();
                         tracker.connectProxy(proxy, route.isSecure() && !route.isTunnelled());
+                        if (route.isTunnelled() && execRuntime.getEstablishedRoute() != null) {
+                            if (LOG.isDebugEnabled()) {
+                                LOG.debug("{} tunnel to target already established by connection pool", exchangeId);
+                            }
+                            tracker.tunnelTarget(false);
+                            if (route.isLayered()) {
+                                tracker.layerProtocol(route.isSecure());
+                            }
+                        }
                         if (LOG.isDebugEnabled()) {
                             LOG.debug("{} connected to proxy", exchangeId);
                         }
@@ -519,31 +527,8 @@ public final class AsyncConnectExec implements AsyncExecChainHandler {
             final HttpHost proxy,
             final HttpResponse response,
             final HttpClientContext context) throws AuthenticationException, MalformedChallengeException {
-        final RequestConfig config = context.getRequestConfigOrDefault();
-        if (config.isAuthenticationEnabled()) {
-            final boolean proxyAuthRequested = authenticator.isChallenged(proxy, ChallengeType.PROXY, response, proxyAuthExchange, context);
-            final boolean proxyMutualAuthRequired = authenticator.isChallengeExpected(proxyAuthExchange);
-
-            if (authCacheKeeper != null) {
-                if (proxyAuthRequested) {
-                    authCacheKeeper.updateOnChallenge(proxy, null, proxyAuthExchange, context);
-                } else {
-                    authCacheKeeper.updateOnNoChallenge(proxy, null, proxyAuthExchange, context);
-                }
-            }
-
-            if (proxyAuthRequested || proxyMutualAuthRequired) {
-                final boolean updated = authenticator.handleResponse(proxy, ChallengeType.PROXY, response,
-                        proxyAuthStrategy, proxyAuthExchange, context);
-
-                if (authCacheKeeper != null) {
-                    authCacheKeeper.updateOnResponse(proxy, null, proxyAuthExchange, context);
-                }
-
-                return updated;
-            }
-        }
-        return false;
+        return authenticator.needProxyAuthentication(
+                proxyAuthExchange, proxy, response, proxyAuthStrategy, authCacheKeeper, context);
     }
 
     private void proceedConnected(

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/H2AsyncClientBuilder.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/H2AsyncClientBuilder.java
@@ -840,9 +840,12 @@ public class H2AsyncClientBuilder {
                 new H2AsyncMainClientExec(httpProcessor),
                 ChainElement.MAIN_TRANSPORT.name());
 
+        final HttpProcessor proxyConnectHttpProcessor =
+                new DefaultHttpProcessor(new RequestTargetHost(), new RequestUserAgent(userAgentCopy));
+
         execChainDefinition.addFirst(
                 new AsyncConnectExec(
-                        new DefaultHttpProcessor(new RequestTargetHost(), new RequestUserAgent(userAgentCopy)),
+                        proxyConnectHttpProcessor,
                         proxyAuthStrategyCopy,
                         schemePortResolver != null ? schemePortResolver : DefaultSchemePortResolver.INSTANCE,
                         authCachingDisabled),
@@ -971,7 +974,21 @@ public class H2AsyncClientBuilder {
         }
 
         final MultihomeConnectionInitiator connectionInitiator = new MultihomeConnectionInitiator(ioReactor, dnsResolver);
-        final InternalH2ConnPool connPool = new InternalH2ConnPool(connectionInitiator, host -> null, tlsStrategyCopy);
+        final H2RouteOperator routeOperator = new H2RouteOperator(
+                tlsStrategyCopy,
+                new H2TunnelProtocolStarter(h2Config, charCodingConfig),
+                proxyConnectHttpProcessor,
+                proxyAuthStrategyCopy,
+                schemePortResolver != null ? schemePortResolver : DefaultSchemePortResolver.INSTANCE,
+                authCachingDisabled,
+                authSchemeRegistryCopy,
+                credentialsProviderCopy,
+                defaultRequestConfig);
+        final InternalH2ConnPool connPool = new InternalH2ConnPool(
+                connectionInitiator,
+                host -> null,
+                tlsStrategyCopy,
+                routeOperator);
         connPool.setConnectionConfigResolver(connectionConfigResolver);
 
         List<Closeable> closeablesCopy = closeables != null ? new ArrayList<>(closeables) : null;

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/H2OverH2TunnelExchangeHandler.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/H2OverH2TunnelExchangeHandler.java
@@ -1,0 +1,323 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.client5.http.impl.async;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.hc.core5.concurrent.FutureCallback;
+import org.apache.hc.core5.http.ConnectionClosedException;
+import org.apache.hc.core5.http.EntityDetails;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpException;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.HttpRequestInterceptor;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.Method;
+import org.apache.hc.core5.http.StreamControl;
+import org.apache.hc.core5.http.impl.BasicEntityDetails;
+import org.apache.hc.core5.http.message.BasicHttpRequest;
+import org.apache.hc.core5.http.nio.AsyncClientExchangeHandler;
+import org.apache.hc.core5.http.nio.CapacityChannel;
+import org.apache.hc.core5.http.nio.DataStreamChannel;
+import org.apache.hc.core5.http.nio.RequestChannel;
+import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
+import org.apache.hc.core5.http.protocol.HttpContext;
+import org.apache.hc.core5.io.CloseMode;
+import org.apache.hc.core5.net.NamedEndpoint;
+import org.apache.hc.core5.net.URIAuthority;
+import org.apache.hc.core5.reactor.IOEventHandler;
+import org.apache.hc.core5.reactor.IOEventHandlerFactory;
+import org.apache.hc.core5.reactor.IOSession;
+import org.apache.hc.core5.reactor.ProtocolIOSession;
+import org.apache.hc.core5.reactor.ssl.TransportSecurityLayer;
+import org.apache.hc.core5.util.Timeout;
+
+/**
+ * Exchange handler that establishes an HTTP/2 CONNECT tunnel and exposes
+ * the resulting data stream as a {@link ProtocolIOSession}.
+ *
+ * @since 5.7
+ */
+final class H2OverH2TunnelExchangeHandler implements AsyncClientExchangeHandler {
+
+    private final IOSession physicalSession;
+    private final NamedEndpoint targetEndpoint;
+    private final Timeout connectTimeout;
+    private final boolean secure;
+    private final TlsStrategy tlsStrategy;
+    private final HttpRequestInterceptor connectRequestInterceptor;
+    private final IOEventHandlerFactory protocolStarter;
+    private final FutureCallback<ProtocolIOSession> callback;
+
+    private final AtomicBoolean done;
+    private final AtomicBoolean requestEndStreamSent;
+
+    private volatile DataStreamChannel dataChannel;
+    private volatile CapacityChannel capacityChannel;
+    private volatile StreamControl streamControl;
+    private volatile H2TunnelProtocolIOSession tunnelSession;
+    private volatile TunnelRefusedException tunnelRefusedException;
+
+    H2OverH2TunnelExchangeHandler(
+            final IOSession physicalSession,
+            final NamedEndpoint targetEndpoint,
+            final Timeout connectTimeout,
+            final boolean secure,
+            final TlsStrategy tlsStrategy,
+            final HttpRequestInterceptor connectRequestInterceptor,
+            final IOEventHandlerFactory protocolStarter,
+            final FutureCallback<ProtocolIOSession> callback) {
+        this.physicalSession = physicalSession;
+        this.targetEndpoint = targetEndpoint;
+        this.connectTimeout = connectTimeout;
+        this.secure = secure;
+        this.tlsStrategy = tlsStrategy;
+        this.connectRequestInterceptor = connectRequestInterceptor;
+        this.protocolStarter = protocolStarter;
+        this.callback = callback;
+        this.done = new AtomicBoolean(false);
+        this.requestEndStreamSent = new AtomicBoolean(false);
+    }
+
+    void initiated(final StreamControl streamControl) {
+        this.streamControl = streamControl;
+        final H2TunnelProtocolIOSession tunnel = this.tunnelSession;
+        if (tunnel != null) {
+            tunnel.bindStreamControl(streamControl);
+        }
+    }
+
+    @Override
+    public void releaseResources() {
+    }
+
+    @Override
+    public void failed(final Exception cause) {
+        fail(cause);
+    }
+
+    @Override
+    public void cancel() {
+        fail(new ConnectionClosedException("Tunnel setup cancelled"));
+    }
+
+    @Override
+    public void produceRequest(final RequestChannel requestChannel, final HttpContext context) throws HttpException, IOException {
+        final HttpRequest connectRequest = new BasicHttpRequest(Method.CONNECT.name(), (String) null);
+        connectRequest.setAuthority(new URIAuthority(targetEndpoint));
+        if (connectRequestInterceptor != null) {
+            connectRequestInterceptor.process(connectRequest, null, context);
+        }
+        requestChannel.sendRequest(connectRequest, new BasicEntityDetails(-1, null), context);
+    }
+
+    @Override
+    public int available() {
+        final TunnelRefusedException tunnelRefusedException = this.tunnelRefusedException;
+        if (tunnelRefusedException != null && !requestEndStreamSent.get()) {
+            return 1;
+        }
+        final H2TunnelProtocolIOSession tunnel = this.tunnelSession;
+        return tunnel != null ? tunnel.available() : 0;
+    }
+
+    @Override
+    public void produce(final DataStreamChannel channel) throws IOException {
+        this.dataChannel = channel;
+        final TunnelRefusedException tunnelRefusedException = this.tunnelRefusedException;
+        if (tunnelRefusedException != null) {
+            endRequestStream();
+            return;
+        }
+        final H2TunnelProtocolIOSession tunnel = this.tunnelSession;
+        if (tunnel != null) {
+            tunnel.attachChannel(channel);
+            tunnel.onOutputReady();
+        }
+    }
+
+    @Override
+    public void consumeInformation(final HttpResponse response, final HttpContext context) {
+    }
+
+    @Override
+    public void consumeResponse(
+            final HttpResponse response,
+            final EntityDetails entityDetails,
+            final HttpContext context) throws HttpException, IOException {
+
+        final int status = response.getCode();
+        if (status < 200 || status >= 300) {
+            final TunnelRefusedException tunnelRefusedException = new TunnelRefusedException(response);
+            this.tunnelRefusedException = tunnelRefusedException;
+            endRequestStream();
+            if (entityDetails == null) {
+                failTunnelRefused(tunnelRefusedException);
+            }
+            return;
+        }
+
+        if (entityDetails == null) {
+            throw new HttpException("CONNECT response does not provide a tunneled data stream");
+        }
+
+        if (this.tunnelSession != null) {
+            return;
+        }
+
+        final H2TunnelProtocolIOSession tunnel =
+                new H2TunnelProtocolIOSession(physicalSession, targetEndpoint, connectTimeout, streamControl);
+
+        final DataStreamChannel currentChannel = this.dataChannel;
+        if (currentChannel != null) {
+            tunnel.attachChannel(currentChannel);
+        }
+        final CapacityChannel currentCapacity = this.capacityChannel;
+        if (currentCapacity != null) {
+            tunnel.updateCapacityChannel(currentCapacity);
+        }
+        this.tunnelSession = tunnel;
+
+        if (secure) {
+            tlsStrategy.upgrade(
+                    tunnel,
+                    targetEndpoint,
+                    null,
+                    connectTimeout,
+                    new FutureCallback<TransportSecurityLayer>() {
+
+                        @Override
+                        public void completed(final TransportSecurityLayer transportSecurityLayer) {
+                            try {
+                                startProtocol(tunnel);
+                                complete(tunnel);
+                            } catch (final Exception ex) {
+                                fail(ex);
+                            }
+                        }
+
+                        @Override
+                        public void failed(final Exception ex) {
+                            fail(ex);
+                        }
+
+                        @Override
+                        public void cancelled() {
+                            fail(new ConnectionClosedException("Tunnel TLS upgrade cancelled"));
+                        }
+                    });
+        } else {
+            startProtocol(tunnel);
+            complete(tunnel);
+        }
+    }
+
+    private void startProtocol(final H2TunnelProtocolIOSession tunnel) throws IOException {
+        if (protocolStarter == null) {
+            return;
+        }
+        final IOEventHandler protocolHandler = protocolStarter.createHandler(tunnel, null);
+        tunnel.upgrade(protocolHandler);
+        protocolHandler.connected(tunnel);
+    }
+
+    @Override
+    public void updateCapacity(final CapacityChannel capacityChannel) throws IOException {
+        this.capacityChannel = capacityChannel;
+        final H2TunnelProtocolIOSession tunnel = this.tunnelSession;
+        if (tunnel != null) {
+            tunnel.updateCapacityChannel(capacityChannel);
+        }
+    }
+
+    @Override
+    public void consume(final ByteBuffer src) throws IOException {
+        final H2TunnelProtocolIOSession tunnel = this.tunnelSession;
+        if (tunnel != null && src != null && src.hasRemaining()) {
+            tunnel.onInput(src);
+        }
+    }
+
+    @Override
+    public void streamEnd(final List<? extends Header> trailers) throws IOException {
+        final H2TunnelProtocolIOSession tunnel = this.tunnelSession;
+        if (tunnel != null) {
+            tunnel.onRemoteStreamEnd();
+            return;
+        }
+        final TunnelRefusedException tunnelRefusedException = this.tunnelRefusedException;
+        if (tunnelRefusedException != null) {
+            failTunnelRefused(tunnelRefusedException);
+            return;
+        }
+        closeTransport(CloseMode.GRACEFUL);
+        if (done.compareAndSet(false, true) && callback != null) {
+            callback.failed(new ConnectionClosedException("Tunnel stream closed before establishment"));
+        }
+    }
+
+    private void endRequestStream() throws IOException {
+        final DataStreamChannel currentDataChannel = this.dataChannel;
+        if (currentDataChannel != null && requestEndStreamSent.compareAndSet(false, true)) {
+            currentDataChannel.endStream(null);
+        }
+    }
+
+    private void failTunnelRefused(final TunnelRefusedException tunnelRefusedException) {
+        if (done.compareAndSet(false, true) && callback != null) {
+            callback.failed(tunnelRefusedException);
+        }
+    }
+
+    private void closeTransport(final CloseMode closeMode) {
+        final H2TunnelProtocolIOSession tunnel = this.tunnelSession;
+        if (tunnel != null) {
+            tunnel.close(closeMode);
+            return;
+        }
+        final StreamControl currentStreamControl = this.streamControl;
+        if (currentStreamControl != null) {
+            currentStreamControl.cancel();
+        }
+    }
+
+    private void fail(final Exception cause) {
+        closeTransport(CloseMode.IMMEDIATE);
+        if (done.compareAndSet(false, true) && callback != null) {
+            callback.failed(cause);
+        }
+    }
+
+    private void complete(final H2TunnelProtocolIOSession tunnel) {
+        if (done.compareAndSet(false, true) && callback != null) {
+            callback.completed(tunnel);
+        }
+    }
+}

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/H2OverH2TunnelSupport.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/H2OverH2TunnelSupport.java
@@ -1,0 +1,223 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.client5.http.impl.async;
+
+import org.apache.hc.core5.annotation.Contract;
+import org.apache.hc.core5.annotation.ThreadingBehavior;
+import org.apache.hc.core5.concurrent.FutureCallback;
+import org.apache.hc.core5.http.HttpRequestInterceptor;
+import org.apache.hc.core5.http.nio.command.RequestExecutionCommand;
+import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
+import org.apache.hc.core5.http.protocol.HttpCoreContext;
+import org.apache.hc.core5.io.CloseMode;
+import org.apache.hc.core5.net.NamedEndpoint;
+import org.apache.hc.core5.reactor.Command;
+import org.apache.hc.core5.reactor.IOEventHandlerFactory;
+import org.apache.hc.core5.reactor.IOSession;
+import org.apache.hc.core5.reactor.ProtocolIOSession;
+import org.apache.hc.core5.util.Args;
+import org.apache.hc.core5.util.Timeout;
+
+/**
+ * Helper for establishing HTTP/2 CONNECT tunnels through HTTP/2 proxies.
+ * <p>
+ * Multiplexing-safe: tunnel close affects only the CONNECT stream,
+ * not the underlying physical HTTP/2 connection.
+ * </p>
+ * <p>
+ * This helper does not handle proxy authentication (407 retries).
+ * That responsibility belongs to client implementations that maintain
+ * authentication state.
+ * </p>
+ *
+ * @since 5.7
+ */
+@Contract(threading = ThreadingBehavior.STATELESS)
+public final class H2OverH2TunnelSupport {
+
+    private H2OverH2TunnelSupport() {
+    }
+
+    /**
+     * Establishes a CONNECT tunnel and returns the resulting {@link ProtocolIOSession}
+     * via the callback. The tunnel session supports optional TLS upgrade.
+     *
+     * @param proxySession   the HTTP/2 session to the proxy
+     * @param target         the target endpoint for the CONNECT request authority
+     * @param connectTimeout timeout for the CONNECT handshake
+     * @param secure         whether to upgrade the tunnel to TLS after establishment
+     * @param tlsStrategy    TLS strategy for the upgrade (required when {@code secure} is true)
+     * @param callback       completion callback receiving the tunnel session
+     * @since 5.7
+     */
+    public static void establish(
+            final IOSession proxySession,
+            final NamedEndpoint target,
+            final Timeout connectTimeout,
+            final boolean secure,
+            final TlsStrategy tlsStrategy,
+            final FutureCallback<ProtocolIOSession> callback) {
+        establishInternal(proxySession, target, connectTimeout, secure, tlsStrategy, null, null, callback);
+    }
+
+    /**
+     * Establishes a CONNECT tunnel with a request interceptor for injecting
+     * headers (e.g. proxy authentication) into the CONNECT request.
+     *
+     * @param proxySession               the HTTP/2 session to the proxy
+     * @param target                     the target endpoint for the CONNECT request authority
+     * @param connectTimeout             timeout for the CONNECT handshake
+     * @param secure                     whether to upgrade the tunnel to TLS after establishment
+     * @param tlsStrategy                TLS strategy for the upgrade (required when {@code secure} is true)
+     * @param connectRequestInterceptor  interceptor applied to the CONNECT request before sending
+     * @param callback                   completion callback receiving the tunnel session
+     * @since 5.7
+     */
+    public static void establish(
+            final IOSession proxySession,
+            final NamedEndpoint target,
+            final Timeout connectTimeout,
+            final boolean secure,
+            final TlsStrategy tlsStrategy,
+            final HttpRequestInterceptor connectRequestInterceptor,
+            final FutureCallback<ProtocolIOSession> callback) {
+        establishInternal(proxySession, target, connectTimeout, secure, tlsStrategy, connectRequestInterceptor, null, callback);
+    }
+
+    /**
+     * Establishes a CONNECT tunnel and starts a protocol handler inside it.
+     * The protocol starter factory creates an {@link org.apache.hc.core5.reactor.IOEventHandler}
+     * that is connected to the tunnel session immediately after establishment.
+     *
+     * @param proxySession    the HTTP/2 session to the proxy
+     * @param target          the target endpoint for the CONNECT request authority
+     * @param connectTimeout  timeout for the CONNECT handshake
+     * @param secure          whether to upgrade the tunnel to TLS after establishment
+     * @param tlsStrategy     TLS strategy for the upgrade (required when {@code secure} is true)
+     * @param protocolStarter factory for the protocol handler to run inside the tunnel
+     * @param callback        completion callback receiving the tunnel session
+     * @since 5.7
+     */
+    public static void establish(
+            final IOSession proxySession,
+            final NamedEndpoint target,
+            final Timeout connectTimeout,
+            final boolean secure,
+            final TlsStrategy tlsStrategy,
+            final IOEventHandlerFactory protocolStarter,
+            final FutureCallback<IOSession> callback) {
+        establish(proxySession, target, connectTimeout, secure, tlsStrategy, null, protocolStarter, callback);
+    }
+
+    /**
+     * Establishes a CONNECT tunnel with both a request interceptor and a protocol starter.
+     * This is the most general overload combining proxy authentication support with
+     * automatic protocol initialization inside the tunnel.
+     *
+     * @param proxySession               the HTTP/2 session to the proxy
+     * @param target                     the target endpoint for the CONNECT request authority
+     * @param connectTimeout             timeout for the CONNECT handshake
+     * @param secure                     whether to upgrade the tunnel to TLS after establishment
+     * @param tlsStrategy                TLS strategy for the upgrade (required when {@code secure} is true)
+     * @param connectRequestInterceptor  interceptor applied to the CONNECT request before sending
+     * @param protocolStarter            factory for the protocol handler to run inside the tunnel
+     * @param callback                   completion callback receiving the tunnel session
+     * @since 5.7
+     */
+    public static void establish(
+            final IOSession proxySession,
+            final NamedEndpoint target,
+            final Timeout connectTimeout,
+            final boolean secure,
+            final TlsStrategy tlsStrategy,
+            final HttpRequestInterceptor connectRequestInterceptor,
+            final IOEventHandlerFactory protocolStarter,
+            final FutureCallback<IOSession> callback) {
+
+        final FutureCallback<ProtocolIOSession> adapter = callback != null ? new FutureCallback<ProtocolIOSession>() {
+
+            @Override
+            public void completed(final ProtocolIOSession result) {
+                callback.completed(result);
+            }
+
+            @Override
+            public void failed(final Exception ex) {
+                callback.failed(ex);
+            }
+
+            @Override
+            public void cancelled() {
+                callback.cancelled();
+            }
+
+        } : null;
+
+        establishInternal(proxySession, target, connectTimeout, secure, tlsStrategy, connectRequestInterceptor, protocolStarter, adapter);
+    }
+
+    private static void establishInternal(
+            final IOSession proxySession,
+            final NamedEndpoint target,
+            final Timeout connectTimeout,
+            final boolean secure,
+            final TlsStrategy tlsStrategy,
+            final HttpRequestInterceptor connectRequestInterceptor,
+            final IOEventHandlerFactory protocolStarter,
+            final FutureCallback<ProtocolIOSession> callback) {
+
+        Args.notNull(proxySession, "Proxy I/O session");
+        Args.notNull(target, "Tunnel target endpoint");
+        if (secure) {
+            Args.notNull(tlsStrategy, "TLS strategy");
+        }
+
+        final H2OverH2TunnelExchangeHandler exchangeHandler = new H2OverH2TunnelExchangeHandler(
+                proxySession,
+                target,
+                connectTimeout,
+                secure,
+                tlsStrategy,
+                connectRequestInterceptor,
+                protocolStarter,
+                callback);
+
+        proxySession.enqueue(
+                new RequestExecutionCommand(
+                        exchangeHandler,
+                        null,
+                        HttpCoreContext.create(),
+                        exchangeHandler::initiated),
+                Command.Priority.NORMAL);
+    }
+
+    static void closeQuietly(final ProtocolIOSession session) {
+        if (session != null) {
+            session.close(CloseMode.IMMEDIATE);
+        }
+    }
+}

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/H2RouteOperator.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/H2RouteOperator.java
@@ -1,0 +1,255 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.client5.http.impl.async;
+
+import org.apache.hc.client5.http.AuthenticationStrategy;
+import org.apache.hc.client5.http.HttpRoute;
+import org.apache.hc.client5.http.SchemePortResolver;
+import org.apache.hc.client5.http.auth.AuthExchange;
+import org.apache.hc.client5.http.auth.AuthSchemeFactory;
+import org.apache.hc.client5.http.auth.AuthenticationException;
+import org.apache.hc.client5.http.auth.ChallengeType;
+import org.apache.hc.client5.http.auth.CredentialsProvider;
+import org.apache.hc.client5.http.auth.MalformedChallengeException;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.auth.AuthCacheKeeper;
+import org.apache.hc.client5.http.impl.auth.AuthenticationHandler;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
+import org.apache.hc.core5.annotation.Internal;
+import org.apache.hc.core5.concurrent.FutureCallback;
+import org.apache.hc.core5.http.HttpException;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.config.Lookup;
+import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
+import org.apache.hc.core5.http.protocol.HttpProcessor;
+import org.apache.hc.core5.net.NamedEndpoint;
+import org.apache.hc.core5.reactor.IOEventHandlerFactory;
+import org.apache.hc.core5.reactor.IOSession;
+import org.apache.hc.core5.util.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Completes an HTTP/2 route by establishing a CONNECT tunnel through the proxy
+ * and optionally upgrading to TLS. Handles proxy authentication with bounded retry.
+ *
+ * @since 5.7
+ */
+@Internal
+final class H2RouteOperator {
+
+    private static final Logger LOG = LoggerFactory.getLogger(H2RouteOperator.class);
+    private static final int MAX_TUNNEL_AUTH_ATTEMPTS = 3;
+
+    private final TlsStrategy tlsStrategy;
+    private final IOEventHandlerFactory tunnelProtocolStarter;
+    private final HttpProcessor proxyHttpProcessor;
+    private final AuthenticationStrategy proxyAuthStrategy;
+    private final AuthenticationHandler authenticator;
+    private final AuthCacheKeeper authCacheKeeper;
+    private final Lookup<AuthSchemeFactory> authSchemeRegistry;
+    private final CredentialsProvider credentialsProvider;
+    private final RequestConfig defaultRequestConfig;
+
+    H2RouteOperator(
+            final TlsStrategy tlsStrategy,
+            final IOEventHandlerFactory tunnelProtocolStarter) {
+        this(tlsStrategy, tunnelProtocolStarter, null, null, null, true, null, null, null);
+    }
+
+    H2RouteOperator(
+            final TlsStrategy tlsStrategy,
+            final IOEventHandlerFactory tunnelProtocolStarter,
+            final HttpProcessor proxyHttpProcessor,
+            final AuthenticationStrategy proxyAuthStrategy,
+            final SchemePortResolver schemePortResolver,
+            final boolean authCachingDisabled,
+            final Lookup<AuthSchemeFactory> authSchemeRegistry,
+            final CredentialsProvider credentialsProvider,
+            final RequestConfig defaultRequestConfig) {
+        this.tlsStrategy = tlsStrategy;
+        this.tunnelProtocolStarter = tunnelProtocolStarter;
+        this.proxyHttpProcessor = proxyHttpProcessor;
+        this.proxyAuthStrategy = proxyAuthStrategy;
+        this.authenticator = proxyHttpProcessor != null && proxyAuthStrategy != null
+                ? new AuthenticationHandler() : null;
+        this.authCacheKeeper = proxyHttpProcessor != null && proxyAuthStrategy != null
+                && !authCachingDisabled && schemePortResolver != null
+                ? new AuthCacheKeeper(schemePortResolver)
+                : null;
+        this.authSchemeRegistry = authSchemeRegistry;
+        this.credentialsProvider = credentialsProvider;
+        this.defaultRequestConfig = defaultRequestConfig != null ? defaultRequestConfig : RequestConfig.DEFAULT;
+    }
+
+    void completeRoute(
+            final HttpRoute route,
+            final Timeout connectTimeout,
+            final IOSession ioSession,
+            final FutureCallback<IOSession> callback) {
+        if (!route.isTunnelled()) {
+            callback.completed(ioSession);
+            return;
+        }
+        if (route.getHopCount() > 2) {
+            callback.failed(new HttpException("Proxy chains are not supported for HTTP/2 CONNECT tunneling"));
+            return;
+        }
+        if (tunnelProtocolStarter == null) {
+            callback.failed(new IllegalStateException("HTTP/2 tunnel protocol starter not configured"));
+            return;
+        }
+        if (route.isLayered() && tlsStrategy == null) {
+            callback.failed(new IllegalStateException("TLS strategy not configured"));
+            return;
+        }
+        final NamedEndpoint targetEndpoint = route.getTargetName() != null
+                ? route.getTargetName() : route.getTargetHost();
+        final HttpHost proxy = route.getProxyHost();
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("{} establishing H2 tunnel to {} via {}", ioSession.getId(), targetEndpoint, proxy);
+        }
+        if (proxy != null && proxyHttpProcessor != null && proxyAuthStrategy != null && authenticator != null) {
+            establishTunnelWithAuth(route, ioSession, targetEndpoint, proxy, connectTimeout, callback);
+        } else {
+            H2OverH2TunnelSupport.establish(
+                    ioSession,
+                    targetEndpoint,
+                    connectTimeout,
+                    route.isLayered(),
+                    tlsStrategy,
+                    tunnelProtocolStarter,
+                    callback);
+        }
+    }
+
+    private void establishTunnelWithAuth(
+            final HttpRoute route,
+            final IOSession ioSession,
+            final NamedEndpoint targetEndpoint,
+            final HttpHost proxy,
+            final Timeout connectTimeout,
+            final FutureCallback<IOSession> callback) {
+        final HttpClientContext tunnelContext = HttpClientContext.create();
+        if (authSchemeRegistry != null) {
+            tunnelContext.setAuthSchemeRegistry(authSchemeRegistry);
+        }
+        if (credentialsProvider != null) {
+            tunnelContext.setCredentialsProvider(credentialsProvider);
+        }
+        tunnelContext.setRequestConfig(defaultRequestConfig);
+
+        final AuthExchange proxyAuthExchange = tunnelContext.getAuthExchange(proxy);
+        if (authCacheKeeper != null) {
+            authCacheKeeper.loadPreemptively(proxy, null, proxyAuthExchange, tunnelContext);
+        }
+        establishTunnelWithAuthAttempt(
+                route, ioSession, targetEndpoint, proxy, connectTimeout,
+                callback, tunnelContext, proxyAuthExchange, 1);
+    }
+
+    private void establishTunnelWithAuthAttempt(
+            final HttpRoute route,
+            final IOSession ioSession,
+            final NamedEndpoint targetEndpoint,
+            final HttpHost proxy,
+            final Timeout connectTimeout,
+            final FutureCallback<IOSession> callback,
+            final HttpClientContext tunnelContext,
+            final AuthExchange proxyAuthExchange,
+            final int attemptCount) {
+        H2OverH2TunnelSupport.establish(
+                ioSession,
+                targetEndpoint,
+                connectTimeout,
+                route.isLayered(),
+                tlsStrategy,
+                (request, entityDetails, context) -> {
+                    proxyHttpProcessor.process(request, null, tunnelContext);
+                    authenticator.addAuthResponse(proxy, ChallengeType.PROXY, request, proxyAuthExchange, tunnelContext);
+                },
+                tunnelProtocolStarter,
+                new FutureCallback<IOSession>() {
+
+                    @Override
+                    public void completed(final IOSession result) {
+                        callback.completed(result);
+                    }
+
+                    @Override
+                    public void failed(final Exception ex) {
+                        if (!(ex instanceof TunnelRefusedException)) {
+                            callback.failed(ex);
+                            return;
+                        }
+                        final TunnelRefusedException tunnelRefusedException = (TunnelRefusedException) ex;
+                        final HttpResponse response = tunnelRefusedException.getResponse();
+                        if (response.getCode() != HttpStatus.SC_PROXY_AUTHENTICATION_REQUIRED
+                                || attemptCount >= MAX_TUNNEL_AUTH_ATTEMPTS) {
+                            callback.failed(ex);
+                            return;
+                        }
+                        try {
+                            proxyHttpProcessor.process(response, null, tunnelContext);
+                            final boolean retry = needAuthentication(
+                                    proxyAuthExchange, proxy, response, tunnelContext);
+                            if (retry) {
+                                if (LOG.isDebugEnabled()) {
+                                    LOG.debug("{} tunnel auth challenge from {}; attempt {}/{}",
+                                            ioSession.getId(), proxy, attemptCount, MAX_TUNNEL_AUTH_ATTEMPTS);
+                                }
+                                establishTunnelWithAuthAttempt(
+                                        route, ioSession, targetEndpoint, proxy, connectTimeout,
+                                        callback, tunnelContext, proxyAuthExchange, attemptCount + 1);
+                            } else {
+                                callback.failed(ex);
+                            }
+                        } catch (final Exception ioEx) {
+                            callback.failed(ioEx);
+                        }
+                    }
+
+                    @Override
+                    public void cancelled() {
+                        callback.cancelled();
+                    }
+
+                });
+    }
+
+    private boolean needAuthentication(
+            final AuthExchange proxyAuthExchange,
+            final HttpHost proxy,
+            final HttpResponse response,
+            final HttpClientContext context) throws AuthenticationException, MalformedChallengeException {
+        return authenticator.needProxyAuthentication(
+                proxyAuthExchange, proxy, response, proxyAuthStrategy, authCacheKeeper, context);
+    }
+
+}

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/H2TunnelProtocolIOSession.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/H2TunnelProtocolIOSession.java
@@ -1,0 +1,401 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.client5.http.impl.async;
+
+import java.io.IOException;
+import java.net.SocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.ByteChannel;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Lock;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSession;
+
+import org.apache.hc.core5.concurrent.CallbackContribution;
+import org.apache.hc.core5.concurrent.FutureCallback;
+import org.apache.hc.core5.http.StreamControl;
+import org.apache.hc.core5.http.nio.CapacityChannel;
+import org.apache.hc.core5.http.nio.DataStreamChannel;
+import org.apache.hc.core5.io.CloseMode;
+import org.apache.hc.core5.net.NamedEndpoint;
+import org.apache.hc.core5.reactor.Command;
+import org.apache.hc.core5.reactor.IOEventHandler;
+import org.apache.hc.core5.reactor.IOSession;
+import org.apache.hc.core5.reactor.ProtocolIOSession;
+import org.apache.hc.core5.reactor.ssl.SSLBufferMode;
+import org.apache.hc.core5.reactor.ssl.SSLIOSession;
+import org.apache.hc.core5.reactor.ssl.SSLMode;
+import org.apache.hc.core5.reactor.ssl.SSLSessionInitializer;
+import org.apache.hc.core5.reactor.ssl.SSLSessionVerifier;
+import org.apache.hc.core5.reactor.ssl.TlsDetails;
+import org.apache.hc.core5.reactor.ssl.TransportSecurityLayer;
+import org.apache.hc.core5.util.Timeout;
+
+/**
+ * {@link ProtocolIOSession} backed by a single HTTP/2 CONNECT stream.
+ * <p>
+ * Supports optional TLS upgrade via {@link #startTls} for establishing
+ * secure tunnels to the target endpoint.
+ * </p>
+ *
+ * @since 5.7
+ */
+final class H2TunnelProtocolIOSession implements ProtocolIOSession {
+
+    private static final IOEventHandler NOOP_HANDLER = new IOEventHandler() {
+
+        @Override
+        public void connected(final IOSession session) {
+        }
+
+        @Override
+        public void inputReady(final IOSession session, final ByteBuffer src) {
+        }
+
+        @Override
+        public void outputReady(final IOSession session) {
+        }
+
+        @Override
+        public void timeout(final IOSession session, final Timeout timeout) {
+        }
+
+        @Override
+        public void exception(final IOSession session, final Exception cause) {
+        }
+
+        @Override
+        public void disconnected(final IOSession session) {
+        }
+    };
+
+    private final NamedEndpoint initialEndpoint;
+    private final H2TunnelRawIOSession ioSession;
+    private final AtomicReference<SSLIOSession> tlsSessionRef;
+    private final AtomicReference<IOSession> currentSessionRef;
+
+    H2TunnelProtocolIOSession(
+            final IOSession physicalSession,
+            final NamedEndpoint initialEndpoint,
+            final Timeout socketTimeout,
+            final StreamControl streamControl) {
+        this.initialEndpoint = initialEndpoint;
+        this.ioSession = new H2TunnelRawIOSession(physicalSession, socketTimeout, streamControl);
+        this.tlsSessionRef = new AtomicReference<>();
+        this.currentSessionRef = new AtomicReference<>(ioSession);
+        this.ioSession.upgrade(NOOP_HANDLER);
+    }
+
+    void bindStreamControl(final StreamControl streamControl) {
+        ioSession.bindStreamControl(streamControl);
+    }
+
+    void attachChannel(final DataStreamChannel channel) {
+        ioSession.attachChannel(channel);
+    }
+
+    void updateCapacityChannel(final CapacityChannel capacityChannel) throws IOException {
+        ioSession.updateCapacityChannel(capacityChannel);
+    }
+
+    int available() {
+        return ioSession.available();
+    }
+
+    void onInput(final ByteBuffer src) throws IOException {
+        final ByteBuffer handlerSrc = src != null ? src.asReadOnlyBuffer() : null;
+
+        ioSession.appendInput(src);
+
+        final IOSession currentSession = currentSessionRef.get();
+        final IOEventHandler handler = currentSession.getHandler();
+        if (handler != null) {
+            if (currentSession == ioSession) {
+                handler.inputReady(currentSession, handlerSrc);
+                if (handlerSrc != null) {
+                    final int consumed = handlerSrc.position();
+                    if (consumed > 0) {
+                        ioSession.discardInbound(consumed);
+                    }
+                }
+            } else {
+                driveWrappedInput(currentSession, handler);
+            }
+        }
+
+        if (ioSession.available() > 0) {
+            ioSession.requestOutput();
+        }
+    }
+
+    private void driveWrappedInput(final IOSession currentSession, final IOEventHandler handler) throws IOException {
+        for (;;) {
+            final int pendingInput = ioSession.pendingInput();
+            handler.inputReady(currentSession, null);
+            final int remainingInput = ioSession.pendingInput();
+            if (remainingInput == 0 || remainingInput >= pendingInput) {
+                break;
+            }
+        }
+    }
+
+    void onOutputReady() throws IOException {
+        final IOSession currentSession = currentSessionRef.get();
+        final IOEventHandler handler = currentSession.getHandler();
+        if (handler != null) {
+            handler.outputReady(currentSession);
+        }
+        ioSession.flushOutput();
+        if (ioSession.available() > 0) {
+            ioSession.requestOutput();
+        }
+    }
+
+    void onRemoteStreamEnd() throws IOException {
+        ioSession.onRemoteStreamEnd();
+        final IOSession currentSession = currentSessionRef.get();
+        final IOEventHandler handler = currentSession.getHandler();
+        if (handler != null) {
+            handler.inputReady(currentSession, null);
+        }
+    }
+
+    @Override
+    public NamedEndpoint getInitialEndpoint() {
+        return initialEndpoint;
+    }
+
+    @Override
+    public IOEventHandler getHandler() {
+        return currentSessionRef.get().getHandler();
+    }
+
+    @Override
+    public void upgrade(final IOEventHandler handler) {
+        currentSessionRef.get().upgrade(handler);
+    }
+
+    @Override
+    public Lock getLock() {
+        return ioSession.getLock();
+    }
+
+    @Override
+    public void enqueue(final Command command, final Command.Priority priority) {
+        currentSessionRef.get().enqueue(command, priority);
+    }
+
+    @Override
+    public boolean hasCommands() {
+        return currentSessionRef.get().hasCommands();
+    }
+
+    @Override
+    public Command poll() {
+        return currentSessionRef.get().poll();
+    }
+
+    @Override
+    public ByteChannel channel() {
+        return currentSessionRef.get().channel();
+    }
+
+    @Override
+    public SocketAddress getRemoteAddress() {
+        return ioSession.getRemoteAddress();
+    }
+
+    @Override
+    public SocketAddress getLocalAddress() {
+        return ioSession.getLocalAddress();
+    }
+
+    @Override
+    public int getEventMask() {
+        return currentSessionRef.get().getEventMask();
+    }
+
+    @Override
+    public void setEventMask(final int ops) {
+        currentSessionRef.get().setEventMask(ops);
+    }
+
+    @Override
+    public void setEvent(final int op) {
+        currentSessionRef.get().setEvent(op);
+    }
+
+    @Override
+    public void clearEvent(final int op) {
+        currentSessionRef.get().clearEvent(op);
+    }
+
+    @Override
+    public void close() {
+        close(CloseMode.GRACEFUL);
+    }
+
+    @Override
+    public void close(final CloseMode closeMode) {
+        if (closeMode == CloseMode.IMMEDIATE) {
+            ioSession.close(closeMode);
+        } else {
+            currentSessionRef.get().close(closeMode);
+        }
+    }
+
+    @Override
+    public Status getStatus() {
+        return currentSessionRef.get().getStatus();
+    }
+
+    @Override
+    public Timeout getSocketTimeout() {
+        return ioSession.getSocketTimeout();
+    }
+
+    @Override
+    public void setSocketTimeout(final Timeout timeout) {
+        ioSession.setSocketTimeout(timeout);
+    }
+
+    @Override
+    public long getLastReadTime() {
+        return ioSession.getLastReadTime();
+    }
+
+    @Override
+    public long getLastWriteTime() {
+        return ioSession.getLastWriteTime();
+    }
+
+    @Override
+    public long getLastEventTime() {
+        return ioSession.getLastEventTime();
+    }
+
+    @Override
+    public void updateReadTime() {
+        ioSession.updateReadTime();
+    }
+
+    @Override
+    public void updateWriteTime() {
+        ioSession.updateWriteTime();
+    }
+
+    @Override
+    public int read(final ByteBuffer dst) throws IOException {
+        return currentSessionRef.get().read(dst);
+    }
+
+    @Override
+    public int write(final ByteBuffer src) throws IOException {
+        return currentSessionRef.get().write(src);
+    }
+
+    @Override
+    public boolean isOpen() {
+        return currentSessionRef.get().isOpen();
+    }
+
+    @Override
+    public String getId() {
+        return ioSession.getId();
+    }
+
+    @Override
+    public void startTls(
+            final SSLContext sslContext,
+            final NamedEndpoint endpoint,
+            final SSLBufferMode sslBufferMode,
+            final SSLSessionInitializer initializer,
+            final SSLSessionVerifier verifier,
+            final Timeout handshakeTimeout) {
+        startTls(sslContext, endpoint, sslBufferMode, initializer, verifier, handshakeTimeout, null);
+    }
+
+    @Override
+    public void startTls(
+            final SSLContext sslContext,
+            final NamedEndpoint endpoint,
+            final SSLBufferMode sslBufferMode,
+            final SSLSessionInitializer initializer,
+            final SSLSessionVerifier verifier,
+            final Timeout handshakeTimeout,
+            final FutureCallback<TransportSecurityLayer> callback) {
+
+        final SSLIOSession sslioSession = new SSLIOSession(
+                endpoint != null ? endpoint : initialEndpoint,
+                ioSession,
+                SSLMode.CLIENT,
+                sslContext,
+                sslBufferMode,
+                initializer,
+                verifier,
+                handshakeTimeout,
+                null,
+                null,
+                new CallbackContribution<SSLSession>(callback) {
+
+                    @Override
+                    public void completed(final SSLSession sslSession) {
+                        if (callback != null) {
+                            callback.completed(H2TunnelProtocolIOSession.this);
+                        }
+                    }
+
+                });
+
+        if (tlsSessionRef.compareAndSet(null, sslioSession)) {
+            currentSessionRef.set(sslioSession);
+        } else {
+            throw new IllegalStateException("TLS already activated");
+        }
+
+        try {
+            sslioSession.beginHandshake(this);
+        } catch (final Exception ex) {
+            if (callback != null) {
+                callback.failed(ex);
+            }
+            close(CloseMode.IMMEDIATE);
+        }
+    }
+
+    @Override
+    public TlsDetails getTlsDetails() {
+        final SSLIOSession sslIoSession = tlsSessionRef.get();
+        return sslIoSession != null ? sslIoSession.getTlsDetails() : null;
+    }
+
+    @Override
+    public int getPendingCommandCount() {
+        return currentSessionRef.get().getPendingCommandCount();
+    }
+}

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/H2TunnelProtocolStarter.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/H2TunnelProtocolStarter.java
@@ -1,0 +1,74 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.hc.client5.http.impl.async;
+
+import org.apache.hc.core5.http.config.CharCodingConfig;
+import org.apache.hc.core5.http.protocol.HttpProcessorBuilder;
+import org.apache.hc.core5.http2.config.H2Config;
+import org.apache.hc.core5.http2.impl.nio.ClientH2PrefaceHandler;
+import org.apache.hc.core5.http2.impl.nio.ClientH2StreamMultiplexerFactory;
+import org.apache.hc.core5.reactor.IOEventHandler;
+import org.apache.hc.core5.reactor.IOEventHandlerFactory;
+import org.apache.hc.core5.reactor.ProtocolIOSession;
+
+/**
+ * Minimal {@link IOEventHandlerFactory} for starting HTTP/2 client protocol
+ * inside a CONNECT tunnel session.
+ * <p>
+ * Unlike {@link H2AsyncClientProtocolStarter}, this factory does not
+ * install push consumer handling, frame/header logging listeners, or
+ * exception callbacks. Those concerns belong to the outer proxy
+ * connection, not the tunneled target connection.
+ * </p>
+ *
+ * @since 5.7
+ */
+final class H2TunnelProtocolStarter implements IOEventHandlerFactory {
+
+    private final H2Config h2Config;
+    private final CharCodingConfig charCodingConfig;
+
+    H2TunnelProtocolStarter(
+            final H2Config h2Config,
+            final CharCodingConfig charCodingConfig) {
+        this.h2Config = h2Config != null ? h2Config : H2Config.DEFAULT;
+        this.charCodingConfig = charCodingConfig != null ? charCodingConfig : CharCodingConfig.DEFAULT;
+    }
+
+    @Override
+    public IOEventHandler createHandler(final ProtocolIOSession ioSession, final Object attachment) {
+        final ClientH2StreamMultiplexerFactory multiplexerFactory = new ClientH2StreamMultiplexerFactory(
+                HttpProcessorBuilder.create().build(),
+                null,
+                h2Config,
+                charCodingConfig,
+                null);
+        return new ClientH2PrefaceHandler(ioSession, multiplexerFactory, false, null);
+    }
+
+}

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/H2TunnelRawIOSession.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/H2TunnelRawIOSession.java
@@ -1,0 +1,733 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.client5.http.impl.async;
+
+import java.io.IOException;
+import java.net.SocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.ByteChannel;
+import java.nio.channels.CancelledKeyException;
+import java.nio.channels.SelectionKey;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.apache.hc.core5.http.StreamControl;
+import org.apache.hc.core5.http.nio.CapacityChannel;
+import org.apache.hc.core5.http.nio.DataStreamChannel;
+import org.apache.hc.core5.io.CloseMode;
+import org.apache.hc.core5.reactor.Command;
+import org.apache.hc.core5.reactor.IOEventHandler;
+import org.apache.hc.core5.reactor.IOSession;
+import org.apache.hc.core5.util.Timeout;
+
+/**
+ * Raw tunnel {@link IOSession} implementation with bounded buffering,
+ * capacity flow control and stream-scoped close semantics.
+ * <p>
+ * Closing this session cancels only the CONNECT stream,
+ * not the underlying physical HTTP/2 connection.
+ * </p>
+ *
+ * @since 5.7
+ */
+final class H2TunnelRawIOSession implements IOSession {
+
+    private static final int INBOUND_BUFFER_LIMIT = 64 * 1024;
+    private static final int OUTBOUND_BUFFER_LIMIT = 64 * 1024;
+
+    private final IOSession physicalSession;
+    private final String id;
+    private final Lock lock;
+
+    private final Deque<Command> commandQueue;
+    private final Deque<ByteBuffer> inboundQueue;
+    private final Deque<ByteBuffer> outboundQueue;
+
+    private final AtomicReference<IOEventHandler> handlerRef;
+    private final AtomicReference<DataStreamChannel> dataChannelRef;
+    private final AtomicReference<StreamControl> streamControlRef;
+
+    private CapacityChannel capacityChannel;
+    private Timeout socketTimeout;
+    private int eventMask;
+    private Status status;
+
+    private int inboundBytes;
+    private int outboundBytes;
+    private int consumedBytesSinceUpdate;
+
+    private boolean capacityInitialized;
+    private boolean localEndStreamSent;
+    private boolean remoteEndStream;
+
+    private long lastReadTime;
+    private long lastWriteTime;
+    private long lastEventTime;
+
+    H2TunnelRawIOSession(
+            final IOSession physicalSession,
+            final Timeout socketTimeout,
+            final StreamControl streamControl) {
+        this.physicalSession = physicalSession;
+        this.id = physicalSession.getId() + "-h2-tunnel";
+        this.lock = new ReentrantLock();
+        this.commandQueue = new ArrayDeque<>();
+        this.inboundQueue = new ArrayDeque<>();
+        this.outboundQueue = new ArrayDeque<>();
+        this.handlerRef = new AtomicReference<>();
+        this.dataChannelRef = new AtomicReference<>();
+        this.streamControlRef = new AtomicReference<>(streamControl);
+
+        this.capacityChannel = null;
+        this.socketTimeout = socketTimeout;
+        this.eventMask = SelectionKey.OP_READ;
+        this.status = Status.ACTIVE;
+
+        this.capacityInitialized = false;
+        this.localEndStreamSent = false;
+        this.remoteEndStream = false;
+
+        final long now = System.currentTimeMillis();
+        this.lastReadTime = now;
+        this.lastWriteTime = now;
+        this.lastEventTime = now;
+    }
+
+    void bindStreamControl(final StreamControl streamControl) {
+        streamControlRef.compareAndSet(null, streamControl);
+    }
+
+    void attachChannel(final DataStreamChannel channel) {
+        dataChannelRef.set(channel);
+    }
+
+    void updateCapacityChannel(final CapacityChannel capacityChannel) throws IOException {
+        int update = 0;
+        lock.lock();
+        try {
+            this.capacityChannel = capacityChannel;
+            if (!capacityInitialized) {
+                update += Math.max(0, INBOUND_BUFFER_LIMIT - inboundBytes);
+                capacityInitialized = true;
+            }
+            if (consumedBytesSinceUpdate > 0) {
+                update += consumedBytesSinceUpdate;
+                consumedBytesSinceUpdate = 0;
+            }
+        } finally {
+            lock.unlock();
+        }
+        if (update > 0) {
+            capacityChannel.update(update);
+        }
+    }
+
+    void onRemoteStreamEnd() {
+        lock.lock();
+        try {
+            remoteEndStream = true;
+            if (status == Status.ACTIVE) {
+                status = Status.CLOSING;
+            }
+            if (localEndStreamSent) {
+                status = Status.CLOSED;
+            }
+            lastEventTime = System.currentTimeMillis();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    void requestOutput() {
+        final DataStreamChannel dataChannel = dataChannelRef.get();
+        if (dataChannel == null) {
+            return;
+        }
+        try {
+            dataChannel.requestOutput();
+        } catch (final CancelledKeyException ex) {
+            discard();
+        }
+    }
+
+    int available() {
+        lock.lock();
+        try {
+            if (outboundBytes > 0) {
+                return outboundBytes;
+            }
+            if (!localEndStreamSent && status == Status.CLOSING) {
+                return 1;
+            }
+            if (!commandQueue.isEmpty() || (eventMask & SelectionKey.OP_WRITE) != 0) {
+                return 1;
+            }
+            return 0;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    void appendInput(final ByteBuffer src) throws IOException {
+        if (src == null || !src.hasRemaining()) {
+            return;
+        }
+        lock.lock();
+        try {
+            if (status == Status.CLOSED) {
+                return;
+            }
+            final int remaining = src.remaining();
+            final int freeSpace = INBOUND_BUFFER_LIMIT - inboundBytes;
+            if (remaining > freeSpace) {
+                throw new IOException("Tunnel inbound buffer overflow");
+            }
+            final byte[] data = new byte[remaining];
+            src.get(data);
+            inboundQueue.addLast(ByteBuffer.wrap(data));
+            inboundBytes += data.length;
+            final long now = System.currentTimeMillis();
+            lastReadTime = now;
+            lastEventTime = now;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    int pendingInput() {
+        lock.lock();
+        try {
+            return inboundBytes;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    void discardInbound(final int bytes) throws IOException {
+        if (bytes <= 0) {
+            return;
+        }
+        int remaining = bytes;
+        int update = 0;
+        CapacityChannel currentCapacityChannel = null;
+
+        lock.lock();
+        try {
+            while (remaining > 0) {
+                final ByteBuffer buffer = inboundQueue.peekFirst();
+                if (buffer == null) {
+                    break;
+                }
+                final int chunk = Math.min(remaining, buffer.remaining());
+                if (chunk <= 0) {
+                    break;
+                }
+                buffer.position(buffer.position() + chunk);
+                remaining -= chunk;
+                inboundBytes -= chunk;
+                if (!buffer.hasRemaining()) {
+                    inboundQueue.pollFirst();
+                }
+                consumedBytesSinceUpdate += chunk;
+            }
+            if (capacityChannel != null && consumedBytesSinceUpdate > 0) {
+                currentCapacityChannel = capacityChannel;
+                update = consumedBytesSinceUpdate;
+                consumedBytesSinceUpdate = 0;
+            }
+        } finally {
+            lock.unlock();
+        }
+
+        if (currentCapacityChannel != null && update > 0) {
+            currentCapacityChannel.update(update);
+        }
+    }
+
+    void flushOutput() throws IOException {
+        final DataStreamChannel dataChannel = dataChannelRef.get();
+        if (dataChannel == null) {
+            return;
+        }
+
+        boolean sendEndStream = false;
+
+        lock.lock();
+        try {
+            for (; ; ) {
+                final ByteBuffer buffer = outboundQueue.peekFirst();
+                if (buffer == null) {
+                    break;
+                }
+                final int bytesWritten = dataChannel.write(buffer);
+                if (bytesWritten <= 0) {
+                    break;
+                }
+                outboundBytes -= bytesWritten;
+                if (!buffer.hasRemaining()) {
+                    outboundQueue.pollFirst();
+                }
+                final long now = System.currentTimeMillis();
+                lastWriteTime = now;
+                lastEventTime = now;
+            }
+            if (!localEndStreamSent && status == Status.CLOSING && outboundQueue.isEmpty()) {
+                localEndStreamSent = true;
+                sendEndStream = true;
+            }
+        } finally {
+            lock.unlock();
+        }
+
+        if (sendEndStream) {
+            try {
+                dataChannel.endStream(null);
+            } finally {
+                lock.lock();
+                try {
+                    if (remoteEndStream) {
+                        status = Status.CLOSED;
+                    }
+                } finally {
+                    lock.unlock();
+                }
+            }
+        }
+    }
+
+    private void cancelPendingCommands() {
+        for (final Command command : commandQueue) {
+            command.cancel();
+        }
+        commandQueue.clear();
+    }
+
+    private void discard() {
+        lock.lock();
+        try {
+            if (status == Status.CLOSED) {
+                return;
+            }
+            status = Status.CLOSED;
+            localEndStreamSent = true;
+            cancelPendingCommands();
+            inboundQueue.clear();
+            inboundBytes = 0;
+            outboundQueue.clear();
+            outboundBytes = 0;
+            consumedBytesSinceUpdate = 0;
+            lastEventTime = System.currentTimeMillis();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private void cancelStream() {
+        final StreamControl streamControl = streamControlRef.get();
+        if (streamControl != null) {
+            streamControl.cancel();
+        }
+    }
+
+    @Override
+    public IOEventHandler getHandler() {
+        return handlerRef.get();
+    }
+
+    @Override
+    public void upgrade(final IOEventHandler handler) {
+        handlerRef.set(handler);
+    }
+
+    @Override
+    public Lock getLock() {
+        return lock;
+    }
+
+    @Override
+    public void enqueue(final Command command, final Command.Priority priority) {
+        if (command == null) {
+            return;
+        }
+        lock.lock();
+        try {
+            if (status != Status.ACTIVE) {
+                command.cancel();
+                return;
+            }
+            if (priority == Command.Priority.IMMEDIATE) {
+                commandQueue.addFirst(command);
+            } else {
+                commandQueue.addLast(command);
+            }
+            lastEventTime = System.currentTimeMillis();
+        } finally {
+            lock.unlock();
+        }
+        requestOutput();
+    }
+
+    @Override
+    public boolean hasCommands() {
+        lock.lock();
+        try {
+            return !commandQueue.isEmpty();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public Command poll() {
+        lock.lock();
+        try {
+            return commandQueue.pollFirst();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public ByteChannel channel() {
+        return this;
+    }
+
+    @Override
+    public SocketAddress getRemoteAddress() {
+        return physicalSession.getRemoteAddress();
+    }
+
+    @Override
+    public SocketAddress getLocalAddress() {
+        return physicalSession.getLocalAddress();
+    }
+
+    @Override
+    public int getEventMask() {
+        lock.lock();
+        try {
+            return eventMask;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public void setEventMask(final int ops) {
+        final boolean wantOutput = (ops & SelectionKey.OP_WRITE) != 0;
+        lock.lock();
+        try {
+            eventMask = ops;
+            lastEventTime = System.currentTimeMillis();
+        } finally {
+            lock.unlock();
+        }
+        if (wantOutput) {
+            requestOutput();
+        }
+    }
+
+    @Override
+    public void setEvent(final int op) {
+        final boolean wantOutput = (op & SelectionKey.OP_WRITE) != 0;
+        lock.lock();
+        try {
+            eventMask |= op;
+            lastEventTime = System.currentTimeMillis();
+        } finally {
+            lock.unlock();
+        }
+        if (wantOutput) {
+            requestOutput();
+        }
+    }
+
+    @Override
+    public void clearEvent(final int op) {
+        lock.lock();
+        try {
+            eventMask &= ~op;
+            lastEventTime = System.currentTimeMillis();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public void close() {
+        close(CloseMode.GRACEFUL);
+    }
+
+    @Override
+    public void close(final CloseMode closeMode) {
+        boolean cancel = false;
+
+        lock.lock();
+        try {
+            if (status == Status.CLOSED) {
+                return;
+            }
+            if (closeMode == CloseMode.IMMEDIATE) {
+                status = Status.CLOSED;
+                localEndStreamSent = true;
+                cancelPendingCommands();
+                inboundQueue.clear();
+                inboundBytes = 0;
+                outboundQueue.clear();
+                outboundBytes = 0;
+                consumedBytesSinceUpdate = 0;
+                cancel = true;
+            } else {
+                status = Status.CLOSING;
+                if (dataChannelRef.get() == null && outboundBytes == 0) {
+                    status = Status.CLOSED;
+                    localEndStreamSent = true;
+                    cancel = true;
+                }
+            }
+            lastEventTime = System.currentTimeMillis();
+        } finally {
+            lock.unlock();
+        }
+
+        if (cancel) {
+            cancelStream();
+        } else {
+            requestOutput();
+        }
+    }
+
+    @Override
+    public Status getStatus() {
+        lock.lock();
+        try {
+            return status;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public Timeout getSocketTimeout() {
+        lock.lock();
+        try {
+            return socketTimeout;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public void setSocketTimeout(final Timeout timeout) {
+        lock.lock();
+        try {
+            socketTimeout = timeout;
+            lastEventTime = System.currentTimeMillis();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public long getLastReadTime() {
+        lock.lock();
+        try {
+            return lastReadTime;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public long getLastWriteTime() {
+        lock.lock();
+        try {
+            return lastWriteTime;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public long getLastEventTime() {
+        lock.lock();
+        try {
+            return lastEventTime;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public void updateReadTime() {
+        final long now = System.currentTimeMillis();
+        lock.lock();
+        try {
+            lastReadTime = now;
+            lastEventTime = now;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public void updateWriteTime() {
+        final long now = System.currentTimeMillis();
+        lock.lock();
+        try {
+            lastWriteTime = now;
+            lastEventTime = now;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public int read(final ByteBuffer dst) throws IOException {
+        int total = 0;
+        int update = 0;
+        CapacityChannel currentCapacityChannel = null;
+
+        lock.lock();
+        try {
+            if (inboundQueue.isEmpty()) {
+                return remoteEndStream || status == Status.CLOSED ? -1 : 0;
+            }
+            while (dst.hasRemaining()) {
+                final ByteBuffer buffer = inboundQueue.peekFirst();
+                if (buffer == null) {
+                    break;
+                }
+                final int chunk = Math.min(dst.remaining(), buffer.remaining());
+                if (chunk <= 0) {
+                    break;
+                }
+
+                if (buffer.hasArray()) {
+                    final int pos = buffer.position();
+                    dst.put(buffer.array(), buffer.arrayOffset() + pos, chunk);
+                    buffer.position(pos + chunk);
+                } else {
+                    for (int i = 0; i < chunk; i++) {
+                        dst.put(buffer.get());
+                    }
+                }
+
+                total += chunk;
+                inboundBytes -= chunk;
+                if (!buffer.hasRemaining()) {
+                    inboundQueue.pollFirst();
+                }
+            }
+
+            if (total > 0) {
+                consumedBytesSinceUpdate += total;
+                final long now = System.currentTimeMillis();
+                lastReadTime = now;
+                lastEventTime = now;
+                if (capacityChannel != null && consumedBytesSinceUpdate > 0) {
+                    currentCapacityChannel = capacityChannel;
+                    update = consumedBytesSinceUpdate;
+                    consumedBytesSinceUpdate = 0;
+                }
+            }
+        } finally {
+            lock.unlock();
+        }
+
+        if (currentCapacityChannel != null && update > 0) {
+            currentCapacityChannel.update(update);
+        }
+        return total;
+    }
+
+    @Override
+    public int write(final ByteBuffer src) {
+        if (src == null || !src.hasRemaining()) {
+            return 0;
+        }
+        int bytesAccepted = 0;
+
+        lock.lock();
+        try {
+            if (status != Status.ACTIVE) {
+                return 0;
+            }
+            final int freeSpace = OUTBOUND_BUFFER_LIMIT - outboundBytes;
+            if (freeSpace <= 0) {
+                return 0;
+            }
+            bytesAccepted = Math.min(src.remaining(), freeSpace);
+            if (bytesAccepted <= 0) {
+                return 0;
+            }
+
+            final byte[] data = new byte[bytesAccepted];
+            src.get(data);
+
+            outboundQueue.addLast(ByteBuffer.wrap(data));
+            outboundBytes += bytesAccepted;
+
+            final long now = System.currentTimeMillis();
+            lastWriteTime = now;
+            lastEventTime = now;
+        } finally {
+            lock.unlock();
+        }
+
+        requestOutput();
+        return bytesAccepted;
+    }
+
+    @Override
+    public boolean isOpen() {
+        lock.lock();
+        try {
+            return status != Status.CLOSED && physicalSession.isOpen();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public int getPendingCommandCount() {
+        lock.lock();
+        try {
+            return commandQueue.size();
+        } finally {
+            lock.unlock();
+        }
+    }
+}

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncClients.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncClients.java
@@ -276,12 +276,16 @@ public final class HttpAsyncClients {
     private static MinimalH2AsyncClient createMinimalHttp2AsyncClientImpl(
             final IOEventHandlerFactory eventHandlerFactory,
             final AsyncPushConsumerRegistry pushConsumerRegistry,
+            final H2Config h2Config,
+            final CharCodingConfig charCodingConfig,
             final IOReactorConfig ioReactorConfig,
             final DnsResolver dnsResolver,
             final TlsStrategy tlsStrategy) {
         return new MinimalH2AsyncClient(
                 eventHandlerFactory,
                 pushConsumerRegistry,
+                h2Config,
+                charCodingConfig,
                 ioReactorConfig,
                 new DefaultThreadFactory("httpclient-main", true),
                 new DefaultThreadFactory("httpclient-dispatch", true),
@@ -307,6 +311,8 @@ public final class HttpAsyncClients {
                         CharCodingConfig.DEFAULT,
                         LoggingExceptionCallback.INSTANCE),
                 pushConsumerRegistry,
+                h2Config,
+                CharCodingConfig.DEFAULT,
                 ioReactorConfig,
                 dnsResolver,
                 tlsStrategy);

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalH2AsyncClient.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalH2AsyncClient.java
@@ -102,12 +102,11 @@ public final class InternalH2AsyncClient extends InternalAbstractHttpAsyncClient
     }
 
     @Override
-    HttpRoute determineRoute(final HttpHost httpHost, final HttpRequest request, final HttpClientContext clientContext) throws HttpException {
-        final HttpRoute route = routePlanner.determineRoute(httpHost, request, clientContext);
-        if (route.isTunnelled()) {
-            throw new HttpException("HTTP/2 tunneling not supported");
-        }
-        return route;
+    HttpRoute determineRoute(
+            final HttpHost httpHost,
+            final HttpRequest request,
+            final HttpClientContext clientContext) throws HttpException {
+        return routePlanner.determineRoute(httpHost, request, clientContext);
     }
 
     @Override

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalH2AsyncExecRuntime.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalH2AsyncExecRuntime.java
@@ -183,6 +183,12 @@ class InternalH2AsyncExecRuntime implements AsyncExecRuntime {
     }
 
     @Override
+    public HttpRoute getEstablishedRoute() {
+        final Endpoint endpoint = sessionRef.get();
+        return endpoint != null ? endpoint.route : null;
+    }
+
+    @Override
     public Cancellable connectEndpoint(
             final HttpClientContext context,
             final FutureCallback<AsyncExecRuntime> callback) {

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalH2ConnPool.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalH2ConnPool.java
@@ -51,6 +51,8 @@ import org.apache.hc.core5.reactor.IOSession;
 import org.apache.hc.core5.reactor.ssl.TransportSecurityLayer;
 import org.apache.hc.core5.util.TimeValue;
 import org.apache.hc.core5.util.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class InternalH2ConnPool implements ModalCloseable {
 
@@ -58,10 +60,23 @@ class InternalH2ConnPool implements ModalCloseable {
 
     private volatile Resolver<HttpHost, ConnectionConfig> connectionConfigResolver;
 
-    InternalH2ConnPool(final ConnectionInitiator connectionInitiator,
-                       final Resolver<HttpHost, InetSocketAddress> addressResolver,
-                       final TlsStrategy tlsStrategy) {
-        this.sessionPool = new SessionPool(connectionInitiator, addressResolver, tlsStrategy);
+    InternalH2ConnPool(
+            final ConnectionInitiator connectionInitiator,
+            final Resolver<HttpHost, InetSocketAddress> addressResolver,
+            final TlsStrategy tlsStrategy) {
+        this(connectionInitiator, addressResolver, tlsStrategy, null);
+    }
+
+    InternalH2ConnPool(
+            final ConnectionInitiator connectionInitiator,
+            final Resolver<HttpHost, InetSocketAddress> addressResolver,
+            final TlsStrategy tlsStrategy,
+            final H2RouteOperator routeOperator) {
+        this.sessionPool = new SessionPool(
+                connectionInitiator,
+                addressResolver,
+                tlsStrategy,
+                routeOperator);
     }
 
     @Override
@@ -74,9 +89,10 @@ class InternalH2ConnPool implements ModalCloseable {
         sessionPool.close();
     }
 
-    private ConnectionConfig resolveConnectionConfig(final HttpHost httpHost) {
+    private ConnectionConfig resolveConnectionConfig(final HttpRoute route) {
+        final HttpHost firstHop = route.getProxyHost() != null ? route.getProxyHost() : route.getTargetHost();
         final Resolver<HttpHost, ConnectionConfig> resolver = this.connectionConfigResolver;
-        final ConnectionConfig connectionConfig = resolver != null ? resolver.resolve(httpHost) : null;
+        final ConnectionConfig connectionConfig = resolver != null ? resolver.resolve(firstHop) : null;
         return connectionConfig != null ? connectionConfig : ConnectionConfig.DEFAULT;
     }
 
@@ -84,7 +100,7 @@ class InternalH2ConnPool implements ModalCloseable {
             final HttpRoute route,
             final Timeout connectTimeout,
             final FutureCallback<IOSession> callback) {
-        final ConnectionConfig connectionConfig = resolveConnectionConfig(route.getTargetHost());
+        final ConnectionConfig connectionConfig = resolveConnectionConfig(route);
         return sessionPool.getSession(
                 route,
                 connectTimeout != null ? connectTimeout : connectionConfig.getConnectTimeout(),
@@ -118,32 +134,41 @@ class InternalH2ConnPool implements ModalCloseable {
         sessionPool.validateAfterInactivity = timeValue;
     }
 
-
     static class SessionPool extends AbstractIOSessionPool<HttpRoute> {
+
+        private static final Logger LOG = LoggerFactory.getLogger(InternalH2ConnPool.class);
 
         private final ConnectionInitiator connectionInitiator;
         private final Resolver<HttpHost, InetSocketAddress> addressResolver;
         private final TlsStrategy tlsStrategy;
+        private final H2RouteOperator routeOperator;
 
         private volatile TimeValue validateAfterInactivity = TimeValue.NEG_ONE_MILLISECOND;
 
-        SessionPool(final ConnectionInitiator connectionInitiator,
-                    final Resolver<HttpHost, InetSocketAddress> addressResolver,
-                    final TlsStrategy tlsStrategy) {
+        SessionPool(
+                final ConnectionInitiator connectionInitiator,
+                final Resolver<HttpHost, InetSocketAddress> addressResolver,
+                final TlsStrategy tlsStrategy,
+                final H2RouteOperator routeOperator) {
             this.connectionInitiator = connectionInitiator;
             this.addressResolver = addressResolver;
             this.tlsStrategy = tlsStrategy;
+            this.routeOperator = routeOperator;
         }
 
         @Override
-        protected Future<IOSession> connectSession(final HttpRoute route,
-                                                   final Timeout connectTimeout,
-                                                   final FutureCallback<IOSession> callback) {
+        protected Future<IOSession> connectSession(
+                final HttpRoute route,
+                final Timeout connectTimeout,
+                final FutureCallback<IOSession> callback) {
+            final HttpHost proxy = route.getProxyHost();
             final HttpHost target = route.getTargetHost();
+            final HttpHost firstHop = proxy != null ? proxy : target;
+            final NamedEndpoint firstHopName = proxy == null && route.getTargetName() != null ? route.getTargetName() : firstHop;
             final InetSocketAddress localAddress = route.getLocalSocketAddress();
-            final InetSocketAddress remoteAddress = addressResolver.resolve(target);
+            final InetSocketAddress remoteAddress = addressResolver.resolve(firstHop);
             return connectionInitiator.connect(
-                    target,
+                    firstHopName,
                     remoteAddress,
                     localAddress,
                     connectTimeout,
@@ -153,34 +178,46 @@ class InternalH2ConnPool implements ModalCloseable {
                         @Override
                         public void completed(final IOSession ioSession) {
                             if (tlsStrategy != null
-                                    && URIScheme.HTTPS.same(target.getSchemeName())
+                                    && URIScheme.HTTPS.same(firstHop.getSchemeName())
                                     && ioSession instanceof TransportSecurityLayer) {
-                                final NamedEndpoint tlsName = route.getTargetName() != null ? route.getTargetName() : target;
                                 tlsStrategy.upgrade(
                                         (TransportSecurityLayer) ioSession,
-                                        tlsName,
+                                        firstHopName,
                                         null,
                                         connectTimeout,
                                         new CallbackContribution<TransportSecurityLayer>(callback) {
 
                                             @Override
                                             public void completed(final TransportSecurityLayer transportSecurityLayer) {
-                                                callback.completed(ioSession);
+                                                completeRoute(route, connectTimeout, ioSession, callback);
                                             }
 
                                         });
                                 ioSession.setSocketTimeout(connectTimeout);
                             } else {
-                                callback.completed(ioSession);
+                                completeRoute(route, connectTimeout, ioSession, callback);
                             }
                         }
 
                     });
         }
 
+        private void completeRoute(
+                final HttpRoute route,
+                final Timeout connectTimeout,
+                final IOSession ioSession,
+                final FutureCallback<IOSession> callback) {
+            if (routeOperator != null) {
+                routeOperator.completeRoute(route, connectTimeout, ioSession, callback);
+            } else {
+                callback.completed(ioSession);
+            }
+        }
+
         @Override
-        protected void validateSession(final IOSession ioSession,
-                                       final Callback<Boolean> callback) {
+        protected void validateSession(
+                final IOSession ioSession,
+                final Callback<Boolean> callback) {
             if (ioSession.isOpen()) {
                 final TimeValue timeValue = validateAfterInactivity;
                 if (TimeValue.isNonNegative(timeValue)) {
@@ -202,8 +239,9 @@ class InternalH2ConnPool implements ModalCloseable {
         }
 
         @Override
-        protected void closeSession(final IOSession ioSession,
-                                    final CloseMode closeMode) {
+        protected void closeSession(
+                final IOSession ioSession,
+                final CloseMode closeMode) {
             if (closeMode == CloseMode.GRACEFUL) {
                 ioSession.enqueue(ShutdownCommand.GRACEFUL, Command.Priority.NORMAL);
             } else {

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/MinimalH2AsyncClient.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/MinimalH2AsyncClient.java
@@ -54,6 +54,7 @@ import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.URIScheme;
 import org.apache.hc.core5.http.nio.AsyncClientExchangeHandler;
 import org.apache.hc.core5.http.nio.AsyncPushConsumer;
 import org.apache.hc.core5.http.nio.CapacityChannel;
@@ -61,9 +62,11 @@ import org.apache.hc.core5.http.nio.DataStreamChannel;
 import org.apache.hc.core5.http.nio.HandlerFactory;
 import org.apache.hc.core5.http.nio.RequestChannel;
 import org.apache.hc.core5.http.nio.command.RequestExecutionCommand;
+import org.apache.hc.core5.http.config.CharCodingConfig;
 import org.apache.hc.core5.http.nio.command.ShutdownCommand;
 import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
 import org.apache.hc.core5.http.protocol.HttpContext;
+import org.apache.hc.core5.http2.config.H2Config;
 import org.apache.hc.core5.io.CloseMode;
 import org.apache.hc.core5.reactor.Command;
 import org.apache.hc.core5.reactor.ConnectionInitiator;
@@ -79,8 +82,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Minimal implementation of HTTP/2 only {@link CloseableHttpAsyncClient}. This client
  * is optimized for HTTP/2 multiplexing message transport and does not support advanced
- * HTTP protocol functionality such as request execution via a proxy, state management,
- * authentication and request redirects.
+ * HTTP protocol functionality such as state management, authentication and request redirects.
  * <p>
  * Concurrent message exchanges with the same connection route executed by
  * this client will get automatically multiplexed over a single physical HTTP/2
@@ -99,6 +101,8 @@ public final class MinimalH2AsyncClient extends AbstractMinimalHttpAsyncClientBa
     MinimalH2AsyncClient(
             final IOEventHandlerFactory eventHandlerFactory,
             final AsyncPushConsumerRegistry pushConsumerRegistry,
+            final H2Config h2Config,
+            final CharCodingConfig charCodingConfig,
             final IOReactorConfig reactorConfig,
             final ThreadFactory threadFactory,
             final ThreadFactory workerThreadFactory,
@@ -115,7 +119,13 @@ public final class MinimalH2AsyncClient extends AbstractMinimalHttpAsyncClientBa
                 pushConsumerRegistry,
                 threadFactory);
         this.connectionInitiator = new MultihomeConnectionInitiator(getConnectionInitiator(), dnsResolver);
-        this.connPool = new InternalH2ConnPool(this.connectionInitiator, object -> null, tlsStrategy);
+        this.connPool = new InternalH2ConnPool(
+                this.connectionInitiator,
+                object -> null,
+                tlsStrategy,
+                new H2RouteOperator(
+                        tlsStrategy,
+                        new H2TunnelProtocolStarter(h2Config, charCodingConfig)));
     }
 
     @Override
@@ -144,8 +154,14 @@ public final class MinimalH2AsyncClient extends AbstractMinimalHttpAsyncClientBa
                 final Timeout connectTimeout = requestConfig.getConnectTimeout();
                 final Timeout responseTimeout = requestConfig.getResponseTimeout();
                 final HttpHost target = new HttpHost(request.getScheme(), request.getAuthority());
+                final HttpHost proxy = requestConfig.getProxy();
+                final HttpRoute route = proxy != null ? new HttpRoute(
+                        target,
+                        null,
+                        proxy,
+                        URIScheme.HTTPS.same(target.getSchemeName())) : new HttpRoute(target);
 
-                final Future<IOSession> sessionFuture = connPool.getSession(new HttpRoute(target), connectTimeout,
+                final Future<IOSession> sessionFuture = connPool.getSession(route, connectTimeout,
                     new FutureCallback<IOSession>() {
 
                     @Override

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/TunnelRefusedException.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/TunnelRefusedException.java
@@ -1,0 +1,86 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.client5.http.impl.async;
+
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpException;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.message.BasicHttpResponse;
+import org.apache.hc.core5.http.message.StatusLine;
+import org.apache.hc.core5.util.Args;
+
+/**
+ * Exception indicating CONNECT tunnel refusal by the proxy.
+ *
+ * @since 5.7
+ */
+public final class TunnelRefusedException extends HttpException {
+
+    private static final long serialVersionUID = 1L;
+
+    private final HttpResponse response;
+
+    /**
+     * Creates a new exception from the proxy response that refused the tunnel.
+     *
+     * @param response the non-2xx CONNECT response from the proxy
+     * @since 5.7
+     */
+    public TunnelRefusedException(final HttpResponse response) {
+        super("Tunnel refused: " + new StatusLine(Args.notNull(response, "Response")));
+        this.response = copy(response);
+    }
+
+    /**
+     * Returns a defensive copy of the proxy response that refused the tunnel.
+     *
+     * @return the proxy response
+     * @since 5.7
+     */
+    public HttpResponse getResponse() {
+        return response;
+    }
+
+    /**
+     * Returns the HTTP status code of the proxy response.
+     *
+     * @return the status code (e.g. 407 for proxy authentication required)
+     * @since 5.7
+     */
+    public int getStatusCode() {
+        return response.getCode();
+    }
+
+    private static HttpResponse copy(final HttpResponse response) {
+        final BasicHttpResponse copy = new BasicHttpResponse(response.getCode(), response.getReasonPhrase());
+        copy.setVersion(response.getVersion());
+        for (final Header header : response.getHeaders()) {
+            copy.addHeader(header);
+        }
+        return copy;
+    }
+}

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/AuthenticationHandler.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/AuthenticationHandler.java
@@ -42,6 +42,7 @@ import org.apache.hc.client5.http.auth.AuthenticationException;
 import org.apache.hc.client5.http.auth.ChallengeType;
 import org.apache.hc.client5.http.auth.CredentialsProvider;
 import org.apache.hc.client5.http.auth.MalformedChallengeException;
+import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.protocol.HttpClientContext;
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.Internal;
@@ -352,6 +353,47 @@ public class AuthenticationHandler {
             authExchange.setState(AuthExchange.State.CHALLENGED);
             authExchange.setOptions(authOptions);
             return true;
+        }
+        return false;
+    }
+
+    /**
+     * Determines whether proxy authentication is needed for the given response,
+     * updating the {@link AuthExchange} and auth cache state as appropriate.
+     *
+     * @since 5.7
+     */
+    public boolean needProxyAuthentication(
+            final AuthExchange proxyAuthExchange,
+            final HttpHost proxy,
+            final HttpResponse response,
+            final AuthenticationStrategy proxyAuthStrategy,
+            final AuthCacheKeeper authCacheKeeper,
+            final HttpClientContext context) throws AuthenticationException, MalformedChallengeException {
+        final RequestConfig config = context.getRequestConfigOrDefault();
+        if (config.isAuthenticationEnabled()) {
+            final boolean proxyAuthRequested = isChallenged(
+                    proxy, ChallengeType.PROXY, response, proxyAuthExchange, context);
+            final boolean proxyMutualAuthRequired = isChallengeExpected(proxyAuthExchange);
+
+            if (authCacheKeeper != null) {
+                if (proxyAuthRequested) {
+                    authCacheKeeper.updateOnChallenge(proxy, null, proxyAuthExchange, context);
+                } else {
+                    authCacheKeeper.updateOnNoChallenge(proxy, null, proxyAuthExchange, context);
+                }
+            }
+
+            if (proxyAuthRequested || proxyMutualAuthRequired) {
+                final boolean updated = handleResponse(
+                        proxy, ChallengeType.PROXY, response, proxyAuthStrategy, proxyAuthExchange, context);
+
+                if (authCacheKeeper != null) {
+                    authCacheKeeper.updateOnResponse(proxy, null, proxyAuthExchange, context);
+                }
+
+                return updated;
+            }
         }
         return false;
     }

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/examples/AsyncClientH2ViaH2ProxyTunnel.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/examples/AsyncClientH2ViaH2ProxyTunnel.java
@@ -1,0 +1,150 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.client5.http.examples;
+
+import java.io.File;
+import java.util.concurrent.CountDownLatch;
+
+import javax.net.ssl.SSLContext;
+
+import org.apache.hc.client5.http.HttpRoute;
+import org.apache.hc.client5.http.async.methods.SimpleHttpRequest;
+import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
+import org.apache.hc.client5.http.async.methods.SimpleRequestBuilder;
+import org.apache.hc.client5.http.async.methods.SimpleRequestProducer;
+import org.apache.hc.client5.http.async.methods.SimpleResponseConsumer;
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.client5.http.impl.async.H2AsyncClientBuilder;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
+import org.apache.hc.client5.http.routing.HttpRoutePlanner;
+import org.apache.hc.core5.concurrent.FutureCallback;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.URIScheme;
+import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
+import org.apache.hc.core5.http2.ssl.H2ClientTlsStrategy;
+import org.apache.hc.core5.http.message.StatusLine;
+import org.apache.hc.core5.io.CloseMode;
+import org.apache.hc.core5.ssl.SSLContexts;
+
+/**
+ * Full example of pure HTTP/2 client execution through an HTTP/2 proxy tunnel.
+ *
+ * <p>
+ * Requirements:
+ * </p>
+ * <ul>
+ *   <li>Proxy endpoint speaks HTTP/2.</li>
+ *   <li>Proxy supports CONNECT for the requested target.</li>
+ *   <li>Target endpoint supports HTTP/2.</li>
+ * </ul>
+ *
+ * <p>
+ * This example configures a tunneled and layered route:
+ * {@code client -> (h2) proxy -> CONNECT tunnel -> TLS -> (h2) target}.
+ * </p>
+ */
+public class AsyncClientH2ViaH2ProxyTunnel {
+
+    private static TlsStrategy createTlsStrategy() throws Exception {
+        final String trustStore = System.getProperty("h2.truststore");
+        if (trustStore == null || trustStore.isEmpty()) {
+            return new H2ClientTlsStrategy();
+        }
+        final String trustStorePassword = System.getProperty("h2.truststore.password", "changeit");
+        final SSLContext sslContext = SSLContexts.custom()
+                .loadTrustMaterial(new File(trustStore), trustStorePassword.toCharArray())
+                .build();
+        return new H2ClientTlsStrategy(sslContext);
+    }
+
+    public static void main(final String[] args) throws Exception {
+        final String proxyScheme = System.getProperty("h2.proxy.scheme", "http");
+        final String proxyHost = System.getProperty("h2.proxy.host", "localhost");
+        final int proxyPort = Integer.parseInt(System.getProperty("h2.proxy.port", "8080"));
+        final String targetScheme = System.getProperty("h2.target.scheme", "https");
+        final String targetHost = System.getProperty("h2.target.host", "origin");
+        final int targetPort = Integer.parseInt(System.getProperty("h2.target.port", "9443"));
+        final String[] requestUris = System.getProperty("h2.paths", "/").split(",");
+
+        final HttpHost proxy = new HttpHost(proxyScheme, proxyHost, proxyPort);
+        final HttpHost target = new HttpHost(targetScheme, targetHost, targetPort);
+
+        final HttpRoutePlanner routePlanner = (final HttpHost routeTarget, final org.apache.hc.core5.http.protocol.HttpContext context) ->
+                new HttpRoute(routeTarget, null, proxy, URIScheme.HTTPS.same(routeTarget.getSchemeName()));
+        final TlsStrategy tlsStrategy = createTlsStrategy();
+
+        try (CloseableHttpAsyncClient client = H2AsyncClientBuilder.create()
+                .setRoutePlanner(routePlanner)
+                .setTlsStrategy(tlsStrategy)
+                .build()) {
+
+            client.start();
+
+            final CountDownLatch latch = new CountDownLatch(requestUris.length);
+
+            for (final String requestUri : requestUris) {
+                final String normalizedRequestUri = requestUri.trim();
+                final SimpleHttpRequest request = SimpleRequestBuilder.get()
+                        .setHttpHost(target)
+                        .setPath(normalizedRequestUri)
+                        .build();
+                final HttpClientContext clientContext = HttpClientContext.create();
+
+                client.execute(
+                        SimpleRequestProducer.create(request),
+                        SimpleResponseConsumer.create(),
+                        clientContext,
+                        new FutureCallback<SimpleHttpResponse>() {
+
+                            @Override
+                            public void completed(final SimpleHttpResponse response) {
+                                latch.countDown();
+                                System.out.println(request + " -> " + new StatusLine(response));
+                                System.out.println("Protocol: " + clientContext.getProtocolVersion());
+                                System.out.println(response.getBodyText());
+                            }
+
+                            @Override
+                            public void failed(final Exception ex) {
+                                latch.countDown();
+                                System.out.println(request + " -> " + ex);
+                            }
+
+                            @Override
+                            public void cancelled() {
+                                latch.countDown();
+                                System.out.println(request + " cancelled");
+                            }
+
+                        });
+            }
+
+            latch.await();
+            client.close(CloseMode.GRACEFUL);
+        }
+    }
+}

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/async/TestH2OverH2TunnelSupport.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/async/TestH2OverH2TunnelSupport.java
@@ -1,0 +1,718 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.client5.http.impl.async;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.net.SocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.ByteChannel;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.apache.hc.core5.concurrent.FutureCallback;
+import org.apache.hc.core5.http.EntityDetails;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.StreamControl;
+import org.apache.hc.core5.http.message.BasicHttpResponse;
+import org.apache.hc.core5.http.nio.AsyncClientExchangeHandler;
+import org.apache.hc.core5.http.nio.CapacityChannel;
+import org.apache.hc.core5.http.nio.DataStreamChannel;
+import org.apache.hc.core5.http.nio.RequestChannel;
+import org.apache.hc.core5.http.nio.command.RequestExecutionCommand;
+import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
+import org.apache.hc.core5.io.CloseMode;
+import org.apache.hc.core5.net.NamedEndpoint;
+import org.apache.hc.core5.reactor.Command;
+import org.apache.hc.core5.reactor.IOEventHandler;
+import org.apache.hc.core5.reactor.IOEventHandlerFactory;
+import org.apache.hc.core5.reactor.IOSession;
+import org.apache.hc.core5.reactor.ProtocolIOSession;
+import org.apache.hc.core5.reactor.ssl.TransportSecurityLayer;
+import org.apache.hc.core5.util.Timeout;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class TestH2OverH2TunnelSupport {
+
+    @Test
+    void testEstablishBuildsH2ConnectForAuthorityAndCompletes() {
+        final ScriptedProxySession session = new ScriptedProxySession(HttpStatus.SC_OK, true);
+        final HttpHost target = new HttpHost("https", "example.org", 443);
+        final RecordingCallback<ProtocolIOSession> callback = new RecordingCallback<>();
+
+        H2OverH2TunnelSupport.establish(session, target, Timeout.ofSeconds(1), false, null, callback);
+
+        Assertions.assertTrue(callback.completed);
+        Assertions.assertNull(callback.failed);
+        Assertions.assertFalse(callback.cancelled);
+        Assertions.assertNotNull(session.capturedRequest);
+        Assertions.assertEquals("CONNECT", session.capturedRequest.getMethod());
+        Assertions.assertEquals("example.org", session.capturedRequest.getAuthority().getHostName());
+        Assertions.assertEquals(443, session.capturedRequest.getAuthority().getPort());
+        Assertions.assertNull(session.capturedRequest.getScheme());
+        Assertions.assertNull(session.capturedRequest.getPath());
+    }
+
+    @Test
+    void testEstablishAppliesConnectRequestInterceptor() {
+        final ScriptedProxySession session = new ScriptedProxySession(HttpStatus.SC_OK, true);
+        final RecordingCallback<ProtocolIOSession> callback = new RecordingCallback<>();
+
+        H2OverH2TunnelSupport.establish(
+                session,
+                new HttpHost("https", "example.org", 443),
+                Timeout.ofSeconds(1),
+                false,
+                null,
+                (request, entityDetails, context) -> request.addHeader("Proxy-Authorization", "Basic dGVzdDp0ZXN0"),
+                callback);
+
+        Assertions.assertTrue(callback.completed);
+        Assertions.assertNotNull(session.capturedRequest);
+        Assertions.assertEquals("Basic dGVzdDp0ZXN0", session.capturedRequest.getFirstHeader("Proxy-Authorization").getValue());
+    }
+
+    @Test
+    void testEstablishFailsOnRefusedTunnel() {
+        final ScriptedProxySession session = new ScriptedProxySession(HttpStatus.SC_PROXY_AUTHENTICATION_REQUIRED, false);
+        final RecordingCallback<ProtocolIOSession> callback = new RecordingCallback<>();
+
+        H2OverH2TunnelSupport.establish(
+                session,
+                new HttpHost("https", "example.org", 443),
+                Timeout.ofSeconds(1),
+                false,
+                null,
+                callback);
+
+        Assertions.assertFalse(callback.completed);
+        Assertions.assertNotNull(callback.failed);
+        Assertions.assertInstanceOf(TunnelRefusedException.class, callback.failed);
+        Assertions.assertEquals(
+                HttpStatus.SC_PROXY_AUTHENTICATION_REQUIRED,
+                ((TunnelRefusedException) callback.failed).getStatusCode());
+    }
+
+    @Test
+    void testEstablishFailsWhenConnectResponseHasNoTunnelStream() {
+        final ScriptedProxySession session = new ScriptedProxySession(HttpStatus.SC_OK, false);
+        final RecordingCallback<ProtocolIOSession> callback = new RecordingCallback<>();
+
+        H2OverH2TunnelSupport.establish(
+                session,
+                new HttpHost("https", "example.org", 443),
+                Timeout.ofSeconds(1),
+                false,
+                null,
+                callback);
+
+        Assertions.assertFalse(callback.completed);
+        Assertions.assertNotNull(callback.failed);
+    }
+
+    @Test
+    void testEstablishWithProtocolStarterInvokesConnectedAndSeesInputBuffer() {
+        final ScriptedProxySession session = new ScriptedProxySession(HttpStatus.SC_OK, true, false, true, false);
+        final RecordingProtocolStarter protocolStarter = new RecordingProtocolStarter();
+        final RecordingCallback<IOSession> callback = new RecordingCallback<>();
+
+        H2OverH2TunnelSupport.establish(
+                session,
+                new HttpHost("http", "example.org", 80),
+                Timeout.ofSeconds(1),
+                false,
+                null,
+                protocolStarter,
+                callback);
+
+        Assertions.assertTrue(callback.completed);
+        Assertions.assertNull(callback.failed);
+        Assertions.assertTrue(protocolStarter.connectedCalled);
+        Assertions.assertTrue(protocolStarter.inputBufferSeen);
+    }
+
+    @Test
+    void testEstablishSecureTunnelUsesTlsStrategy() {
+        final ScriptedProxySession session = new ScriptedProxySession(HttpStatus.SC_OK, true);
+        final RecordingTlsStrategy tlsStrategy = new RecordingTlsStrategy();
+        final RecordingCallback<ProtocolIOSession> callback = new RecordingCallback<>();
+
+        H2OverH2TunnelSupport.establish(
+                session,
+                new HttpHost("https", "example.org", 443),
+                Timeout.ofSeconds(1),
+                true,
+                tlsStrategy,
+                callback);
+
+        Assertions.assertTrue(callback.completed);
+        Assertions.assertNull(callback.failed);
+        Assertions.assertTrue(tlsStrategy.invoked);
+    }
+
+    @Test
+    void testClosingTunnelDoesNotClosePhysicalSession() {
+        final ScriptedProxySession session = new ScriptedProxySession(HttpStatus.SC_OK, true);
+        final RecordingCallback<ProtocolIOSession> callback = new RecordingCallback<>();
+
+        H2OverH2TunnelSupport.establish(
+                session,
+                new HttpHost("http", "example.org", 80),
+                Timeout.ofSeconds(1),
+                false,
+                null,
+                callback);
+
+        Assertions.assertTrue(callback.completed);
+        Assertions.assertNotNull(callback.result);
+        callback.result.close(CloseMode.IMMEDIATE);
+        Assertions.assertTrue(session.isOpen(), "Closing tunnel session must not close physical HTTP/2 connection");
+    }
+
+    @Test
+    void testTunnelImmediateCloseCancelsStreamControlWhenPresent() {
+        final ScriptedProxySession session = new ScriptedProxySession(HttpStatus.SC_OK, true, false, false, true);
+        final RecordingCallback<ProtocolIOSession> callback = new RecordingCallback<>();
+
+        H2OverH2TunnelSupport.establish(
+                session,
+                new HttpHost("http", "example.org", 80),
+                Timeout.ofSeconds(1),
+                false,
+                null,
+                callback);
+
+        Assertions.assertTrue(callback.completed);
+        Assertions.assertNotNull(callback.result);
+        callback.result.close(CloseMode.IMMEDIATE);
+
+        Assertions.assertTrue(session.streamCancelCalled.get(), "IMMEDIATE close must cancel the CONNECT stream");
+        Assertions.assertTrue(session.isOpen(), "Cancelling tunnel stream must not close physical HTTP/2 connection");
+    }
+
+    @Test
+    void testTunnelWriteBufferIsBounded() throws Exception {
+        final ScriptedProxySession session = new ScriptedProxySession(HttpStatus.SC_OK, true);
+        final RecordingCallback<ProtocolIOSession> callback = new RecordingCallback<>();
+
+        H2OverH2TunnelSupport.establish(
+                session,
+                new HttpHost("http", "example.org", 80),
+                Timeout.ofSeconds(1),
+                false,
+                null,
+                callback);
+
+        Assertions.assertTrue(callback.completed);
+        Assertions.assertNotNull(callback.result);
+        final int payloadSize = 1024 * 1024;
+        final ByteBuffer src = ByteBuffer.allocate(payloadSize);
+        final int written = callback.result.write(src);
+        Assertions.assertTrue(written > 0);
+        Assertions.assertTrue(written < payloadSize, "Outbound writes must be bounded by tunnel buffer capacity");
+    }
+
+    @Test
+    void testCapacityUpdateIsNotUnbounded() {
+        final ScriptedProxySession session = new ScriptedProxySession(HttpStatus.SC_OK, true, true, false, false);
+        final RecordingCallback<ProtocolIOSession> callback = new RecordingCallback<>();
+
+        H2OverH2TunnelSupport.establish(
+                session,
+                new HttpHost("http", "example.org", 80),
+                Timeout.ofSeconds(1),
+                false,
+                null,
+                callback);
+
+        Assertions.assertTrue(callback.completed);
+        Assertions.assertTrue(session.lastCapacityUpdate > 0, "Tunnel setup should publish initial bounded capacity");
+        Assertions.assertTrue(session.lastCapacityUpdate < Integer.MAX_VALUE, "Capacity must not be unbounded");
+    }
+
+    @Test
+    void testGracefulCloseEndsStreamAfterDrain() throws Exception {
+        final ScriptedProxySession session = new ScriptedProxySession(HttpStatus.SC_OK, true);
+        final RecordingCallback<ProtocolIOSession> callback = new RecordingCallback<>();
+
+        H2OverH2TunnelSupport.establish(
+                session,
+                new HttpHost("http", "example.org", 80),
+                Timeout.ofSeconds(1),
+                false,
+                null,
+                callback);
+
+        Assertions.assertTrue(callback.completed);
+        Assertions.assertNotNull(callback.result);
+
+        final ByteBuffer src = ByteBuffer.wrap(new byte[]{1, 2, 3, 4, 5});
+        final int written = callback.result.write(src);
+        Assertions.assertEquals(5, written);
+
+        callback.result.close(CloseMode.GRACEFUL);
+
+        // Drive output flush: test runs in same package -> can call package-private method.
+        ((H2TunnelProtocolIOSession) callback.result).onOutputReady();
+
+        Assertions.assertTrue(session.endStreamCalled.get(), "GRACEFUL close must end the CONNECT stream after draining");
+        Assertions.assertTrue(session.isOpen(), "Ending tunnel stream must not close physical HTTP/2 connection");
+    }
+
+    @Test
+    void testStreamEndAfterEstablishedTunnelDoesNotFireFailure() {
+        final ScriptedProxySession session = new ScriptedProxySession(HttpStatus.SC_OK, true, false, false, false, true);
+        final RecordingCallback<ProtocolIOSession> callback = new RecordingCallback<>();
+
+        H2OverH2TunnelSupport.establish(
+                session,
+                new HttpHost("http", "example.org", 80),
+                Timeout.ofSeconds(1),
+                false,
+                null,
+                callback);
+
+        Assertions.assertTrue(callback.completed, "Tunnel should complete successfully");
+        Assertions.assertNull(callback.failed, "streamEnd after established tunnel must not overwrite with failure");
+    }
+
+    @Test
+    void testStreamEndBeforeTunnelEstablishedFiresFailure() {
+        // 200 but no entity details -> consumeResponse throws -> fail() fires
+        // then streamEnd arrives on the already-failed handler
+        final ScriptedProxySession session = new ScriptedProxySession(HttpStatus.SC_OK, false, false, false, false, true);
+        final RecordingCallback<ProtocolIOSession> callback = new RecordingCallback<>();
+
+        H2OverH2TunnelSupport.establish(
+                session,
+                new HttpHost("http", "example.org", 80),
+                Timeout.ofSeconds(1),
+                false,
+                null,
+                callback);
+
+        Assertions.assertFalse(callback.completed);
+        Assertions.assertNotNull(callback.failed, "streamEnd with no tunnel must report failure");
+    }
+
+    static class RecordingCallback<T> implements FutureCallback<T> {
+
+        volatile boolean completed;
+        volatile boolean cancelled;
+        volatile Exception failed;
+        volatile T result;
+
+        @Override
+        public void completed(final T result) {
+            this.completed = true;
+            this.result = result;
+        }
+
+        @Override
+        public void failed(final Exception ex) {
+            this.failed = ex;
+        }
+
+        @Override
+        public void cancelled() {
+            this.cancelled = true;
+        }
+    }
+
+    static class RecordingProtocolStarter implements IOEventHandlerFactory {
+
+        volatile boolean connectedCalled;
+        volatile boolean inputBufferSeen;
+
+        @Override
+        public IOEventHandler createHandler(final ProtocolIOSession ioSession, final Object attachment) {
+            return new IOEventHandler() {
+
+                @Override
+                public void connected(final IOSession session) {
+                    connectedCalled = true;
+                }
+
+                @Override
+                public void inputReady(final IOSession session, final ByteBuffer src) {
+                    if (src != null && src.hasRemaining()) {
+                        inputBufferSeen = true;
+                    }
+                }
+
+                @Override
+                public void outputReady(final IOSession session) {
+                }
+
+                @Override
+                public void timeout(final IOSession session, final Timeout timeout) {
+                }
+
+                @Override
+                public void exception(final IOSession session, final Exception cause) {
+                }
+
+                @Override
+                public void disconnected(final IOSession session) {
+                }
+            };
+        }
+    }
+
+    static class RecordingTlsStrategy implements TlsStrategy {
+
+        volatile boolean invoked;
+
+        @Override
+        public boolean upgrade(
+                final TransportSecurityLayer sessionLayer,
+                final HttpHost host,
+                final SocketAddress localAddress,
+                final SocketAddress remoteAddress,
+                final Object attachment,
+                final Timeout handshakeTimeout) {
+            invoked = true;
+            return true;
+        }
+
+        @Override
+        public void upgrade(
+                final TransportSecurityLayer sessionLayer,
+                final NamedEndpoint endpoint,
+                final Object attachment,
+                final Timeout handshakeTimeout,
+                final FutureCallback<TransportSecurityLayer> callback) {
+            invoked = true;
+            if (callback != null) {
+                callback.completed(sessionLayer);
+            }
+        }
+    }
+
+    static class ScriptedProxySession implements IOSession {
+
+        private final int responseCode;
+        private final boolean withTunnelStream;
+        private final boolean signalCapacity;
+        private final boolean emitInputData;
+        private final boolean provideStreamControl;
+        private final boolean sendStreamEnd;
+
+        private final Lock lock;
+        private Timeout socketTimeout;
+
+        HttpRequest capturedRequest;
+        volatile int lastCapacityUpdate;
+
+        private final AtomicBoolean open;
+        final AtomicBoolean streamCancelCalled;
+        final AtomicBoolean endStreamCalled;
+
+        ScriptedProxySession(final int responseCode, final boolean withTunnelStream) {
+            this(responseCode, withTunnelStream, false, false, false, false);
+        }
+
+        ScriptedProxySession(final int responseCode, final boolean withTunnelStream, final boolean signalCapacity) {
+            this(responseCode, withTunnelStream, signalCapacity, false, false, false);
+        }
+
+        ScriptedProxySession(
+                final int responseCode,
+                final boolean withTunnelStream,
+                final boolean signalCapacity,
+                final boolean emitInputData,
+                final boolean provideStreamControl) {
+            this(responseCode, withTunnelStream, signalCapacity, emitInputData, provideStreamControl, false);
+        }
+
+        ScriptedProxySession(
+                final int responseCode,
+                final boolean withTunnelStream,
+                final boolean signalCapacity,
+                final boolean emitInputData,
+                final boolean provideStreamControl,
+                final boolean sendStreamEnd) {
+            this.responseCode = responseCode;
+            this.withTunnelStream = withTunnelStream;
+            this.signalCapacity = signalCapacity;
+            this.emitInputData = emitInputData;
+            this.provideStreamControl = provideStreamControl;
+            this.sendStreamEnd = sendStreamEnd;
+
+            this.lock = new ReentrantLock();
+            this.socketTimeout = Timeout.ofSeconds(30);
+            this.lastCapacityUpdate = -1;
+            this.open = new AtomicBoolean(true);
+            this.streamCancelCalled = new AtomicBoolean(false);
+            this.endStreamCalled = new AtomicBoolean(false);
+        }
+
+        @Override
+        public IOEventHandler getHandler() {
+            return null;
+        }
+
+        @Override
+        public void upgrade(final IOEventHandler handler) {
+        }
+
+        @Override
+        public Lock getLock() {
+            return lock;
+        }
+
+        @Override
+        public void enqueue(final Command command, final Command.Priority priority) {
+            if (!(command instanceof RequestExecutionCommand)) {
+                return;
+            }
+
+            final RequestExecutionCommand requestExecutionCommand = (RequestExecutionCommand) command;
+            final AsyncClientExchangeHandler exchangeHandler = requestExecutionCommand.getExchangeHandler();
+            final org.apache.hc.core5.http.protocol.HttpContext context = requestExecutionCommand.getContext();
+
+            try {
+                if (provideStreamControl && exchangeHandler instanceof H2OverH2TunnelExchangeHandler) {
+                    final StreamControl streamControl = (StreamControl) Proxy.newProxyInstance(
+                            StreamControl.class.getClassLoader(),
+                            new Class<?>[]{StreamControl.class},
+                            (proxy, method, args) -> {
+                                if ("cancel".equals(method.getName())) {
+                                    streamCancelCalled.set(true);
+                                    return method.getReturnType() == Boolean.TYPE ? Boolean.TRUE : null;
+                                }
+                                return defaultValue(method);
+                            });
+
+                    ((H2OverH2TunnelExchangeHandler) exchangeHandler).initiated(streamControl);
+                }
+
+                exchangeHandler.produceRequest((RequestChannel) (request, entityDetails, requestContext) -> capturedRequest = request, context);
+
+                if (signalCapacity) {
+                    exchangeHandler.updateCapacity((CapacityChannel) increment -> lastCapacityUpdate = increment);
+                }
+
+                final EntityDetails responseEntityDetails =
+                        withTunnelStream ? new org.apache.hc.core5.http.impl.BasicEntityDetails(-1, null) : null;
+                exchangeHandler.consumeResponse(new BasicHttpResponse(responseCode), responseEntityDetails, context);
+
+                if (withTunnelStream && responseCode == HttpStatus.SC_OK) {
+                    exchangeHandler.produce(new DataStreamChannel() {
+
+                        @Override
+                        public void requestOutput() {
+                        }
+
+                        @Override
+                        public int write(final ByteBuffer src) {
+                            final int remaining = src != null ? src.remaining() : 0;
+                            if (remaining > 0 && src != null) {
+                                final byte[] tmp = new byte[remaining];
+                                src.get(tmp);
+                            }
+                            return remaining;
+                        }
+
+                        @Override
+                        public void endStream() throws IOException {
+
+                        }
+
+                        @Override
+                        public void endStream(final java.util.List<? extends org.apache.hc.core5.http.Header> trailers) {
+                            endStreamCalled.set(true);
+                        }
+
+                    });
+
+                    if (emitInputData) {
+                        exchangeHandler.consume(ByteBuffer.wrap(new byte[]{1, 2, 3}));
+                    }
+                }
+
+                if (sendStreamEnd) {
+                    exchangeHandler.streamEnd(null);
+                }
+            } catch (final Exception ex) {
+                exchangeHandler.failed(ex);
+            }
+        }
+
+        private static Object defaultValue(final Method method) {
+            final Class<?> rt = method.getReturnType();
+            if (rt == Void.TYPE) {
+                return null;
+            }
+            if (rt == Boolean.TYPE) {
+                return false;
+            }
+            if (rt == Integer.TYPE) {
+                return 0;
+            }
+            if (rt == Long.TYPE) {
+                return 0L;
+            }
+            if (rt == Short.TYPE) {
+                return (short) 0;
+            }
+            if (rt == Byte.TYPE) {
+                return (byte) 0;
+            }
+            if (rt == Character.TYPE) {
+                return (char) 0;
+            }
+            if (rt == Float.TYPE) {
+                return 0f;
+            }
+            if (rt == Double.TYPE) {
+                return 0d;
+            }
+            return null;
+        }
+
+        @Override
+        public boolean hasCommands() {
+            return false;
+        }
+
+        @Override
+        public Command poll() {
+            return null;
+        }
+
+        @Override
+        public ByteChannel channel() {
+            return this;
+        }
+
+        @Override
+        public SocketAddress getRemoteAddress() {
+            return null;
+        }
+
+        @Override
+        public SocketAddress getLocalAddress() {
+            return null;
+        }
+
+        @Override
+        public int getEventMask() {
+            return 0;
+        }
+
+        @Override
+        public void setEventMask(final int ops) {
+        }
+
+        @Override
+        public void setEvent(final int op) {
+        }
+
+        @Override
+        public void clearEvent(final int op) {
+        }
+
+        @Override
+        public void close() {
+            open.set(false);
+        }
+
+        @Override
+        public void close(final CloseMode closeMode) {
+            open.set(false);
+        }
+
+        @Override
+        public Status getStatus() {
+            return open.get() ? Status.ACTIVE : Status.CLOSED;
+        }
+
+        @Override
+        public Timeout getSocketTimeout() {
+            return socketTimeout;
+        }
+
+        @Override
+        public void setSocketTimeout(final Timeout timeout) {
+            this.socketTimeout = timeout;
+        }
+
+        @Override
+        public long getLastReadTime() {
+            return 0;
+        }
+
+        @Override
+        public long getLastWriteTime() {
+            return 0;
+        }
+
+        @Override
+        public long getLastEventTime() {
+            return 0;
+        }
+
+        @Override
+        public void updateReadTime() {
+        }
+
+        @Override
+        public void updateWriteTime() {
+        }
+
+        @Override
+        public int read(final ByteBuffer dst) {
+            return 0;
+        }
+
+        @Override
+        public int write(final ByteBuffer src) {
+            final int remaining = src != null ? src.remaining() : 0;
+            if (remaining > 0) {
+                final byte[] tmp = new byte[remaining];
+                src.get(tmp);
+            }
+            return remaining;
+        }
+
+        @Override
+        public boolean isOpen() {
+            return open.get();
+        }
+
+        @Override
+        public String getId() {
+            return "proxy-session";
+        }
+    }
+}

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/async/TestH2TunnelProtocolStarter.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/async/TestH2TunnelProtocolStarter.java
@@ -1,0 +1,83 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.client5.http.impl.async;
+
+import org.apache.hc.core5.http.config.CharCodingConfig;
+import org.apache.hc.core5.http2.config.H2Config;
+import org.apache.hc.core5.http2.impl.nio.ClientH2PrefaceHandler;
+import org.apache.hc.core5.reactor.IOEventHandler;
+import org.apache.hc.core5.reactor.ProtocolIOSession;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class TestH2TunnelProtocolStarter {
+
+    @Test
+    void testCreatesMinimalH2HandlerWithoutPushOrLogging() {
+        final H2TunnelProtocolStarter starter = new H2TunnelProtocolStarter(
+                H2Config.DEFAULT, CharCodingConfig.DEFAULT);
+        final ProtocolIOSession ioSession = Mockito.mock(ProtocolIOSession.class);
+        Mockito.when(ioSession.getId()).thenReturn("test-tunnel");
+
+        final IOEventHandler handler = starter.createHandler(ioSession, null);
+
+        Assertions.assertNotNull(handler);
+        Assertions.assertInstanceOf(ClientH2PrefaceHandler.class, handler);
+    }
+
+    @Test
+    void testDefaultsWhenNullConfig() {
+        final H2TunnelProtocolStarter starter = new H2TunnelProtocolStarter(null, null);
+        final ProtocolIOSession ioSession = Mockito.mock(ProtocolIOSession.class);
+        Mockito.when(ioSession.getId()).thenReturn("test-tunnel-null");
+
+        final IOEventHandler handler = starter.createHandler(ioSession, null);
+
+        Assertions.assertNotNull(handler);
+        Assertions.assertInstanceOf(ClientH2PrefaceHandler.class, handler);
+    }
+
+    @Test
+    void testCustomH2ConfigIsRespected() {
+        final H2Config customConfig = H2Config.custom()
+                .setMaxFrameSize(32768)
+                .setInitialWindowSize(128 * 1024)
+                .setPushEnabled(false)
+                .build();
+        final H2TunnelProtocolStarter starter = new H2TunnelProtocolStarter(
+                customConfig, CharCodingConfig.DEFAULT);
+        final ProtocolIOSession ioSession = Mockito.mock(ProtocolIOSession.class);
+        Mockito.when(ioSession.getId()).thenReturn("test-tunnel-custom");
+
+        final IOEventHandler handler = starter.createHandler(ioSession, null);
+
+        Assertions.assertNotNull(handler);
+        Assertions.assertInstanceOf(ClientH2PrefaceHandler.class, handler);
+    }
+
+}

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/async/TestH2TunnelRawIOSession.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/async/TestH2TunnelRawIOSession.java
@@ -1,0 +1,391 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.client5.http.impl.async;
+
+import java.io.IOException;
+import java.lang.reflect.Proxy;
+import java.net.SocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.ByteChannel;
+import java.nio.channels.CancelledKeyException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.apache.hc.core5.http.StreamControl;
+import org.apache.hc.core5.http.nio.CapacityChannel;
+import org.apache.hc.core5.http.nio.DataStreamChannel;
+import org.apache.hc.core5.http.nio.command.ShutdownCommand;
+import org.apache.hc.core5.io.CloseMode;
+import org.apache.hc.core5.reactor.Command;
+import org.apache.hc.core5.reactor.IOEventHandler;
+import org.apache.hc.core5.reactor.IOSession;
+import org.apache.hc.core5.util.Timeout;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class TestH2TunnelRawIOSession {
+
+    @Test
+    void testCapacityInitialUpdateIsBounded() throws Exception {
+        final DummyPhysicalSession physical = new DummyPhysicalSession();
+        final H2TunnelRawIOSession raw = new H2TunnelRawIOSession(physical, Timeout.ofSeconds(5), null);
+
+        final AtomicInteger last = new AtomicInteger(0);
+        raw.updateCapacityChannel(new CapacityChannel() {
+            @Override
+            public void update(final int increment) {
+                last.set(increment);
+            }
+        });
+
+        Assertions.assertTrue(last.get() > 0);
+        Assertions.assertTrue(last.get() < Integer.MAX_VALUE);
+    }
+
+    @Test
+    void testAppendInputOverflowFails() throws Exception {
+        final DummyPhysicalSession physical = new DummyPhysicalSession();
+        final H2TunnelRawIOSession raw = new H2TunnelRawIOSession(physical, Timeout.ofSeconds(5), null);
+
+        // INBOUND_BUFFER_LIMIT is 64k in the implementation; overflow by 1.
+        final ByteBuffer tooBig = ByteBuffer.allocate(64 * 1024 + 1);
+        Assertions.assertThrows(IOException.class, () -> raw.appendInput(tooBig));
+    }
+
+    @Test
+    void testReadTriggersCapacityUpdateOnConsumption() throws Exception {
+        final DummyPhysicalSession physical = new DummyPhysicalSession();
+        final H2TunnelRawIOSession raw = new H2TunnelRawIOSession(physical, Timeout.ofSeconds(5), null);
+
+        final AtomicInteger last = new AtomicInteger(-1);
+        raw.updateCapacityChannel(new CapacityChannel() {
+            @Override
+            public void update(final int increment) {
+                last.set(increment);
+            }
+        });
+
+        raw.appendInput(ByteBuffer.wrap(new byte[]{1, 2, 3, 4}));
+
+        final ByteBuffer dst = ByteBuffer.allocate(4);
+        final int n = raw.read(dst);
+        Assertions.assertEquals(4, n);
+        // Capacity update should publish the consumed bytes (4), not unbounded.
+        Assertions.assertEquals(4, last.get());
+    }
+
+    @Test
+    void testWriteIsBounded() {
+        final DummyPhysicalSession physical = new DummyPhysicalSession();
+        final H2TunnelRawIOSession raw = new H2TunnelRawIOSession(physical, Timeout.ofSeconds(5), null);
+
+        final ByteBuffer src = ByteBuffer.allocate(1024 * 1024);
+        final int n = raw.write(src);
+        Assertions.assertTrue(n > 0);
+        Assertions.assertTrue(n < 1024 * 1024);
+        Assertions.assertEquals(64 * 1024, n, "Expected OUTBOUND_BUFFER_LIMIT (64k) write bound");
+    }
+
+    @Test
+    void testImmediateCloseCancelsStreamControlButNotPhysicalSession() {
+        final DummyPhysicalSession physical = new DummyPhysicalSession();
+
+        final AtomicBoolean cancelled = new AtomicBoolean(false);
+        final StreamControl streamControl = (StreamControl) Proxy.newProxyInstance(
+                StreamControl.class.getClassLoader(),
+                new Class<?>[]{StreamControl.class},
+                (proxy, method, args) -> {
+                    final String name = method.getName();
+                    final Class<?> rt = method.getReturnType();
+
+                    if ("cancel".equals(name)) {
+                        cancelled.set(true);
+                        // IMPORTANT: cancel() may return boolean (Cancellable)
+                        return rt == Boolean.TYPE ? Boolean.TRUE : null;
+                    }
+
+                    if (rt == Void.TYPE) {
+                        return null;
+                    }
+                    if (rt == Boolean.TYPE) {
+                        return false;
+                    }
+                    if (rt == Integer.TYPE) {
+                        return 0;
+                    }
+                    if (rt == Long.TYPE) {
+                        return 0L;
+                    }
+                    if (rt == Short.TYPE) {
+                        return (short) 0;
+                    }
+                    if (rt == Byte.TYPE) {
+                        return (byte) 0;
+                    }
+                    if (rt == Character.TYPE) {
+                        return (char) 0;
+                    }
+                    if (rt == Float.TYPE) {
+                        return 0f;
+                    }
+                    if (rt == Double.TYPE) {
+                        return 0d;
+                    }
+                    return null;
+                });
+
+        final H2TunnelRawIOSession raw = new H2TunnelRawIOSession(physical, Timeout.ofSeconds(5), streamControl);
+        raw.close(CloseMode.IMMEDIATE);
+
+        Assertions.assertTrue(cancelled.get(), "IMMEDIATE close must cancel stream");
+        Assertions.assertTrue(physical.isOpen(), "Tunnel close must not close physical HTTP/2 connection");
+    }
+
+    @Test
+    void testGracefulCloseEndsStreamAfterDrain() throws Exception {
+        final DummyPhysicalSession physical = new DummyPhysicalSession();
+
+        final AtomicBoolean endStreamCalled = new AtomicBoolean(false);
+        rawAttachChannel(physical, endStreamCalled);
+
+        final H2TunnelRawIOSession raw = new H2TunnelRawIOSession(physical, Timeout.ofSeconds(5), null);
+        raw.attachChannel(physical.dataChannel);
+
+        // Put some outbound bytes
+        final ByteBuffer src = ByteBuffer.wrap(new byte[]{1, 2, 3, 4, 5});
+        final int written = raw.write(src);
+        Assertions.assertEquals(5, written);
+
+        raw.close(CloseMode.GRACEFUL);
+        raw.flushOutput();
+
+        Assertions.assertTrue(endStreamCalled.get(), "GRACEFUL close must endStream once outbound drained");
+    }
+
+    @Test
+    void testRequestOutputOnCancelledKeyClosesTunnel() {
+        final DummyPhysicalSession physical = new DummyPhysicalSession();
+        final H2TunnelRawIOSession raw = new H2TunnelRawIOSession(physical, Timeout.ofSeconds(5), null);
+        raw.attachChannel(new DataStreamChannel() {
+
+            @Override
+            public void requestOutput() {
+                throw new CancelledKeyException();
+            }
+
+            @Override
+            public int write(final ByteBuffer src) {
+                return 0;
+            }
+
+            @Override
+            public void endStream() {
+            }
+
+            @Override
+            public void endStream(final java.util.List<? extends org.apache.hc.core5.http.Header> trailers) {
+            }
+        });
+
+        raw.enqueue(ShutdownCommand.GRACEFUL, Command.Priority.NORMAL);
+
+        Assertions.assertEquals(IOSession.Status.CLOSED, raw.getStatus());
+    }
+
+    private static void rawAttachChannel(final DummyPhysicalSession physical, final AtomicBoolean endStreamCalled) {
+        physical.dataChannel = new DataStreamChannel() {
+
+            @Override
+            public void requestOutput() {
+            }
+
+            @Override
+            public int write(final ByteBuffer src) {
+                final int remaining = src != null ? src.remaining() : 0;
+                if (remaining > 0 && src != null) {
+                    final byte[] tmp = new byte[remaining];
+                    src.get(tmp);
+                }
+                return remaining;
+            }
+
+            @Override
+            public void endStream() throws IOException {
+
+            }
+
+            @Override
+            public void endStream(final java.util.List<? extends org.apache.hc.core5.http.Header> trailers) {
+                endStreamCalled.set(true);
+            }
+        };
+    }
+
+    static final class DummyPhysicalSession implements IOSession {
+
+        private final Lock lock = new ReentrantLock();
+        private volatile boolean open = true;
+        private volatile Timeout socketTimeout = Timeout.ofSeconds(30);
+
+        volatile DataStreamChannel dataChannel;
+
+        @Override
+        public IOEventHandler getHandler() {
+            return null;
+        }
+
+        @Override
+        public void upgrade(final IOEventHandler handler) {
+        }
+
+        @Override
+        public Lock getLock() {
+            return lock;
+        }
+
+        @Override
+        public void enqueue(final Command command, final Command.Priority priority) {
+        }
+
+        @Override
+        public boolean hasCommands() {
+            return false;
+        }
+
+        @Override
+        public Command poll() {
+            return null;
+        }
+
+        @Override
+        public ByteChannel channel() {
+            return this;
+        }
+
+        @Override
+        public SocketAddress getRemoteAddress() {
+            return null;
+        }
+
+        @Override
+        public SocketAddress getLocalAddress() {
+            return null;
+        }
+
+        @Override
+        public int getEventMask() {
+            return 0;
+        }
+
+        @Override
+        public void setEventMask(final int ops) {
+        }
+
+        @Override
+        public void setEvent(final int op) {
+        }
+
+        @Override
+        public void clearEvent(final int op) {
+        }
+
+        @Override
+        public void close() {
+            open = false;
+        }
+
+        @Override
+        public void close(final CloseMode closeMode) {
+            open = false;
+        }
+
+        @Override
+        public Status getStatus() {
+            return open ? Status.ACTIVE : Status.CLOSED;
+        }
+
+        @Override
+        public Timeout getSocketTimeout() {
+            return socketTimeout;
+        }
+
+        @Override
+        public void setSocketTimeout(final Timeout timeout) {
+            socketTimeout = timeout;
+        }
+
+        @Override
+        public long getLastReadTime() {
+            return 0;
+        }
+
+        @Override
+        public long getLastWriteTime() {
+            return 0;
+        }
+
+        @Override
+        public long getLastEventTime() {
+            return 0;
+        }
+
+        @Override
+        public void updateReadTime() {
+        }
+
+        @Override
+        public void updateWriteTime() {
+        }
+
+        @Override
+        public int read(final ByteBuffer dst) {
+            return 0;
+        }
+
+        @Override
+        public int write(final ByteBuffer src) {
+            final int remaining = src != null ? src.remaining() : 0;
+            if (remaining > 0 && src != null) {
+                final byte[] tmp = new byte[remaining];
+                src.get(tmp);
+            }
+            return remaining;
+        }
+
+        @Override
+        public boolean isOpen() {
+            return open;
+        }
+
+        @Override
+        public String getId() {
+            return "dummy-physical";
+        }
+    }
+}


### PR DESCRIPTION
…through HTTP/2 proxies

Wire HTTP/2 tunnel establishment into InternalH2ConnPool for tunneled routes by using H2OverH2TunnelSupport to convert an existing proxy HTTP/2 connection into a stream-backed tunnel session