### PR TITLE
Named Pipe transport support for Windows   

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -84,3 +84,34 @@ jobs:
         EOF
     - name: Build with Maven
       run: ./mvnw -V --file pom.xml --no-transfer-progress -DtrimStackTrace=false -Djunit.jupiter.execution.parallel.enabled=false -Dhc.build.toolchain.version="${HC_BUILD_TOOLCHAIN_VERSION}" -Pdocker
+
+  # Windows Named Pipe tests — requires Windows for \\.\pipe\... support
+  windows-npipe:
+
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        java: [ 17, 21 ]
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v5
+    - uses: actions/cache@v4
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v5
+      with:
+        distribution: 'temurin'
+        java-version: ${{ matrix.java }}
+    - name: Build all modules (compile only)
+      run: ./mvnw.cmd -V --file pom.xml --no-transfer-progress -P-use-toolchains install -DskipTests
+    - name: Run Named Pipe unit tests
+      timeout-minutes: 10
+      run: ./mvnw.cmd -V --file pom.xml --no-transfer-progress -P-use-toolchains -pl httpclient5-testing "-DtrimStackTrace=false" "-Djunit.jupiter.execution.parallel.enabled=false" "-Dtest=NpipeIntegrationTests" test
+    - name: Run Named Pipe Docker integration tests
+      timeout-minutes: 10
+      run: ./mvnw.cmd -V --file pom.xml --no-transfer-progress -P-use-toolchains -pl httpclient5-testing "-DtrimStackTrace=false" "-Djunit.jupiter.execution.parallel.enabled=false" "-Dtest=WindowsNamedPipeDockerIT" -Pdocker verify

--- a/httpclient5-testing/pom.xml
+++ b/httpclient5-testing/pom.xml
@@ -84,6 +84,11 @@
       <type>pom</type>
     </dependency>
     <dependency>
+      <groupId>net.java.dev.jna</groupId>
+      <artifactId>jna-platform</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>

--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/compatibility/WindowsNamedPipeDockerIT.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/compatibility/WindowsNamedPipeDockerIT.java
@@ -1,0 +1,178 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.client5.testing.compatibility;
+
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Integration test that validates Windows Named Pipe (npipe://) connectivity
+ * to Docker Desktop via {@code \\.\pipe\docker_engine}.
+ * <p>
+ * This test requires:
+ * <ul>
+ *     <li>Windows OS</li>
+ *     <li>Docker Desktop running (which exposes {@code \\.\pipe\docker_engine})</li>
+ * </ul>
+ * <p>
+ * The test uses Testcontainers to verify Docker is available, then exercises the
+ * HttpClient Named Pipe transport by querying Docker's REST API directly through
+ * the named pipe — the same way Docker CLI communicates with the daemon on Windows.
+ * </p>
+ * <p>
+ * This is the Windows equivalent of connecting to {@code /var/run/docker.sock}
+ * on Linux/macOS.
+ * </p>
+ *
+ * @since 5.7
+ */
+@Testcontainers(disabledWithoutDocker = true)
+@EnabledOnOs(OS.WINDOWS)
+class WindowsNamedPipeDockerIT {
+
+    private static final String DOCKER_PIPE = "\\\\.\\pipe\\docker_engine";
+
+    @Test
+    @DisplayName("GET /version via named pipe to Docker Desktop")
+    void testDockerVersionViaNpipe() throws Exception {
+        // Verify Docker is actually available (Testcontainers check)
+        Assertions.assertTrue(DockerClientFactory.instance().isDockerAvailable(),
+                "Docker must be available for this test");
+
+        try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
+            final HttpGet httpGet = new HttpGet("http://localhost/version");
+            httpGet.setConfig(RequestConfig.custom()
+                    .setNamedPipe(DOCKER_PIPE)
+                    .build());
+
+            client.execute(httpGet, response -> {
+                Assertions.assertEquals(HttpStatus.SC_OK, response.getCode(),
+                        "Docker /version should return 200 OK");
+                final String body = EntityUtils.toString(response.getEntity());
+                Assertions.assertNotNull(body, "Response body should not be null");
+                Assertions.assertTrue(body.contains("ApiVersion"),
+                        "Docker /version response should contain ApiVersion");
+                return null;
+            });
+        }
+    }
+
+    @Test
+    @DisplayName("GET /info via named pipe to Docker Desktop")
+    void testDockerInfoViaNpipe() throws Exception {
+        Assertions.assertTrue(DockerClientFactory.instance().isDockerAvailable(),
+                "Docker must be available for this test");
+
+        try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
+            final HttpGet httpGet = new HttpGet("http://localhost/info");
+            httpGet.setConfig(RequestConfig.custom()
+                    .setNamedPipe(DOCKER_PIPE)
+                    .build());
+
+            client.execute(httpGet, response -> {
+                Assertions.assertEquals(HttpStatus.SC_OK, response.getCode(),
+                        "Docker /info should return 200 OK");
+                final String body = EntityUtils.toString(response.getEntity());
+                Assertions.assertNotNull(body, "Response body should not be null");
+                Assertions.assertTrue(body.contains("Containers"),
+                        "Docker /info response should contain Containers field");
+                return null;
+            });
+        }
+    }
+
+    @Test
+    @DisplayName("GET /containers/json via named pipe to Docker Desktop")
+    void testDockerContainersViaNpipe() throws Exception {
+        Assertions.assertTrue(DockerClientFactory.instance().isDockerAvailable(),
+                "Docker must be available for this test");
+
+        try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
+            final HttpGet httpGet = new HttpGet("http://localhost/containers/json");
+            httpGet.setConfig(RequestConfig.custom()
+                    .setNamedPipe(DOCKER_PIPE)
+                    .build());
+
+            client.execute(httpGet, response -> {
+                Assertions.assertEquals(HttpStatus.SC_OK, response.getCode(),
+                        "Docker /containers/json should return 200 OK");
+                final String body = EntityUtils.toString(response.getEntity());
+                Assertions.assertNotNull(body, "Response body should not be null");
+                // Should be a JSON array (possibly empty)
+                Assertions.assertTrue(body.startsWith("["),
+                        "Docker /containers/json should return a JSON array");
+                return null;
+            });
+        }
+    }
+
+    @Test
+    @DisplayName("Start Testcontainer and verify it appears via named pipe")
+    void testTestcontainersViaNpipe() throws Exception {
+        Assertions.assertTrue(DockerClientFactory.instance().isDockerAvailable(),
+                "Docker must be available for this test");
+
+        // Start a simple container via Testcontainers
+        try (final org.testcontainers.containers.GenericContainer<?> container =
+                     new org.testcontainers.containers.GenericContainer<>("alpine:3.19")
+                             .withCommand("sleep", "30")) {
+            container.start();
+            final String containerId = container.getContainerId();
+
+            // Now query Docker API through our named pipe transport
+            try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
+                final HttpGet httpGet = new HttpGet(
+                        "http://localhost/containers/" + containerId + "/json");
+                httpGet.setConfig(RequestConfig.custom()
+                        .setNamedPipe(DOCKER_PIPE)
+                        .build());
+
+                client.execute(httpGet, response -> {
+                    Assertions.assertEquals(HttpStatus.SC_OK, response.getCode(),
+                            "Container inspect should return 200 OK");
+                    final String body = EntityUtils.toString(response.getEntity());
+                    Assertions.assertTrue(body.contains(containerId),
+                            "Container inspect should reference the container ID");
+                    Assertions.assertTrue(body.contains("Running"),
+                            "Container should be in Running state");
+                    return null;
+                });
+            }
+        }
+    }
+}

--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/sync/NamedPipeProxyServer.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/sync/NamedPipeProxyServer.java
@@ -1,0 +1,394 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.hc.client5.testing.extension.sync;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.sun.jna.Memory;
+import com.sun.jna.Native;
+import com.sun.jna.Pointer;
+import com.sun.jna.platform.win32.Kernel32;
+import com.sun.jna.platform.win32.WinBase;
+import com.sun.jna.platform.win32.WinNT;
+import com.sun.jna.ptr.IntByReference;
+import com.sun.jna.win32.StdCallLibrary;
+import com.sun.jna.win32.W32APIOptions;
+
+/**
+ * A test proxy server that bridges Windows Named Pipes to TCP connections.
+ * <p>
+ * Mirrors the architecture of {@link UnixDomainProxyServer}: each client
+ * connection is accepted on a new pipe instance and proxied bidirectionally
+ * to a TCP backend, without blocking the accept loop.
+ * </p>
+ * <p>
+ * Uses overlapped I/O with {@link Pointer}-based buffers for pipe operations,
+ * matching the I/O mode used by the production {@code NamedPipeSocket}.
+ * </p>
+ *
+ * @since 5.7
+ */
+public final class NamedPipeProxyServer {
+
+    /**
+     * Custom Kernel32 binding with Pointer-based ReadFile/WriteFile for
+     * overlapped I/O safety. Standard JNA Kernel32 uses byte[] buffers
+     * which are unsafe with overlapped I/O (JNA frees the temporary native
+     * memory before the async operation completes).
+     */
+    interface PipeKernel32 extends StdCallLibrary {
+
+        PipeKernel32 INSTANCE = Native.load("kernel32", PipeKernel32.class,
+                W32APIOptions.DEFAULT_OPTIONS);
+
+        boolean ReadFile(WinNT.HANDLE hFile, Pointer lpBuffer, int nNumberOfBytesToRead,
+                         IntByReference lpNumberOfBytesRead, WinBase.OVERLAPPED lpOverlapped);
+
+        boolean WriteFile(WinNT.HANDLE hFile, Pointer lpBuffer, int nNumberOfBytesToWrite,
+                          IntByReference lpNumberOfBytesWritten, WinBase.OVERLAPPED lpOverlapped);
+
+        /**
+         * Uses {@link Pointer} to prevent JNA auto-marshaling from overwriting
+         * OS-updated native OVERLAPPED fields with stale Java-side values.
+         */
+        boolean GetOverlappedResult(WinNT.HANDLE hFile, Pointer lpOverlapped,
+                                    IntByReference lpNumberOfBytesTransferred, boolean bWait);
+
+        WinNT.HANDLE CreateEvent(WinBase.SECURITY_ATTRIBUTES lpEventAttributes,
+                                 boolean bManualReset, boolean bInitialState, String lpName);
+
+        boolean ResetEvent(WinNT.HANDLE hEvent);
+
+        int WaitForSingleObject(WinNT.HANDLE hHandle, int dwMilliseconds);
+    }
+
+    private static final PipeKernel32 K32 = PipeKernel32.INSTANCE;
+
+    private final int port;
+    private final ExecutorService executorService;
+    private final String pipeName;
+    private final CountDownLatch serverReady = new CountDownLatch(1);
+    private final AtomicInteger requestsReceived = new AtomicInteger(0);
+    private volatile boolean running;
+    private volatile WinNT.HANDLE waitingHandle;
+
+    private static final int PIPE_ACCESS_DUPLEX = 0x00000003;
+    private static final int FILE_FLAG_OVERLAPPED = 0x40000000;
+    private static final int PIPE_TYPE_BYTE = 0x00000000;
+    private static final int PIPE_READMODE_BYTE = 0x00000000;
+    private static final int PIPE_WAIT = 0x00000000;
+    private static final int PIPE_UNLIMITED_INSTANCES = 255;
+    private static final int BUFFER_SIZE = 8192;
+
+    // Win32 error codes — use constants to avoid dependency on WinError
+    private static final int ERROR_IO_PENDING = 997;
+    private static final int ERROR_BROKEN_PIPE = 109;
+    private static final int ERROR_PIPE_NOT_CONNECTED = 233;
+    private static final int ERROR_PIPE_CONNECTED = 535;
+
+    public NamedPipeProxyServer(final int port) {
+        this.port = port;
+        this.executorService = Executors.newCachedThreadPool();
+        this.pipeName = "\\\\.\\pipe\\httpclient5-test-" + UUID.randomUUID();
+    }
+
+    public void start() {
+        running = true;
+        executorService.submit(this::runPipeServer);
+        try {
+            if (!serverReady.await(10, TimeUnit.SECONDS)) {
+                throw new RuntimeException("Named Pipe proxy server did not start within 10 seconds");
+            }
+        } catch (final InterruptedException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    public String getPipeName() {
+        return pipeName;
+    }
+
+    public int getRequestsReceived() {
+        return requestsReceived.get();
+    }
+
+    public void close() {
+        running = false;
+        // Close the pipe handle that is blocked on ConnectNamedPipe,
+        // same as UDS closing the server socket to unblock accept().
+        final WinNT.HANDLE h = waitingHandle;
+        if (h != null) {
+            Kernel32.INSTANCE.CloseHandle(h);
+        }
+        executorService.shutdownNow();
+        try {
+            if (!executorService.awaitTermination(5, TimeUnit.SECONDS)) {
+                throw new RuntimeException("Failed to shut down");
+            }
+        } catch (final InterruptedException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    /**
+     * Creates a new overlapped pipe instance.
+     */
+    private WinNT.HANDLE createPipeInstance() {
+        return Kernel32.INSTANCE.CreateNamedPipe(
+                pipeName,
+                PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED,
+                PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT,
+                PIPE_UNLIMITED_INSTANCES,
+                BUFFER_SIZE,
+                BUFFER_SIZE,
+                0,
+                null);
+    }
+
+    private void runPipeServer() {
+        WinNT.HANDLE pipeHandle = createPipeInstance();
+        if (WinBase.INVALID_HANDLE_VALUE.equals(pipeHandle)) {
+            serverReady.countDown();
+            throw new RuntimeException("CreateNamedPipe failed: error " + Native.getLastError());
+        }
+        // Event used to wait for overlapped ConnectNamedPipe
+        final WinNT.HANDLE connectEvent = K32.CreateEvent(null, true, false, null);
+        serverReady.countDown();
+
+        while (running) {
+            waitingHandle = pipeHandle;
+
+            if (!waitForClient(pipeHandle, connectEvent)) {
+                if (!running) {
+                    break;
+                }
+                // Unrecoverable error — skip this instance
+                Kernel32.INSTANCE.CloseHandle(pipeHandle);
+                pipeHandle = createPipeInstance();
+                continue;
+            }
+            waitingHandle = null;
+            requestsReceived.incrementAndGet();
+
+            final WinNT.HANDLE connectedHandle = pipeHandle;
+            final Socket tcpSocket;
+            try {
+                tcpSocket = new Socket("localhost", port);
+            } catch (final IOException ex) {
+                Kernel32.INSTANCE.DisconnectNamedPipe(connectedHandle);
+                Kernel32.INSTANCE.CloseHandle(connectedHandle);
+                pipeHandle = createPipeInstance();
+                continue;
+            }
+
+            // Cross-direction cancellation: named pipes don't support half-close,
+            // so each direction must unblock the other when it exits.
+            final CompletableFuture<Void> f1 = CompletableFuture.runAsync(() -> {
+                try {
+                    pipeToSocket(connectedHandle, tcpSocket);
+                } finally {
+                    // Pipe read ended — close TCP socket to unblock socketToPipe's in.read()
+                    try {
+                        tcpSocket.close();
+                    } catch (final IOException ignore) {
+                    }
+                }
+            }, executorService);
+            final CompletableFuture<Void> f2 = CompletableFuture.runAsync(() -> {
+                try {
+                    socketToPipe(connectedHandle, tcpSocket);
+                } finally {
+                    // TCP read ended — disconnect pipe to unblock pipeToSocket's overlappedRead
+                    Kernel32.INSTANCE.DisconnectNamedPipe(connectedHandle);
+                }
+            }, executorService);
+            CompletableFuture.allOf(f1, f2).whenComplete((result, ex) -> {
+                try {
+                    tcpSocket.close();
+                } catch (final IOException ignore) {
+                }
+                Kernel32.INSTANCE.DisconnectNamedPipe(connectedHandle);
+                Kernel32.INSTANCE.CloseHandle(connectedHandle);
+            });
+
+            pipeHandle = createPipeInstance();
+        }
+
+        waitingHandle = null;
+        Kernel32.INSTANCE.CloseHandle(pipeHandle);
+        Kernel32.INSTANCE.CloseHandle(connectEvent);
+    }
+
+    /**
+     * Waits for a client to connect using overlapped ConnectNamedPipe.
+     * Overlapped mode is required because the pipe handle was created with
+     * FILE_FLAG_OVERLAPPED (needed for concurrent read/write in the proxy).
+     *
+     * @return true if a client connected, false on error
+     */
+    private static boolean waitForClient(final WinNT.HANDLE pipeHandle,
+                                         final WinNT.HANDLE connectEvent) {
+        final WinBase.OVERLAPPED ol = new WinBase.OVERLAPPED();
+        ol.hEvent = connectEvent;
+        K32.ResetEvent(connectEvent);
+        ol.write();
+
+        if (Kernel32.INSTANCE.ConnectNamedPipe(pipeHandle, ol)) {
+            return true; // Client connected synchronously
+        }
+
+        final int err = Native.getLastError();
+        if (err == ERROR_PIPE_CONNECTED) {
+            return true; // Client already connected
+        }
+        if (err != ERROR_IO_PENDING) {
+            return false; // Real error
+        }
+
+        // Wait for a client to connect (or handle to be closed by close())
+        K32.WaitForSingleObject(connectEvent, WinBase.INFINITE);
+        final IntByReference dummy = new IntByReference();
+        return K32.GetOverlappedResult(pipeHandle, ol.getPointer(), dummy, false);
+    }
+
+    private static void pipeToSocket(final WinNT.HANDLE pipeHandle, final Socket tcpSocket) {
+        final WinNT.HANDLE event = K32.CreateEvent(null, true, false, null);
+        if (event == null) {
+            return;
+        }
+        final Memory buf = new Memory(BUFFER_SIZE);
+        try {
+            final OutputStream out = tcpSocket.getOutputStream();
+            final byte[] javaBuf = new byte[BUFFER_SIZE];
+            int n;
+            while ((n = overlappedRead(pipeHandle, buf, BUFFER_SIZE, event)) > 0) {
+                buf.read(0, javaBuf, 0, n);
+                out.write(javaBuf, 0, n);
+                out.flush();
+            }
+        } catch (final IOException ignore) {
+        } finally {
+            Kernel32.INSTANCE.CloseHandle(event);
+        }
+    }
+
+    private static void socketToPipe(final WinNT.HANDLE pipeHandle, final Socket tcpSocket) {
+        final WinNT.HANDLE event = K32.CreateEvent(null, true, false, null);
+        if (event == null) {
+            return;
+        }
+        final Memory buf = new Memory(BUFFER_SIZE);
+        try {
+            final InputStream in = tcpSocket.getInputStream();
+            final byte[] javaBuf = new byte[BUFFER_SIZE];
+            int len;
+            while ((len = in.read(javaBuf)) != -1) {
+                buf.write(0, javaBuf, 0, len);
+                if (overlappedWrite(pipeHandle, buf, len, event) <= 0) {
+                    break;
+                }
+            }
+        } catch (final IOException ignore) {
+        } finally {
+            Kernel32.INSTANCE.CloseHandle(event);
+        }
+    }
+
+    /**
+     * Performs an overlapped read, waiting for completion.
+     *
+     * @return bytes read, or -1 on EOF/error
+     */
+    private static int overlappedRead(final WinNT.HANDLE pipe, final Memory buf,
+                                      final int toRead, final WinNT.HANDLE event) {
+        final WinBase.OVERLAPPED ol = new WinBase.OVERLAPPED();
+        ol.hEvent = event;
+        K32.ResetEvent(event);
+        ol.write();
+
+        final IntByReference bytesRead = new IntByReference();
+        if (K32.ReadFile(pipe, buf, toRead, bytesRead, ol)) {
+            final int n = bytesRead.getValue();
+            return n == 0 ? -1 : n;
+        }
+
+        final int err = Native.getLastError();
+        if (err == ERROR_BROKEN_PIPE || err == ERROR_PIPE_NOT_CONNECTED) {
+            return -1;
+        }
+        if (err != ERROR_IO_PENDING) {
+            return -1;
+        }
+
+        K32.WaitForSingleObject(event, WinBase.INFINITE);
+        if (!K32.GetOverlappedResult(pipe, ol.getPointer(), bytesRead, false)) {
+            return -1;
+        }
+        final int n = bytesRead.getValue();
+        return n == 0 ? -1 : n;
+    }
+
+    /**
+     * Performs an overlapped write, waiting for completion.
+     *
+     * @return bytes written, or -1 on error
+     */
+    private static int overlappedWrite(final WinNT.HANDLE pipe, final Memory buf,
+                                       final int toWrite, final WinNT.HANDLE event) {
+        final WinBase.OVERLAPPED ol = new WinBase.OVERLAPPED();
+        ol.hEvent = event;
+        K32.ResetEvent(event);
+        ol.write();
+
+        final IntByReference bytesWritten = new IntByReference();
+        if (K32.WriteFile(pipe, buf, toWrite, bytesWritten, ol)) {
+            return bytesWritten.getValue();
+        }
+
+        final int err = Native.getLastError();
+        if (err != ERROR_IO_PENDING) {
+            return -1;
+        }
+
+        K32.WaitForSingleObject(event, WinBase.INFINITE);
+        if (!K32.GetOverlappedResult(pipe, ol.getPointer(), bytesWritten, false)) {
+            return -1;
+        }
+        return bytesWritten.getValue();
+    }
+}

--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/sync/StandardTestClientBuilder.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/sync/StandardTestClientBuilder.java
@@ -169,6 +169,14 @@ final class StandardTestClientBuilder implements TestClientBuilder {
     }
 
     @Override
+    public TestClientBuilder setNamedPipe(final String namedPipe) {
+        this.clientBuilder.setDefaultRequestConfig(RequestConfig.custom()
+                .setNamedPipe(namedPipe)
+                .build());
+        return this;
+    }
+
+    @Override
     public TestClientBuilder setRedirectStrategy(final RedirectStrategy redirectStrategy) {
         this.clientBuilder.setRedirectStrategy(redirectStrategy);
         return this;

--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/sync/TestClientBuilder.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/sync/TestClientBuilder.java
@@ -109,6 +109,10 @@ public interface TestClientBuilder {
         throw new UnsupportedOperationException("Operation not supported by " + getProtocolLevel());
     }
 
+    default TestClientBuilder setNamedPipe(String namedPipe) {
+        throw new UnsupportedOperationException("Operation not supported by " + getProtocolLevel());
+    }
+
     default TestClientBuilder setRedirectStrategy(RedirectStrategy redirectStrategy) {
         throw new UnsupportedOperationException("Operation not supported by " + getProtocolLevel());
     }

--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/sync/TestClientResources.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/sync/TestClientResources.java
@@ -51,6 +51,7 @@ public class TestClientResources implements AfterEachCallback {
     private TestServer server;
     private TestClient client;
     private UnixDomainProxyServer udsProxy;
+    private NamedPipeProxyServer namedPipeProxy;
 
     public TestClientResources(final URIScheme scheme, final ClientProtocolLevel clientProtocolLevel, final Timeout timeout) {
         this.scheme = scheme != null ? scheme : URIScheme.HTTP;
@@ -82,6 +83,12 @@ public class TestClientResources implements AfterEachCallback {
                 throw new AssertionError("The UDS proxy did not receive any requests");
             }
             udsProxy.close();
+        }
+        if (namedPipeProxy != null) {
+            if (namedPipeProxy.getRequestsReceived() == 0) {
+                throw new AssertionError("The Named Pipe proxy did not receive any requests");
+            }
+            namedPipeProxy.close();
         }
         if (server != null) {
             server.shutdown(CloseMode.IMMEDIATE);
@@ -115,6 +122,15 @@ public class TestClientResources implements AfterEachCallback {
             udsProxy = new UnixDomainProxyServer(port);
         }
         return udsProxy;
+    }
+
+    public NamedPipeProxyServer namedPipeProxy() throws Exception {
+        if (namedPipeProxy == null) {
+            final TestServer testServer = server();
+            final int port = testServer.getServerAddress().getPort();
+            namedPipeProxy = new NamedPipeProxyServer(port);
+        }
+        return namedPipeProxy;
     }
 
     public void configureClient(final Consumer<TestClientBuilder> clientCustomizer) {

--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/AbstractIntegrationTestBase.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/AbstractIntegrationTestBase.java
@@ -49,15 +49,23 @@ abstract class AbstractIntegrationTestBase {
     @RegisterExtension
     private final TestClientResources testResources;
     private final boolean useUnixDomainSocket;
+    private final boolean useNamedPipe;
 
     protected AbstractIntegrationTestBase(final URIScheme scheme, final ClientProtocolLevel clientProtocolLevel) {
-        this(scheme, clientProtocolLevel, false);
+        this(scheme, clientProtocolLevel, false, false);
     }
 
     protected AbstractIntegrationTestBase(
         final URIScheme scheme, final ClientProtocolLevel clientProtocolLevel, final boolean useUnixDomainSocket) {
+        this(scheme, clientProtocolLevel, useUnixDomainSocket, false);
+    }
+
+    protected AbstractIntegrationTestBase(
+        final URIScheme scheme, final ClientProtocolLevel clientProtocolLevel,
+        final boolean useUnixDomainSocket, final boolean useNamedPipe) {
         this.testResources = new TestClientResources(scheme, clientProtocolLevel, TIMEOUT);
         this.useUnixDomainSocket = useUnixDomainSocket;
+        this.useNamedPipe = useNamedPipe;
     }
 
     public URIScheme scheme() {
@@ -78,6 +86,9 @@ abstract class AbstractIntegrationTestBase {
         if (useUnixDomainSocket) {
             testResources.udsProxy().start();
         }
+        if (useNamedPipe) {
+            testResources.namedPipeProxy().start();
+        }
         return new HttpHost(testResources.scheme().id, "localhost", inetSocketAddress.getPort());
     }
 
@@ -92,12 +103,25 @@ abstract class AbstractIntegrationTestBase {
                 builder.setUnixDomainSocket(socketPath);
             });
         }
+        if (useNamedPipe) {
+            final String pipeName = getNamedPipe();
+            testResources.configureClient(builder -> {
+                builder.setNamedPipe(pipeName);
+            });
+        }
         return testResources.client();
     }
 
     public Path getUnixDomainSocket() throws Exception {
         if (useUnixDomainSocket) {
             return testResources.udsProxy().getSocketPath();
+        }
+        return null;
+    }
+
+    public String getNamedPipe() throws Exception {
+        if (useNamedPipe) {
+            return testResources.namedPipeProxy().getPipeName();
         }
         return null;
     }

--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/NpipeIntegrationTests.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/NpipeIntegrationTests.java
@@ -1,0 +1,70 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.client5.testing.sync;
+
+import org.apache.hc.core5.http.URIScheme;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+/**
+ * Integration tests for Windows Named Pipe (npipe://) support.
+ * <p>
+ * These tests mirror the {@link UdsIntegrationTests} but use Windows Named Pipes
+ * instead of Unix domain sockets. They require Windows and JNA (for the test proxy server).
+ * </p>
+ *
+ * @since 5.7
+ */
+@EnabledOnOs(OS.WINDOWS)
+class NpipeIntegrationTests {
+
+    @Nested
+    @DisplayName("Request execution (HTTP/1.1, Named Pipe)")
+    class RequestExecution extends TestClientRequestExecution {
+        public RequestExecution() {
+            super(URIScheme.HTTP, false, true);
+        }
+    }
+
+    @Nested
+    @DisplayName("Request execution (HTTP/1.1, TLS over Named Pipe)")
+    class RequestExecutionTls extends TestClientRequestExecution {
+        public RequestExecutionTls() {
+            super(URIScheme.HTTPS, false, true);
+        }
+    }
+
+    @Nested
+    @DisplayName("Content coding (HTTP/1.1, Named Pipe)")
+    class ContentCoding extends TestContentCodings {
+        public ContentCoding() {
+            super(URIScheme.HTTP, false, true);
+        }
+    }
+}

--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestClientRequestExecution.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestClientRequestExecution.java
@@ -81,6 +81,11 @@ abstract class TestClientRequestExecution extends AbstractIntegrationTestBase {
         super(scheme, ClientProtocolLevel.STANDARD, useUnixDomainSocket);
     }
 
+    public TestClientRequestExecution(final URIScheme scheme, final boolean useUnixDomainSocket,
+                                      final boolean useNamedPipe) {
+        super(scheme, ClientProtocolLevel.STANDARD, useUnixDomainSocket, useNamedPipe);
+    }
+
     private static class SimpleService implements HttpRequestHandler {
 
         public SimpleService() {

--- a/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestContentCodings.java
+++ b/httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestContentCodings.java
@@ -73,6 +73,11 @@ abstract class TestContentCodings extends AbstractIntegrationTestBase {
         super(scheme, ClientProtocolLevel.STANDARD, useUnixDomainSocket);
     }
 
+    protected TestContentCodings(final URIScheme scheme, final boolean useUnixDomainSocket,
+                                 final boolean useNamedPipe) {
+        super(scheme, ClientProtocolLevel.STANDARD, useUnixDomainSocket, useNamedPipe);
+    }
+
     /**
      * Test for when we don't get an entity back; e.g. for a 204 or 304 response; nothing blows
      * up with the new behaviour.

--- a/httpclient5/pom.xml
+++ b/httpclient5/pom.xml
@@ -58,6 +58,12 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>net.java.dev.jna</groupId>
+      <artifactId>jna-platform</artifactId>
+      <scope>compile</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.apache.httpcomponents.core5</groupId>
       <artifactId>httpcore5</artifactId>
       <classifier>tests</classifier>

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/HttpRoute.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/HttpRoute.java
@@ -69,6 +69,9 @@ public final class HttpRoute implements RouteInfo, Cloneable {
     /** The path to the UDS to connect to, if any. */
     private final Path unixDomainSocket;
 
+    /** The Windows Named Pipe path to connect to, if any. */
+    private final String namedPipe;
+
     /** Whether the the route is tunnelled through the proxy. */
     private final TunnelType tunnelled;
 
@@ -83,6 +86,7 @@ public final class HttpRoute implements RouteInfo, Cloneable {
               final InetAddress local,
               final List<HttpHost> proxies,
               final Path unixDomainSocket,
+              final String namedPipe,
               final boolean secure,
               final TunnelType tunnelled,
               final LayerType layered) {
@@ -92,6 +96,7 @@ public final class HttpRoute implements RouteInfo, Cloneable {
         this.targetHost = targetHost;
         this.localAddress = local;
         this.unixDomainSocket = unixDomainSocket;
+        this.namedPipe = namedPipe;
         if (proxies != null && !proxies.isEmpty()) {
             this.proxyChain = new ArrayList<>(proxies);
         } else {
@@ -106,6 +111,20 @@ public final class HttpRoute implements RouteInfo, Cloneable {
         if (this.unixDomainSocket != null) {
             validateUdsArguments();
         }
+        if (this.namedPipe != null) {
+            validateNamedPipeArguments();
+        }
+    }
+
+    HttpRoute(final HttpHost targetHost,
+              final NamedEndpoint targetName,
+              final InetAddress local,
+              final List<HttpHost> proxies,
+              final Path unixDomainSocket,
+              final boolean secure,
+              final TunnelType tunnelled,
+              final LayerType layered) {
+        this(targetHost, targetName, local, proxies, unixDomainSocket, null, secure, tunnelled, layered);
     }
 
     private void validateUdsArguments() {
@@ -117,6 +136,20 @@ public final class HttpRoute implements RouteInfo, Cloneable {
             throw new UnsupportedOperationException("Layering is not supported over a UDS connection");
         } else if (this.tunnelled != TunnelType.PLAIN) {
             throw new UnsupportedOperationException("Tunnelling is not supported over a UDS connection");
+        }
+    }
+
+    private void validateNamedPipeArguments() {
+        if (this.unixDomainSocket != null) {
+            throw new UnsupportedOperationException("Cannot specify both a Unix domain socket and a Named Pipe");
+        } else if (this.localAddress != null) {
+            throw new UnsupportedOperationException("A localAddress cannot be specified for a Named Pipe connection");
+        } else if (this.proxyChain != null) {
+            throw new UnsupportedOperationException("Proxies are not supported over a Named Pipe connection");
+        } else if (this.layered != LayerType.PLAIN) {
+            throw new UnsupportedOperationException("Layering is not supported over a Named Pipe connection");
+        } else if (this.tunnelled != TunnelType.PLAIN) {
+            throw new UnsupportedOperationException("Tunnelling is not supported over a Named Pipe connection");
         }
     }
 
@@ -237,7 +270,34 @@ public final class HttpRoute implements RouteInfo, Cloneable {
      * @since 5.6
      */
     public HttpRoute(final HttpHost target, final boolean secure, final Path unixDomainSocket) {
-        this(target, null, null, Collections.emptyList(), unixDomainSocket, secure,
+        this(target, null, null, Collections.emptyList(), unixDomainSocket, null, secure,
+                TunnelType.PLAIN, LayerType.PLAIN);
+    }
+
+    /**
+     * Creates a new direct route that connects over a Windows Named Pipe rather than TCP.
+     *
+     * @param target    the host to which to route
+     * @param namedPipe the Named Pipe path (e.g. {@code \\.\pipe\docker_engine})
+     *
+     * @since 5.7
+     */
+    public HttpRoute(final HttpHost target, final String namedPipe) {
+        this(target, false, namedPipe);
+    }
+
+    /**
+     * Creates a new direct route that connects over a Windows Named Pipe rather than TCP.
+     *
+     * @param target    the host to which to route
+     * @param secure    {@code true} if the route is (to be) secure,
+     *                  {@code false} otherwise
+     * @param namedPipe the Named Pipe path (e.g. {@code \\.\pipe\docker_engine})
+     *
+     * @since 5.7
+     */
+    public HttpRoute(final HttpHost target, final boolean secure, final String namedPipe) {
+        this(target, null, null, Collections.emptyList(), null, namedPipe, secure,
                 TunnelType.PLAIN, LayerType.PLAIN);
     }
 
@@ -354,6 +414,11 @@ public final class HttpRoute implements RouteInfo, Cloneable {
     }
 
     @Override
+    public String getNamedPipe() {
+        return this.namedPipe;
+    }
+
+    @Override
     public TunnelType getTunnelType() {
         return this.tunnelled;
     }
@@ -402,7 +467,8 @@ public final class HttpRoute implements RouteInfo, Cloneable {
                             Objects.equals(this.targetName, that.targetName) &&
                             Objects.equals(this.localAddress, that.localAddress) &&
                             Objects.equals(this.proxyChain, that.proxyChain) &&
-                            Objects.equals(this.unixDomainSocket, that.unixDomainSocket);
+                            Objects.equals(this.unixDomainSocket, that.unixDomainSocket) &&
+                            Objects.equals(this.namedPipe, that.namedPipe);
         }
         return false;
     }
@@ -427,6 +493,9 @@ public final class HttpRoute implements RouteInfo, Cloneable {
         if (this.unixDomainSocket != null) {
             hash = LangUtils.hashCode(hash, unixDomainSocket);
         }
+        if (this.namedPipe != null) {
+            hash = LangUtils.hashCode(hash, namedPipe);
+        }
         hash = LangUtils.hashCode(hash, this.secure);
         hash = LangUtils.hashCode(hash, this.tunnelled);
         hash = LangUtils.hashCode(hash, this.layered);
@@ -446,6 +515,8 @@ public final class HttpRoute implements RouteInfo, Cloneable {
             cab.append("->");
         } else if (unixDomainSocket != null) {
             cab.append(unixDomainSocket).append("->");
+        } else if (namedPipe != null) {
+            cab.append(namedPipe).append("->");
         }
         cab.append('{');
         if (this.tunnelled == TunnelType.TUNNELLED) {

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/RouteInfo.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/RouteInfo.java
@@ -100,6 +100,16 @@ public interface RouteInfo {
     }
 
     /**
+     * Obtains the Windows Named Pipe through which to connect to the target host.
+     *
+     * @return  the named pipe path (e.g. {@code \\.\pipe\docker_engine}), or {@code null} if none
+     * @since 5.7
+     */
+    default String getNamedPipe() {
+        return null;
+    }
+
+    /**
      * Obtains the number of hops in this route.
      * A direct route has one hop. A route through a proxy has two hops.
      * A route through a chain of <i>n</i> proxies has <i>n+1</i> hops.

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/RouteTracker.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/RouteTracker.java
@@ -55,6 +55,9 @@ public final class RouteTracker implements RouteInfo, Cloneable {
     /** The Unix domain socket to connect through, if any. */
     private final Path unixDomainSocket;
 
+    /** The Windows Named Pipe to connect through, if any. */
+    private final String namedPipe;
+
     // the attributes above are fixed at construction time
     // now follow attributes that indicate the established route
 
@@ -82,24 +85,37 @@ public final class RouteTracker implements RouteInfo, Cloneable {
      *                  {@code null} for the default
      */
     public RouteTracker(final HttpHost target, final InetAddress local) {
-        this(target, local, null);
+        this(target, local, null, null);
     }
 
     /**
      * Creates a new route tracker.
-     * The target and origin need to be specified at creation time.
      *
      * @param target              the host to which to route
-     * @param local               the local address to route from, or
-     *                            {@code null} for the default
-     * @param unixDomainSocket    the path to the Unix domain socket
-     *                            through which to connect, or {@code null}
+     * @param local               the local address to route from, or {@code null}
+     * @param unixDomainSocket    the path to the Unix domain socket, or {@code null}
      */
     public RouteTracker(final HttpHost target, final InetAddress local, final Path unixDomainSocket) {
+        this(target, local, unixDomainSocket, null);
+    }
+
+    /**
+     * Creates a new route tracker.
+     *
+     * @param target              the host to which to route
+     * @param local               the local address to route from, or {@code null}
+     * @param unixDomainSocket    the path to the Unix domain socket, or {@code null}
+     * @param namedPipe           the Windows Named Pipe path, or {@code null}
+     *
+     * @since 5.7
+     */
+    public RouteTracker(final HttpHost target, final InetAddress local, final Path unixDomainSocket,
+                        final String namedPipe) {
         Args.notNull(target, "Target host");
         this.targetHost = target;
         this.localAddress = local;
         this.unixDomainSocket = unixDomainSocket;
+        this.namedPipe = namedPipe;
         this.tunnelled = TunnelType.PLAIN;
         this.layered = LayerType.PLAIN;
     }
@@ -123,7 +139,7 @@ public final class RouteTracker implements RouteInfo, Cloneable {
      * @param route     the route to track
      */
     public RouteTracker(final HttpRoute route) {
-        this(route.getTargetHost(), route.getLocalAddress(), route.getUnixDomainSocket());
+        this(route.getTargetHost(), route.getLocalAddress(), route.getUnixDomainSocket(), route.getNamedPipe());
     }
 
     /**
@@ -219,6 +235,11 @@ public final class RouteTracker implements RouteInfo, Cloneable {
     }
 
     @Override
+    public String getNamedPipe() {
+        return this.namedPipe;
+    }
+
+    @Override
     public int getHopCount() {
         int hops = 0;
         if (this.connected) {
@@ -293,6 +314,8 @@ public final class RouteTracker implements RouteInfo, Cloneable {
             return null;
         } else if (this.unixDomainSocket != null) {
             return new HttpRoute(this.targetHost, this.secure, this.unixDomainSocket);
+        } else if (this.namedPipe != null) {
+            return new HttpRoute(this.targetHost, this.secure, this.namedPipe);
         } else {
             return new HttpRoute(this.targetHost, this.localAddress,
                 this.proxyChain, this.secure,
@@ -327,6 +350,7 @@ public final class RouteTracker implements RouteInfo, Cloneable {
                         Objects.equals(this.targetHost, that.targetHost) &&
                         Objects.equals(this.localAddress, that.localAddress) &&
                         Objects.equals(this.unixDomainSocket, that.unixDomainSocket) &&
+                        Objects.equals(this.namedPipe, that.namedPipe) &&
                         Objects.equals(this.proxyChain, that.proxyChain);
     }
 
@@ -344,6 +368,7 @@ public final class RouteTracker implements RouteInfo, Cloneable {
         hash = LangUtils.hashCode(hash, this.targetHost);
         hash = LangUtils.hashCode(hash, this.localAddress);
         hash = LangUtils.hashCode(hash, this.unixDomainSocket);
+        hash = LangUtils.hashCode(hash, this.namedPipe);
         if (this.proxyChain != null) {
             for (final HttpHost element : this.proxyChain) {
                 hash = LangUtils.hashCode(hash, element);
@@ -371,6 +396,8 @@ public final class RouteTracker implements RouteInfo, Cloneable {
             cab.append("->");
         } else if (this.unixDomainSocket != null) {
             cab.append(this.unixDomainSocket).append("->");
+        } else if (this.namedPipe != null) {
+            cab.append(this.namedPipe).append("->");
         }
         cab.append('{');
         if (this.connected) {

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/config/RequestConfig.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/config/RequestConfig.java
@@ -67,6 +67,7 @@ public class RequestConfig implements Cloneable {
     private final boolean hardCancellationEnabled;
     private final boolean protocolUpgradeEnabled;
     private final Path unixDomainSocket;
+    private final String namedPipe;
     /**
      * HTTP/2 Priority header value to emit when using H2+. Null means “don’t emit”.
      */
@@ -78,7 +79,7 @@ public class RequestConfig implements Cloneable {
     protected RequestConfig() {
         this(false, null, null, false, false, 0, false, null, null,
                 DEFAULT_CONNECTION_REQUEST_TIMEOUT, null, null, DEFAULT_CONN_KEEP_ALIVE, false, false, false, null,
-                null);
+                null, null);
     }
 
     RequestConfig(
@@ -99,6 +100,7 @@ public class RequestConfig implements Cloneable {
             final boolean hardCancellationEnabled,
             final boolean protocolUpgradeEnabled,
             final Path unixDomainSocket,
+            final String namedPipe,
             final PriorityValue h2Priority) {
         super();
         this.expectContinueEnabled = expectContinueEnabled;
@@ -118,6 +120,7 @@ public class RequestConfig implements Cloneable {
         this.hardCancellationEnabled = hardCancellationEnabled;
         this.protocolUpgradeEnabled = protocolUpgradeEnabled;
         this.unixDomainSocket = unixDomainSocket;
+        this.namedPipe = namedPipe;
         this.h2Priority = h2Priority;
     }
 
@@ -244,6 +247,14 @@ public class RequestConfig implements Cloneable {
     }
 
     /**
+     * @see Builder#setNamedPipe(String)
+     * @since 5.7
+     */
+    public String getNamedPipe() {
+        return namedPipe;
+    }
+
+    /**
      * Returns the HTTP/2+ priority preference for this request or {@code null} if unset.
      * @since 5.6
      */
@@ -278,6 +289,7 @@ public class RequestConfig implements Cloneable {
         builder.append(", hardCancellationEnabled=").append(hardCancellationEnabled);
         builder.append(", protocolUpgradeEnabled=").append(protocolUpgradeEnabled);
         builder.append(", unixDomainSocket=").append(unixDomainSocket);
+        builder.append(", namedPipe=").append(namedPipe);
         builder.append(", h2Priority=").append(h2Priority);
         builder.append("]");
         return builder.toString();
@@ -306,6 +318,7 @@ public class RequestConfig implements Cloneable {
             .setHardCancellationEnabled(config.isHardCancellationEnabled())
             .setProtocolUpgradeEnabled(config.isProtocolUpgradeEnabled())
             .setUnixDomainSocket(config.getUnixDomainSocket())
+            .setNamedPipe(config.getNamedPipe())
             .setH2Priority(config.getH2Priority());
     }
 
@@ -328,6 +341,7 @@ public class RequestConfig implements Cloneable {
         private boolean hardCancellationEnabled;
         private boolean protocolUpgradeEnabled;
         private Path unixDomainSocket;
+        private String namedPipe;
         private PriorityValue h2Priority;
 
         Builder() {
@@ -687,6 +701,25 @@ public class RequestConfig implements Cloneable {
         }
 
         /**
+         * Sets the Windows Named Pipe path to use for the connection.
+         * <p>
+         * When set, the connection will use the specified Windows Named Pipe
+         * instead of a TCP socket. This is useful for communicating with local
+         * services like Docker Desktop on Windows (e.g. {@code \\.\pipe\docker_engine}).
+         * </p>
+         * <p>
+         * Default: {@code null}
+         * </p>
+         *
+         * @return this instance.
+         * @since 5.7
+         */
+        public Builder setNamedPipe(final String namedPipe) {
+            this.namedPipe = namedPipe;
+            return this;
+        }
+
+        /**
          * Sets HTTP/2+ request priority. If {@code null}, the header is not emitted.
          * @since 5.6
          */
@@ -715,6 +748,7 @@ public class RequestConfig implements Cloneable {
                     hardCancellationEnabled,
                     protocolUpgradeEnabled,
                     unixDomainSocket,
+                    namedPipe,
                     h2Priority);
         }
 

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/DefaultHttpClientConnectionOperator.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/DefaultHttpClientConnectionOperator.java
@@ -49,6 +49,7 @@ import org.apache.hc.client5.http.impl.DefaultSchemePortResolver;
 import org.apache.hc.client5.http.io.DetachedSocketFactory;
 import org.apache.hc.client5.http.io.HttpClientConnectionOperator;
 import org.apache.hc.client5.http.io.ManagedHttpClientConnection;
+import org.apache.hc.client5.http.socket.NamedPipeSocketFactory;
 import org.apache.hc.client5.http.socket.UnixDomainSocketFactory;
 import org.apache.hc.client5.http.ssl.TlsSocketStrategy;
 import org.apache.hc.core5.annotation.Contract;
@@ -91,6 +92,7 @@ public class DefaultHttpClientConnectionOperator implements HttpClientConnection
 
     private final DetachedSocketFactory detachedSocketFactory;
     private final UnixDomainSocketFactory unixDomainSocketFactory = UnixDomainSocketFactory.getSocketFactory();
+    private final NamedPipeSocketFactory namedPipeSocketFactory = NamedPipeSocketFactory.getSocketFactory();
     private final Lookup<TlsSocketStrategy> tlsSocketStrategyLookup;
     private final SchemePortResolver schemePortResolver;
     private final DnsResolver dnsResolver;
@@ -166,6 +168,31 @@ public class DefaultHttpClientConnectionOperator implements HttpClientConnection
             final HttpContext context) throws IOException {
         connect(conn, endpointHost, endpointName, null, localAddress, connectTimeout, socketConfig, attachment,
             context);
+    }
+
+    @Override
+    public void connect(
+            final ManagedHttpClientConnection conn,
+            final HttpHost endpointHost,
+            final NamedEndpoint endpointName,
+            final Path unixDomainSocket,
+            final String namedPipe,
+            final InetSocketAddress localAddress,
+            final Timeout connectTimeout,
+            final SocketConfig socketConfig,
+            final Object attachment,
+            final HttpContext context) throws IOException {
+        if (namedPipe != null) {
+            Args.notNull(conn, "Connection");
+            Args.notNull(endpointHost, "Host");
+            Args.notNull(socketConfig, "Socket config");
+            Args.notNull(context, "Context");
+            connectToNamedPipe(conn, endpointHost, endpointName, attachment, namedPipe, connectTimeout,
+                socketConfig, context);
+            return;
+        }
+        connect(conn, endpointHost, endpointName, unixDomainSocket, localAddress, connectTimeout,
+            socketConfig, attachment, context);
     }
 
     @Override
@@ -304,6 +331,48 @@ public class DefaultHttpClientConnectionOperator implements HttpClientConnection
             Closer.closeQuietly(newSocket);
             if (LOG.isDebugEnabled()) {
                 LOG.debug("{} connection to {} failed ({}); terminating operation", endpointHost, unixDomainSocket,
+                    ex.getClass());
+            }
+            throw ex;
+        }
+    }
+
+    private void connectToNamedPipe(
+            final ManagedHttpClientConnection conn,
+            final HttpHost endpointHost,
+            final NamedEndpoint endpointName,
+            final Object attachment,
+            final String namedPipe,
+            final Timeout connectTimeout,
+            final SocketConfig socketConfig,
+            final HttpContext context) throws IOException {
+        onBeforeSocketConnect(context, endpointHost);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("{} connecting to named pipe {} ({})", endpointHost, namedPipe, connectTimeout);
+        }
+        final Socket newSocket = namedPipeSocketFactory.connectSocket(namedPipe, connectTimeout);
+        try {
+            conn.bind(newSocket);
+            configureSocket(newSocket, socketConfig, false);
+            conn.bind(newSocket);
+            onAfterSocketConnect(context, endpointHost);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("{} {} connected to named pipe {}", ConnPoolSupport.getId(conn), endpointHost, namedPipe);
+            }
+
+            final TlsSocketStrategy tlsSocketStrategy = tlsSocketStrategyLookup != null
+                    ? tlsSocketStrategyLookup.lookup(endpointHost.getSchemeName()) : null;
+            if (tlsSocketStrategy != null) {
+                upgradeToTls(conn, endpointHost, endpointName, connectTimeout, attachment, context,
+                        tlsSocketStrategy, newSocket);
+            }
+        } catch (final RuntimeException ex) {
+            Closer.closeQuietly(newSocket);
+            throw ex;
+        } catch (final IOException ex) {
+            Closer.closeQuietly(newSocket);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("{} connection to named pipe {} failed ({}); terminating operation", endpointHost, namedPipe,
                     ex.getClass());
             }
             throw ex;

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java
@@ -549,6 +549,7 @@ public class PoolingHttpClientConnectionManager
         }
         final HttpRoute route = poolEntry.getRoute();
         final Path unixDomainSocket = route.getUnixDomainSocket();
+        final String namedPipe = route.getNamedPipe();
         final HttpHost firstHop = route.getProxyHost() != null ? route.getProxyHost() : route.getTargetHost();
         final SocketConfig socketConfig = resolveSocketConfig(route);
         final ConnectionConfig connectionConfig = resolveConnectionConfig(route);
@@ -562,6 +563,7 @@ public class PoolingHttpClientConnectionManager
                 firstHop,
                 route.getTargetName(),
                 unixDomainSocket,
+                namedPipe,
                 route.getLocalSocketAddress(),
                 connectTimeout,
                 socketConfig,

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java
@@ -496,6 +496,7 @@ public class PoolingAsyncClientConnectionManager implements AsyncClientConnectio
         final PoolEntry<HttpRoute, ManagedAsyncClientConnection> poolEntry = internalEndpoint.getPoolEntry();
         final HttpRoute route = poolEntry.getRoute();
         final Path unixDomainSocket = route.getUnixDomainSocket();
+        final String namedPipe = route.getNamedPipe();
         final HttpHost firstHop = route.getProxyHost() != null ? route.getProxyHost() : route.getTargetHost();
         final ConnectionConfig connectionConfig = resolveConnectionConfig(route);
         final Timeout connectTimeout = timeout != null ? timeout : connectionConfig.getConnectTimeout();
@@ -516,6 +517,7 @@ public class PoolingAsyncClientConnectionManager implements AsyncClientConnectio
                 connectionInitiator,
                 firstHop,
                 unixDomainSocket,
+                namedPipe,
                 route.getTargetName(),
                 route.getLocalSocketAddress(),
                 connectTimeout,

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/routing/DefaultRoutePlanner.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/routing/DefaultRoutePlanner.java
@@ -103,6 +103,13 @@ public class DefaultRoutePlanner implements HttpRoutePlanner {
             }
             return new HttpRoute(target, secure, unixDomainSocket);
         }
+        final String namedPipe = config.getNamedPipe();
+        if (namedPipe != null) {
+            if (proxy != null) {
+                throw new UnsupportedOperationException("Proxies are not supported over Windows Named Pipes");
+            }
+            return new HttpRoute(target, secure, namedPipe);
+        }
         final InetAddress inetAddress = determineLocalAddress(target, context);
         if (proxy == null) {
             return new HttpRoute(target, authority, inetAddress, secure);

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/io/HttpClientConnectionOperator.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/io/HttpClientConnectionOperator.java
@@ -128,6 +128,41 @@ public interface HttpClientConnectionOperator {
     }
 
     /**
+     * Connect the given managed connection to the remote endpoint.
+     *
+     * @param conn the managed connection.
+     * @param endpointHost the address of the remote endpoint.
+     * @param endpointName the name of the remote endpoint, if different from the endpoint host name,
+     *                   {@code null} otherwise.
+     * @param unixDomainSocket the path to the Unix domain socket, or {@code null} if none.
+     * @param namedPipe the Windows Named Pipe path (e.g. {@code \\.\pipe\docker_engine}), or {@code null} if none.
+     * @param localAddress the address of the local endpoint.
+     * @param connectTimeout the timeout of the connect operation.
+     * @param socketConfig the socket configuration.
+     * @param attachment connect request attachment.
+     * @param context the execution context.
+     *
+     * @since 5.7
+     */
+    default void connect(
+        ManagedHttpClientConnection conn,
+        HttpHost endpointHost,
+        NamedEndpoint endpointName,
+        Path unixDomainSocket,
+        String namedPipe,
+        InetSocketAddress localAddress,
+        Timeout connectTimeout,
+        SocketConfig socketConfig,
+        Object attachment,
+        HttpContext context) throws IOException {
+        if (namedPipe != null) {
+            throw new UnsupportedOperationException(getClass().getName() + " does not support Windows Named Pipes");
+        }
+        connect(conn, endpointHost, endpointName, unixDomainSocket, localAddress, connectTimeout, socketConfig,
+            attachment, context);
+    }
+
+    /**
      * Upgrades transport security of the given managed connection
      * by using the TLS security protocol.
      *

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/nio/AsyncClientConnectionOperator.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/nio/AsyncClientConnectionOperator.java
@@ -134,6 +134,41 @@ public interface AsyncClientConnectionOperator {
     }
 
     /**
+     * Initiates operation to create a connection to the remote endpoint using
+     * the provided {@link ConnectionInitiator}, optionally via a Windows Named Pipe.
+     *
+     * @param connectionInitiator the connection initiator.
+     * @param endpointHost the address of the remote endpoint.
+     * @param unixDomainSocket the path to the UDS through which to connect, or {@code null}.
+     * @param namedPipe the Windows Named Pipe path, or {@code null}.
+     * @param endpointName the name of the remote endpoint, or {@code null}.
+     * @param localAddress the address of the local endpoint.
+     * @param connectTimeout the timeout of the connect operation.
+     * @param attachment the attachment.
+     * @param context the execution context.
+     * @param callback the future result callback.
+     * @since 5.7
+     */
+    default Future<ManagedAsyncClientConnection> connect(
+            ConnectionInitiator connectionInitiator,
+            HttpHost endpointHost,
+            Path unixDomainSocket,
+            String namedPipe,
+            NamedEndpoint endpointName,
+            SocketAddress localAddress,
+            Timeout connectTimeout,
+            Object attachment,
+            HttpContext context,
+            FutureCallback<ManagedAsyncClientConnection> callback) {
+        if (namedPipe != null) {
+            throw new UnsupportedOperationException(getClass().getName()
+                    + " does not support Windows Named Pipes in async mode");
+        }
+        return connect(connectionInitiator, endpointHost, unixDomainSocket, endpointName, localAddress,
+            connectTimeout, attachment, context, callback);
+    }
+
+    /**
      * Upgrades transport security of the given managed connection
      * by using the TLS security protocol.
      *

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/socket/NamedPipeSocket.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/socket/NamedPipeSocket.java
@@ -1,0 +1,535 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.hc.client5.http.socket;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantLock;
+
+import com.sun.jna.Memory;
+import com.sun.jna.Native;
+import com.sun.jna.Pointer;
+import com.sun.jna.platform.win32.WinBase;
+import com.sun.jna.platform.win32.WinError;
+import com.sun.jna.platform.win32.WinNT;
+import com.sun.jna.ptr.IntByReference;
+import com.sun.jna.win32.StdCallLibrary;
+import com.sun.jna.win32.W32APIOptions;
+
+/**
+ * A {@link Socket} adapter that wraps a Windows Named Pipe connection using JNA
+ * and Win32 overlapped I/O.
+ * <p>
+ * Windows Named Pipes (e.g. {@code \\.\pipe\docker_engine}) are opened via the Win32
+ * {@code CreateFile} API with {@code FILE_FLAG_OVERLAPPED}, enabling true asynchronous
+ * I/O with real timeout support through {@code WaitForSingleObject} and cancellation
+ * through {@code CancelIoEx}.
+ * </p>
+ * <h3>Timeout semantics</h3>
+ * <p>
+ * When {@link #setSoTimeout(int)} is set to a positive value, reads are executed as
+ * overlapped operations guarded by {@code WaitForSingleObject} with the configured
+ * timeout. On timeout, the pending I/O is cancelled via {@code CancelIoEx} and a
+ * {@link SocketTimeoutException} is thrown &mdash; the same contract as
+ * {@code Socket#setSoTimeout}. A timeout of zero (the default) means block
+ * indefinitely.
+ * </p>
+ * <p>
+ * This class requires JNA ({@code net.java.dev.jna:jna-platform}) on the classpath.
+ * Use {@link NamedPipeSocketFactory#isAvailable()} to check availability at runtime.
+ * </p>
+ *
+ * @since 5.7
+ */
+final class NamedPipeSocket extends Socket {
+
+    /**
+     * Custom Kernel32 binding with the signatures required for overlapped named pipe I/O.
+     * <p>
+     * The standard JNA {@code Kernel32} interface provides {@code ReadFile}/{@code WriteFile}
+     * with {@code byte[]} buffers, which is unsafe for overlapped I/O (JNA frees the
+     * temporary native memory when the call returns, but the OS may still be writing to it).
+     * This interface uses {@link Pointer} buffers and adds {@code GetOverlappedResult} and
+     * {@code CancelIoEx} which are not in the standard JNA Kernel32.
+     * </p>
+     */
+    interface NpipeKernel32 extends StdCallLibrary {
+
+        NpipeKernel32 INSTANCE = Native.load("kernel32", NpipeKernel32.class,
+                W32APIOptions.DEFAULT_OPTIONS);
+
+        WinNT.HANDLE CreateFile(String lpFileName, int dwDesiredAccess, int dwShareMode,
+                                WinBase.SECURITY_ATTRIBUTES lpSecurityAttributes, int dwCreationDisposition,
+                                int dwFlagsAndAttributes, WinNT.HANDLE hTemplateFile);
+
+        boolean ReadFile(WinNT.HANDLE hFile, Pointer lpBuffer, int nNumberOfBytesToRead,
+                         IntByReference lpNumberOfBytesRead, WinBase.OVERLAPPED lpOverlapped);
+
+        boolean WriteFile(WinNT.HANDLE hFile, Pointer lpBuffer, int nNumberOfBytesToWrite,
+                          IntByReference lpNumberOfBytesWritten, WinBase.OVERLAPPED lpOverlapped);
+
+        /**
+         * Uses {@link Pointer} instead of {@link WinBase.OVERLAPPED} to prevent
+         * JNA auto-marshaling from overwriting OS-updated native OVERLAPPED fields
+         * (Internal, InternalHigh) with stale Java-side values before the call.
+         */
+        boolean GetOverlappedResult(WinNT.HANDLE hFile, Pointer lpOverlapped,
+                                    IntByReference lpNumberOfBytesTransferred, boolean bWait);
+
+        boolean CancelIoEx(WinNT.HANDLE hFile, Pointer lpOverlapped);
+
+        boolean CloseHandle(WinNT.HANDLE hObject);
+
+        WinNT.HANDLE CreateEvent(WinBase.SECURITY_ATTRIBUTES lpEventAttributes,
+                                 boolean bManualReset, boolean bInitialState, String lpName);
+
+        boolean ResetEvent(WinNT.HANDLE hEvent);
+
+        int WaitForSingleObject(WinNT.HANDLE hHandle, int dwMilliseconds);
+
+        boolean WaitNamedPipe(String lpNamedPipeName, int nTimeOut);
+    }
+
+    private static final NpipeKernel32 KERNEL32 = NpipeKernel32.INSTANCE;
+    private static final int BUFFER_SIZE = 8192;
+    private static final int WAIT_FAILED = 0xFFFFFFFF;
+    private static final int ERROR_PIPE_BUSY = 231;
+    private static final int ERROR_SEM_TIMEOUT = 121;
+    private static final int NMPWAIT_WAIT_FOREVER = -1; // 0xFFFFFFFF
+
+    private static boolean isNullHandle(final WinNT.HANDLE h) {
+        return h == null || Pointer.nativeValue(h.getPointer()) == 0L;
+    }
+
+    /**
+     * Opens a named pipe handle, retrying with {@code WaitNamedPipe} when all
+     * server instances are busy ({@code ERROR_PIPE_BUSY}).
+     *
+     * @param pipeName          full pipe path (e.g. {@code \\.\pipe\docker_engine})
+     * @param connectTimeoutMs  connect timeout in milliseconds; 0 means wait indefinitely
+     * @return a valid pipe handle opened with {@code FILE_FLAG_OVERLAPPED}
+     */
+    private static WinNT.HANDLE openPipe(final String pipeName,
+                                          final int connectTimeoutMs) throws IOException {
+        final long deadline = connectTimeoutMs > 0
+                ? System.currentTimeMillis() + connectTimeoutMs : 0;
+
+        while (true) {
+            final WinNT.HANDLE handle = KERNEL32.CreateFile(
+                    pipeName,
+                    WinNT.GENERIC_READ | WinNT.GENERIC_WRITE,
+                    0,
+                    null,
+                    WinNT.OPEN_EXISTING,
+                    WinNT.FILE_FLAG_OVERLAPPED,
+                    null);
+
+            if (!WinBase.INVALID_HANDLE_VALUE.equals(handle)) {
+                return handle;
+            }
+
+            final int err = Native.getLastError();
+            if (err != ERROR_PIPE_BUSY) {
+                throw new IOException("Cannot open named pipe " + pipeName
+                        + ": Windows error " + err);
+            }
+
+            // All server instances are busy — wait for one to become available
+            final int waitMs;
+            if (connectTimeoutMs > 0) {
+                waitMs = (int) (deadline - System.currentTimeMillis());
+                if (waitMs <= 0) {
+                    throw new SocketTimeoutException(
+                            "Connect to named pipe " + pipeName
+                                    + " timed out after " + connectTimeoutMs + " ms");
+                }
+            } else {
+                waitMs = NMPWAIT_WAIT_FOREVER;
+            }
+
+            if (!KERNEL32.WaitNamedPipe(pipeName, waitMs)) {
+                final int waitErr = Native.getLastError();
+                if (waitErr == ERROR_SEM_TIMEOUT) {
+                    throw new SocketTimeoutException(
+                            "Connect to named pipe " + pipeName
+                                    + " timed out after " + connectTimeoutMs + " ms");
+                }
+                throw new IOException("WaitNamedPipe failed for " + pipeName
+                        + ": Windows error " + waitErr);
+            }
+            // An instance became available — retry CreateFile
+        }
+    }
+
+    private final WinNT.HANDLE hPipe;
+    private final String pipeName;
+
+    private final WinNT.HANDLE readEvent;
+    private final Memory readBuffer;
+
+    private final WinNT.HANDLE writeEvent;
+    private final Memory writeBuffer;
+
+    private final ReentrantLock readLock;
+    private final ReentrantLock writeLock;
+
+    private final InputStream inputStream;
+    private final OutputStream outputStream;
+
+    private final AtomicBoolean closed = new AtomicBoolean();
+    private volatile int soTimeoutMs;
+
+    NamedPipeSocket(final String pipeName, final int connectTimeoutMs) throws IOException {
+        this.pipeName = pipeName;
+        this.hPipe = openPipe(pipeName, connectTimeoutMs);
+
+        this.readEvent = KERNEL32.CreateEvent(null, true, false, null);
+        this.writeEvent = KERNEL32.CreateEvent(null, true, false, null);
+        if (isNullHandle(readEvent) || isNullHandle(writeEvent)) {
+            KERNEL32.CloseHandle(hPipe);
+            if (!isNullHandle(readEvent)) {
+                KERNEL32.CloseHandle(readEvent);
+            }
+            if (!isNullHandle(writeEvent)) {
+                KERNEL32.CloseHandle(writeEvent);
+            }
+            throw new IOException("Failed to create I/O events for " + pipeName
+                    + ": Windows error " + Native.getLastError());
+        }
+
+        this.readBuffer = new Memory(BUFFER_SIZE);
+        this.writeBuffer = new Memory(BUFFER_SIZE);
+        this.readLock = new ReentrantLock();
+        this.writeLock = new ReentrantLock();
+        this.inputStream = new PipeInputStream();
+        this.outputStream = new PipeOutputStream();
+    }
+
+    @Override
+    public void connect(final SocketAddress endpoint, final int timeout) throws IOException {
+        // Already connected at construction time via CreateFile.
+    }
+
+    @Override
+    public void connect(final SocketAddress endpoint) throws IOException {
+        // Already connected at construction time via CreateFile.
+    }
+
+    @Override
+    public boolean isConnected() {
+        return !closed.get();
+    }
+
+    @Override
+    public boolean isClosed() {
+        return closed.get();
+    }
+
+    @Override
+    public InputStream getInputStream() throws IOException {
+        if (closed.get()) {
+            throw new SocketException("Socket is closed");
+        }
+        return inputStream;
+    }
+
+    @Override
+    public OutputStream getOutputStream() throws IOException {
+        if (closed.get()) {
+            throw new SocketException("Socket is closed");
+        }
+        return outputStream;
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (closed.compareAndSet(false, true)) {
+            // Cancel all pending overlapped I/O on this handle
+            KERNEL32.CancelIoEx(hPipe, null);
+            // Acquire both I/O locks so that no overlapped operation is still
+            // referencing the pipe handle or event objects when we close them.
+            // CancelIoEx above ensures any blocked WaitForSingleObject returns
+            // promptly, so these locks will not block for long.
+            readLock.lock();
+            writeLock.lock();
+            try {
+                KERNEL32.CloseHandle(hPipe);
+                KERNEL32.CloseHandle(readEvent);
+                KERNEL32.CloseHandle(writeEvent);
+            } finally {
+                writeLock.unlock();
+                readLock.unlock();
+            }
+        }
+    }
+
+    @Override
+    public int getSoTimeout() throws SocketException {
+        return soTimeoutMs;
+    }
+
+    @Override
+    public void setSoTimeout(final int timeout) throws SocketException {
+        if (timeout < 0) {
+            throw new IllegalArgumentException("timeout < 0");
+        }
+        this.soTimeoutMs = timeout;
+    }
+
+    @Override
+    public void setReceiveBufferSize(final int size) throws SocketException {
+        // No-op: named pipes do not expose kernel buffer tuning.
+    }
+
+    @Override
+    public int getReceiveBufferSize() throws SocketException {
+        return BUFFER_SIZE;
+    }
+
+    @Override
+    public void setSendBufferSize(final int size) throws SocketException {
+        // No-op: named pipes do not expose kernel buffer tuning.
+    }
+
+    @Override
+    public int getSendBufferSize() throws SocketException {
+        return BUFFER_SIZE;
+    }
+
+    @Override
+    public void setSoLinger(final boolean on, final int linger) throws SocketException {
+        // No-op for named pipes.
+    }
+
+    @Override
+    public int getSoLinger() throws SocketException {
+        return -1;
+    }
+
+    @Override
+    public String toString() {
+        return "NamedPipeSocket[" + pipeName + (closed.get() ? ", closed" : "") + "]";
+    }
+
+    /**
+     * Performs an overlapped read on the pipe handle with timeout support.
+     *
+     * @param buf       pre-allocated native buffer
+     * @param event     manual-reset event for the overlapped operation
+     * @param toRead    number of bytes to read
+     * @param timeoutMs SO_TIMEOUT value; 0 or negative means infinite
+     * @return number of bytes read, or -1 on EOF / broken pipe
+     */
+    private int overlappedRead(final Memory buf, final WinNT.HANDLE event,
+                               final int toRead, final int timeoutMs) throws IOException {
+        final WinBase.OVERLAPPED overlapped = new WinBase.OVERLAPPED();
+        overlapped.hEvent = event;
+        KERNEL32.ResetEvent(event);
+        overlapped.write();
+
+        final IntByReference bytesRead = new IntByReference();
+        final boolean ok = KERNEL32.ReadFile(hPipe, buf, toRead, bytesRead, overlapped);
+        if (ok) {
+            // Completed synchronously
+            final int n = bytesRead.getValue();
+            return n == 0 ? -1 : n;
+        }
+
+        final int err = Native.getLastError();
+        if (err == WinError.ERROR_BROKEN_PIPE) {
+            return -1;
+        }
+        if (err != WinError.ERROR_IO_PENDING) {
+            throw new IOException("ReadFile on " + pipeName + " failed: Windows error " + err);
+        }
+
+        // I/O is pending — wait with timeout
+        final int waitMs = timeoutMs > 0 ? timeoutMs : WinBase.INFINITE;
+        final int waitResult = KERNEL32.WaitForSingleObject(event, waitMs);
+
+        if (waitResult == WAIT_FAILED) {
+            throw new IOException("WaitForSingleObject failed on read from " + pipeName
+                    + ": Windows error " + Native.getLastError());
+        }
+
+        if (waitResult == WinError.WAIT_TIMEOUT) {
+            KERNEL32.CancelIoEx(hPipe, overlapped.getPointer());
+            // Wait for cancellation to complete so the OVERLAPPED struct is safe to discard
+            KERNEL32.GetOverlappedResult(hPipe, overlapped.getPointer(), bytesRead, true);
+            throw new SocketTimeoutException("Read timed out after " + timeoutMs + " ms on " + pipeName);
+        }
+
+        if (!KERNEL32.GetOverlappedResult(hPipe, overlapped.getPointer(), bytesRead, false)) {
+            final int resultErr = Native.getLastError();
+            if (resultErr == WinError.ERROR_BROKEN_PIPE) {
+                return -1;
+            }
+            throw new IOException("ReadFile on " + pipeName + " failed: Windows error " + resultErr);
+        }
+        final int n = bytesRead.getValue();
+        return n == 0 ? -1 : n;
+    }
+
+    /**
+     * Performs an overlapped write on the pipe handle, blocking until complete.
+     *
+     * @return number of bytes actually written
+     */
+    private int overlappedWrite(final Memory buf, final WinNT.HANDLE event,
+                                final int toWrite) throws IOException {
+        final WinBase.OVERLAPPED overlapped = new WinBase.OVERLAPPED();
+        overlapped.hEvent = event;
+        KERNEL32.ResetEvent(event);
+        overlapped.write();
+
+        final IntByReference bytesWritten = new IntByReference();
+        final boolean ok = KERNEL32.WriteFile(hPipe, buf, toWrite, bytesWritten, overlapped);
+        if (ok) {
+            return bytesWritten.getValue();
+        }
+
+        final int err = Native.getLastError();
+        if (err != WinError.ERROR_IO_PENDING) {
+            throw new IOException("WriteFile on " + pipeName + " failed: Windows error " + err);
+        }
+
+        // Wait for write to complete
+        final int waitResult = KERNEL32.WaitForSingleObject(event, WinBase.INFINITE);
+        if (waitResult == WAIT_FAILED) {
+            throw new IOException("WaitForSingleObject failed on write to " + pipeName
+                    + ": Windows error " + Native.getLastError());
+        }
+        if (!KERNEL32.GetOverlappedResult(hPipe, overlapped.getPointer(), bytesWritten, false)) {
+            throw new IOException("WriteFile on " + pipeName
+                    + " failed: Windows error " + Native.getLastError());
+        }
+        return bytesWritten.getValue();
+    }
+
+    private final class PipeInputStream extends InputStream {
+
+        @Override
+        public int read() throws IOException {
+            final byte[] b = new byte[1];
+            final int n = read(b, 0, 1);
+            return n == -1 ? -1 : (b[0] & 0xFF);
+        }
+
+        @Override
+        public int read(final byte[] b) throws IOException {
+            return read(b, 0, b.length);
+        }
+
+        @Override
+        public int read(final byte[] b, final int off, final int len) throws IOException {
+            if (closed.get()) {
+                throw new SocketException("Socket is closed");
+            }
+            if (len == 0) {
+                return 0;
+            }
+
+            readLock.lock();
+            try {
+                if (closed.get()) {
+                    throw new SocketException("Socket is closed");
+                }
+                final int toRead = Math.min(len, BUFFER_SIZE);
+                final int n = overlappedRead(readBuffer, readEvent, toRead, soTimeoutMs);
+                if (n > 0) {
+                    readBuffer.read(0, b, off, n);
+                }
+                return n;
+            } finally {
+                readLock.unlock();
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            NamedPipeSocket.this.close();
+        }
+    }
+
+    private final class PipeOutputStream extends OutputStream {
+
+        @Override
+        public void write(final int b) throws IOException {
+            write(new byte[]{(byte) b}, 0, 1);
+        }
+
+        @Override
+        public void write(final byte[] b) throws IOException {
+            write(b, 0, b.length);
+        }
+
+        @Override
+        public void write(final byte[] b, final int off, final int len) throws IOException {
+            if (closed.get()) {
+                throw new SocketException("Socket is closed");
+            }
+
+            writeLock.lock();
+            try {
+                if (closed.get()) {
+                    throw new SocketException("Socket is closed");
+                }
+                int offset = off;
+                int remaining = len;
+                while (remaining > 0) {
+                    final int chunk = Math.min(remaining, BUFFER_SIZE);
+                    writeBuffer.write(0, b, offset, chunk);
+                    final int written = overlappedWrite(writeBuffer, writeEvent, chunk);
+                    if (written <= 0) {
+                        throw new IOException("WriteFile on " + pipeName + " wrote 0 bytes");
+                    }
+                    offset += written;
+                    remaining -= written;
+                }
+            } finally {
+                writeLock.unlock();
+            }
+        }
+
+        @Override
+        public void flush() throws IOException {
+            // No-op: named pipes deliver data as soon as WriteFile returns.
+        }
+
+        @Override
+        public void close() throws IOException {
+            NamedPipeSocket.this.close();
+        }
+    }
+}

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/socket/NamedPipeSocketFactory.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/socket/NamedPipeSocketFactory.java
@@ -1,0 +1,181 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.hc.client5.http.socket;
+
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.net.Socket;
+import java.net.SocketTimeoutException;
+
+import org.apache.hc.core5.annotation.Contract;
+import org.apache.hc.core5.annotation.Internal;
+import org.apache.hc.core5.annotation.ThreadingBehavior;
+import org.apache.hc.core5.util.Args;
+import org.apache.hc.core5.util.TimeValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A factory for Windows Named Pipe sockets.
+ * <p>
+ * Windows Named Pipes (e.g. {@code \\.\pipe\docker_engine}) provide an IPC mechanism on Windows
+ * similar to Unix domain sockets. This factory creates {@link Socket} instances that connect to
+ * Named Pipes using the Win32 {@code CreateFile} API via JNA with overlapped I/O, enabling real
+ * timeout enforcement and cancellation.
+ * </p>
+ * <p>
+ * Named Pipe support requires:
+ * <ul>
+ *   <li>Windows OS</li>
+ *   <li>JNA ({@code net.java.dev.jna:jna-platform}) on the classpath</li>
+ * </ul>
+ * Use {@link #isAvailable()} to check at runtime whether both conditions are met.
+ * </p>
+ * <h3>Connect timeout</h3>
+ * <p>
+ * Opening a named pipe can block when all server instances are busy. When a positive connect
+ * timeout is specified, the implementation uses the Win32 {@code WaitNamedPipe} API with
+ * the given deadline. If all instances remain busy past the deadline, a
+ * {@link java.net.SocketTimeoutException} is thrown. A timeout of zero means wait indefinitely.
+ * </p>
+ *
+ * @since 5.7
+ */
+@Contract(threading = ThreadingBehavior.STATELESS)
+@Internal
+public final class NamedPipeSocketFactory {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NamedPipeSocketFactory.class);
+
+    /**
+     * Check for a JNA platform class that does NOT trigger native library loading.
+     * {@code Kernel32.class} must not be used here because its static initializer
+     * calls {@code Native.load("kernel32")} which fails on non-Windows platforms.
+     */
+    private static final String JNA_PLATFORM_CLASS = "com.sun.jna.platform.win32.WinBase";
+
+    private static final boolean IS_WINDOWS = System.getProperty("os.name", "")
+            .toLowerCase(java.util.Locale.ROOT).contains("win");
+
+    private static final boolean JNA_AVAILABLE = detectJna();
+
+    private static final NamedPipeSocketFactory INSTANCE = new NamedPipeSocketFactory();
+
+    private static boolean detectJna() {
+        if (!IS_WINDOWS) {
+            return false;
+        }
+        try {
+            Class.forName(JNA_PLATFORM_CLASS);
+            LOG.debug("JNA detected for Windows Named Pipe support");
+            return true;
+        } catch (final ClassNotFoundException e) {
+            LOG.debug("JNA not available; Windows Named Pipe support disabled");
+            return false;
+        }
+    }
+
+    /**
+     * Checks if Windows Named Pipe support is available on the current platform.
+     * Requires both Windows OS and JNA on the classpath.
+     *
+     * @return true if Named Pipe support is available, false otherwise
+     */
+    public static boolean isAvailable() {
+        return IS_WINDOWS && JNA_AVAILABLE;
+    }
+
+    /**
+     * Gets the singleton instance of {@link NamedPipeSocketFactory}.
+     *
+     * @return the singleton instance
+     */
+    public static NamedPipeSocketFactory getSocketFactory() {
+        return INSTANCE;
+    }
+
+    /**
+     * Connects to a Windows Named Pipe and returns a {@link Socket} wrapping the connection.
+     *
+     * @param pipeName       the full pipe path (e.g. {@code \\.\pipe\docker_engine})
+     * @param connectTimeout the connect timeout; a positive value enables deadline enforcement,
+     *                       zero or {@code null} means block indefinitely
+     * @return a connected {@link Socket} wrapping the Named Pipe
+     * @throws SocketTimeoutException if the pipe could not be opened within the timeout
+     * @throws IOException if the pipe cannot be opened
+     * @throws UnsupportedOperationException if the current platform is not Windows or JNA is missing
+     */
+    public Socket connectSocket(
+            final String pipeName,
+            final TimeValue connectTimeout) throws IOException {
+        Args.notNull(pipeName, "Named pipe path");
+
+        if (!isAvailable()) {
+            throw new UnsupportedOperationException(
+                    "Windows Named Pipes require Windows OS and JNA (jna-platform) on the classpath; "
+                            + "Windows=" + IS_WINDOWS + ", JNA=" + JNA_AVAILABLE);
+        }
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Connecting to named pipe: {} (timeout: {})", pipeName, connectTimeout);
+        }
+
+        final int timeoutMs = TimeValue.isPositive(connectTimeout)
+                ? connectTimeout.toMillisecondsIntBound() : 0;
+
+        try {
+            return createNamedPipeSocket(pipeName, timeoutMs);
+        } catch (final IOException ex) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Failed to connect to named pipe {}: {}", pipeName, ex.getMessage());
+            }
+            throw ex;
+        }
+    }
+
+    /**
+     * Creates a {@link NamedPipeSocket} via reflection to avoid a hard class-loading
+     * dependency on JNA from this factory class.
+     */
+    private static Socket createNamedPipeSocket(final String pipeName,
+                                                final int connectTimeoutMs) throws IOException {
+        try {
+            final Class<?> socketClass = Class.forName(
+                    "org.apache.hc.client5.http.socket.NamedPipeSocket");
+            final Constructor<?> ctor = socketClass.getDeclaredConstructor(String.class, int.class);
+            ctor.setAccessible(true);
+            return (Socket) ctor.newInstance(pipeName, connectTimeoutMs);
+        } catch (final ReflectiveOperationException ex) {
+            final Throwable cause = ex.getCause();
+            if (cause instanceof IOException) {
+                throw (IOException) cause;
+            }
+            throw new IOException("Failed to create named pipe socket for " + pipeName, ex);
+        }
+    }
+}

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/examples/WindowsNamedPipe.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/examples/WindowsNamedPipe.java
@@ -1,0 +1,91 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.client5.http.examples;
+
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+
+/**
+ * Example demonstrating how to communicate with Docker Desktop on Windows
+ * via Windows Named Pipes ({@code npipe://}).
+ * <p>
+ * Docker Desktop on Windows exposes its API through the named pipe
+ * {@code \\.\pipe\docker_engine}. This example connects to that pipe
+ * and sends an HTTP request, just like the Unix domain socket example
+ * connects to {@code /var/run/docker.sock} on Linux/macOS.
+ * </p>
+ * <p>
+ * The named pipe path is opened using {@link java.io.RandomAccessFile},
+ * which internally maps to Win32 {@code CreateFile}/{@code ReadFile}/{@code WriteFile} —
+ * no JNA/JNR/JNI is needed for the client side.
+ * </p>
+ *
+ * @since 5.7
+ */
+public class WindowsNamedPipe {
+
+    public static void main(final String[] args) throws IOException {
+        if (args.length == 0 || "-h".equals(args[0]) || "--help".equals(args[0])) {
+            usage(System.out);
+            return;
+        } else if (args.length != 2) {
+            usage(System.err);
+            return;
+        }
+
+        final String namedPipe = args[0];
+        final String uri = args[1];
+
+        try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
+            final HttpGet httpGet = new HttpGet(uri);
+            httpGet.setConfig(RequestConfig.custom().setNamedPipe(namedPipe).build());
+            client.execute(httpGet, classicHttpResponse -> {
+                final InputStream inputStream = classicHttpResponse.getEntity().getContent();
+                final byte[] buf = new byte[8192];
+                int len;
+                while ((len = inputStream.read(buf)) > 0) {
+                    System.out.write(buf, 0, len);
+                }
+                return null;
+            });
+        }
+    }
+
+    private static void usage(final PrintStream printStream) {
+        printStream.println("Usage: WindowsNamedPipe [pipe-path] [uri]");
+        printStream.println();
+        printStream.println("Examples:");
+        printStream.println("WindowsNamedPipe \\\\.\\pipe\\docker_engine 'http://localhost/info'");
+        printStream.println("WindowsNamedPipe \\\\.\\pipe\\docker_engine 'http://localhost/containers/json?all=1'");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
     <rxjava3.version>3.1.12</rxjava3.version>
     <testcontainers.version>1.21.4</testcontainers.version>
     <junixsocket.version>2.10.1</junixsocket.version>
+    <jna.version>5.16.0</jna.version>
     <api.comparison.version>5.6</api.comparison.version>
     <hc.animal-sniffer.signature.ignores>javax.net.ssl.SSLEngine,javax.net.ssl.SSLParameters,java.nio.ByteBuffer,java.nio.CharBuffer,jdk.net.ExtendedSocketOptions,jdk.net.Sockets</hc.animal-sniffer.signature.ignores>
     <commons.compress.version>1.28.0</commons.compress.version>
@@ -183,6 +184,12 @@
         <artifactId>junixsocket-core</artifactId>
         <version>${junixsocket.version}</version>
         <type>pom</type>
+      </dependency>
+      <dependency>
+        <groupId>net.java.dev.jna</groupId>
+        <artifactId>jna-platform</artifactId>
+        <version>${jna.version}</version>
+        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.junit</groupId>


### PR DESCRIPTION
Added Windows Named Pipe transport as the Windows counterpart to Unix Domain Socket support introduced earlier. This enables HttpClient to communicate over Named Pipes such as \\.\pipe\docker_engine using the same connection management and request execution infrastructure.        
                                                                                                                                                                                                                                                                                                