### PR TITLE
HTTPCLIENT-2421: Use effective retry interval for response timeout check

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/DefaultHttpRequestRetryStrategy.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/DefaultHttpRequestRetryStrategy.java
@@ -203,15 +203,22 @@ public class DefaultHttpRequestRetryStrategy implements HttpRequestRetryStrategy
             final HttpContext context) {
         Args.notNull(response, "response");
 
+        if (execCount > this.maxRetries || !this.retriableCodes.contains(response.getCode())) {
+            return false;
+        }
+
         if (context != null) {
             final HttpClientContext clientContext = HttpClientContext.cast(context);
             final RequestConfig requestConfig = clientContext.getRequestConfigOrDefault();
             final Timeout responseTimeout = requestConfig.getResponseTimeout();
-            if (responseTimeout != null && defaultRetryInterval.compareTo(responseTimeout) > 0) {
-                return false;
+            if (responseTimeout != null) {
+                final TimeValue retryInterval = getRetryInterval(response, execCount, context);
+                if (retryInterval.compareTo(responseTimeout) > 0) {
+                    return false;
+                }
             }
         }
-        return execCount <= this.maxRetries && retriableCodes.contains(response.getCode());
+        return true;
     }
 
     @Override

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/TestDefaultHttpRequestRetryStrategy.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/TestDefaultHttpRequestRetryStrategy.java
@@ -188,4 +188,17 @@ class TestDefaultHttpRequestRetryStrategy {
         Assertions.assertTrue(retryStrategy.retryRequest(request, new IOException(), 1, null));
     }
 
+    @Test
+    void testRetryRequestWithResponseTimeoutAndRetryAfterHeader() {
+        final HttpResponse response = new BasicHttpResponse(429, "Too Many Requests");
+        response.setHeader(HttpHeaders.RETRY_AFTER, "321");
+
+        final HttpClientContext context = HttpClientContext.create();
+        context.setRequestConfig(RequestConfig.custom()
+                .setResponseTimeout(Timeout.ofSeconds(2L))
+                .build());
+
+        Assertions.assertFalse(retryStrategy.retryRequest(response, 1, context));
+    }
+
 }


### PR DESCRIPTION
Use the effective response retry interval when checking the response timeout. 
The retry interval may be derived from the Retry-After response header, not only from the default retry interval.