### PR TITLE
escape quotes and strip line breaks in rfc7578 multipart parameters

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/entity/mime/AbstractMultipartFormat.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/entity/mime/AbstractMultipartFormat.java
@@ -114,6 +114,21 @@ abstract class AbstractMultipartFormat {
         return buf.toString();
     }
 
+    static CharSequence escapeQuoted(final CharSequence s) {
+        if (s == null) {
+            return null;
+        }
+        final StringBuilder buf = new StringBuilder(s.length());
+        for (int n = 0; n < s.length(); n++) {
+            final char ch = s.charAt(n);
+            if (ch == '"' || ch == '\\') {
+                buf.append('\\');
+            }
+            buf.append(ch);
+        }
+        return buf.toString();
+    }
+
     static void writeField(
             final MimeField field, final OutputStream out) throws IOException {
         writeBytes(stripLineBreaks(field.getName()), out);

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/entity/mime/HttpRFC7578Multipart.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/entity/mime/HttpRFC7578Multipart.java
@@ -119,7 +119,7 @@ class HttpRFC7578Multipart extends AbstractMultipartFormat {
                                 writeBytes(value, StandardCharsets.ISO_8859_1, out);
                             }
                         } else {
-                            writeBytes(value, out);
+                            writeBytes(stripLineBreaks(escapeQuoted(value)), out);
                         }
                     }
                     writeBytes("\"", out);

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/entity/mime/HttpRFC7578MultipartTest.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/entity/mime/HttpRFC7578MultipartTest.java
@@ -28,11 +28,36 @@
 package org.apache.hc.client5.http.entity.mime;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+
+import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.net.PercentCodec;
 import org.junit.jupiter.api.Test;
 
 class HttpRFC7578MultipartTest {
+
+    @Test
+    void testFieldNameLineBreaksAndQuotesAreNeutralised() throws Exception {
+        final FormBodyPart part = FormBodyPartBuilder.create(
+                "evil\"\r\nX-Injected: yes",
+                new StringBody("value", ContentType.DEFAULT_TEXT),
+                HttpMultipartMode.EXTENDED).build();
+        final HttpRFC7578Multipart multipart = new HttpRFC7578Multipart(
+                StandardCharsets.UTF_8, "BOUNDARY", Collections.singletonList(part),
+                HttpMultipartMode.EXTENDED);
+
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        multipart.writeTo(out);
+        final String s = out.toString("ISO-8859-1");
+
+        assertFalse(s.contains("\r\nX-Injected: yes"), s);
+        assertTrue(s.contains("name=\"evil\\\"  X-Injected: yes\""), s);
+    }
 
     @Test
     void testPercentDecodingWithValidMessages() {


### PR DESCRIPTION
In EXTENDED mode the RFC 7578 writer builds the Content-Disposition line itself rather than going through MimeField.getBody(), and for parameters other than filename (in practice the form field name) it writes the value straight out with no quoting. So a field name that contains a double quote or a CR/LF ends up breaking out of the quoted string and injecting extra header lines into the part, which matters when the name comes from somewhere untrusted. The STRICT and LEGACY writers already avoid this because they escape quotes and strip line breaks; this just brings the RFC 7578 path in line by backslash-escaping quotes and replacing line breaks the same way. Added a small regression test in HttpRFC7578MultipartTest covering a name with an embedded quote and CRLF.