### PR TITLE
Add QUERY method caching support

### DIFF
--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/AsyncCachingExec.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/AsyncCachingExec.java
@@ -72,6 +72,7 @@ import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.Method;
 import org.apache.hc.core5.http.ProtocolException;
 import org.apache.hc.core5.http.impl.BasicEntityDetails;
 import org.apache.hc.core5.http.nio.AsyncDataConsumer;
@@ -262,8 +263,7 @@ class AsyncCachingExec extends CachingExecBase implements AsyncExecChainHandler 
         }
 
         // Do not attempt to cache requests with an enclosed content body
-        // To be revised when implementing QUERY support
-        if (entityProducer != null) {
+        if (entityProducer != null && !Method.QUERY.isSame(request.getMethod())) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("{} entity enclosing request cannot be served from cache", exchangeId);
             }
@@ -417,11 +417,21 @@ class AsyncCachingExec extends CachingExecBase implements AsyncExecChainHandler 
 
     SimpleHttpRequest prepareRequest(final HttpRequest request,
                                      final AsyncEntityProducer entityProducer) throws ProtocolException {
-        // To be revised when implementing QUERY support
-        if (entityProducer != null) {
+        if (entityProducer != null && !Method.QUERY.isSame(request.getMethod())) {
             throw new ProtocolException("Caching of entity enclosing requests is not supported");
         }
-        return SimpleRequestBuilder.copy(request).build();
+        final SimpleRequestBuilder builder = SimpleRequestBuilder.copy(request);
+        if (request instanceof SimpleHttpRequest) {
+            final SimpleBody body = ((SimpleHttpRequest) request).getBody();
+            if (body != null) {
+                if (body.isText()) {
+                    builder.setBody(body.getBodyText(), body.getContentType());
+                } else {
+                    builder.setBody(body.getBodyBytes(), body.getContentType());
+                }
+            }
+        }
+        return builder.build();
     }
 
     void callChain(

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CacheKeyGenerator.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CacheKeyGenerator.java
@@ -40,6 +40,16 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.stream.StreamSupport;
 
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.function.Function;
+import org.apache.hc.client5.http.async.methods.SimpleHttpRequest;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.Method;
+import org.apache.hc.core5.http.io.entity.ByteArrayEntity;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.client5.http.cache.HttpCacheEntry;
 import org.apache.hc.core5.annotation.Contract;
 import org.apache.hc.core5.annotation.Internal;
@@ -71,6 +81,16 @@ public class CacheKeyGenerator implements Resolver<URI, String> {
      * Default instance of {@link CacheKeyGenerator}.
      */
     public static final CacheKeyGenerator INSTANCE = new CacheKeyGenerator();
+
+    private final Function<HttpRequest, byte[]> bodyBytesExtractor;
+
+    public CacheKeyGenerator() {
+        this(null);
+    }
+
+    public CacheKeyGenerator(final Function<HttpRequest, byte[]> bodyBytesExtractor) {
+        this.bodyBytesExtractor = bodyBytesExtractor;
+    }
 
     @Override
     public String resolve(final URI uri) {
@@ -120,9 +140,24 @@ public class CacheKeyGenerator implements Resolver<URI, String> {
      * @return cache key
      */
     public String generateKey(final URI requestUri) {
+        return generateKey(requestUri, null);
+    }
+
+    /**
+     * Computes a key for the given request {@link URI} and body hash that can
+     * be used as a unique identifier for cached resources. The URI is
+     * expected to be in an absolute form.
+     *
+     * @param requestUri request URI
+     * @param bodyHash hash of the request body
+     * @return cache key
+     */
+    public String generateKey(final URI requestUri, final String bodyHash) {
         try {
             final URI normalizeRequestUri = CacheSupport.normalize(requestUri);
-            return normalizeRequestUri.toASCIIString();
+            final String uriString = normalizeRequestUri.toASCIIString();
+            // Using a Record Separator to make it easy to spot
+            return bodyHash == null ? uriString : uriString + '\u001e' + bodyHash;
         } catch (final URISyntaxException ex) {
             return requestUri.toASCIIString();
         }
@@ -138,10 +173,59 @@ public class CacheKeyGenerator implements Resolver<URI, String> {
      */
     public String generateKey(final HttpHost host, final HttpRequest request) {
         final String s = CacheSupport.requestUriRaw(host, request);
+        final String hash = Method.QUERY.isSame(request.getMethod()) ? getBodyHash(request) : null;
         try {
-            return generateKey(new URI(s));
+            return generateKey(new URI(s), hash);
         } catch (final URISyntaxException ex) {
             return s;
+        }
+    }
+
+    protected byte[] getRequestBodyBytes(final HttpRequest request) {
+        if (bodyBytesExtractor != null) {
+            final byte[] bytes = bodyBytesExtractor.apply(request);
+            if (bytes != null) {
+                return bytes;
+            }
+        }
+        if (request instanceof SimpleHttpRequest) {
+            return ((SimpleHttpRequest) request).getBodyBytes();
+        }
+        if (request instanceof ClassicHttpRequest) {
+            final HttpEntity entity = ((ClassicHttpRequest) request).getEntity();
+            if (entity != null) {
+                try {
+                    if (entity.isRepeatable()) {
+                        final byte[] bytes = EntityUtils.toByteArray(entity);
+                        ((ClassicHttpRequest) request).setEntity(new ByteArrayEntity(bytes, ContentType.parse(entity.getContentType())));
+                        return bytes;
+                    }
+                } catch (final Exception ignore) {
+                }
+            }
+        }
+        return null;
+    }
+
+    protected String getBodyHash(final HttpRequest request) {
+        final byte[] bodyBytes = getRequestBodyBytes(request);
+        if (bodyBytes == null || bodyBytes.length == 0) {
+            return "";
+        }
+        try {
+            final MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            final byte[] hashBytes = digest.digest(bodyBytes);
+            final StringBuilder hexString = new StringBuilder();
+            for (final byte b : hashBytes) {
+                final String hex = Integer.toHexString(0xff & b);
+                if (hex.length() == 1) {
+                    hexString.append('0');
+                }
+                hexString.append(hex);
+            }
+            return hexString.toString();
+        } catch (final NoSuchAlgorithmException e) {
+            return "";
         }
     }
 

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CacheableRequestPolicy.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CacheableRequestPolicy.java
@@ -57,7 +57,7 @@ class CacheableRequestPolicy {
             return false;
         }
 
-        if (!Method.GET.isSame(method) && !Method.HEAD.isSame(method)) {
+        if (!Method.GET.isSame(method) && !Method.HEAD.isSame(method) && !Method.QUERY.isSame(method)) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("{} request cannot be served from cache", method);
             }

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachedHttpResponseGenerator.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachedHttpResponseGenerator.java
@@ -156,7 +156,7 @@ class CachedHttpResponseGenerator {
     }
 
     private boolean responseShouldContainEntity(final HttpRequest request, final HttpCacheEntry cacheEntry) {
-        return Method.GET.isSame(request.getMethod()) && cacheEntry.getResource() != null;
+        return (Method.GET.isSame(request.getMethod()) || Method.QUERY.isSame(request.getMethod())) && cacheEntry.getResource() != null;
     }
 
 }

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingExec.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingExec.java
@@ -61,6 +61,7 @@ import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.http.HttpVersion;
+import org.apache.hc.core5.http.Method;
 import org.apache.hc.core5.http.ProtocolException;
 import org.apache.hc.core5.http.io.entity.ByteArrayEntity;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
@@ -159,9 +160,8 @@ class CachingExec extends CachingExecBase implements ExecChainHandler {
         }
 
         // Do not attempt to cache requests with an enclosed content body
-        // To be revised when implementing QUERY support
         final HttpEntity requestEntity = request.getEntity();
-        if (requestEntity != null) {
+        if (requestEntity != null && !Method.QUERY.isSame(request.getMethod())) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("{} entity enclosing request cannot be served from cache", exchangeId);
             }
@@ -227,11 +227,22 @@ class CachingExec extends CachingExecBase implements ExecChainHandler {
     }
 
     SimpleHttpRequest prepareRequest(final ClassicHttpRequest request) throws ProtocolException {
-        // To be revised when implementing QUERY support
-        if (request.getEntity() != null) {
+        if (request.getEntity() != null && !Method.QUERY.isSame(request.getMethod())) {
             throw new ProtocolException("Caching of entity enclosing requests is not supported");
         }
-        return SimpleRequestBuilder.copy(request).build();
+        final SimpleRequestBuilder builder = SimpleRequestBuilder.copy(request);
+        final HttpEntity entity = request.getEntity();
+        if (entity != null) {
+            try {
+                if (entity.isRepeatable()) {
+                    final byte[] bytes = EntityUtils.toByteArray(entity);
+                    request.setEntity(new ByteArrayEntity(bytes, ContentType.parse(entity.getContentType())));
+                    builder.setBody(bytes, ContentType.parse(entity.getContentType()));
+                }
+            } catch (final Exception ignore) {
+            }
+        }
+        return builder.build();
     }
 
     ClassicHttpResponse callBackend(

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingH2AsyncClientBuilder.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingH2AsyncClientBuilder.java
@@ -56,6 +56,7 @@ public class CachingH2AsyncClientBuilder extends H2AsyncClientBuilder {
     private SchedulingStrategy schedulingStrategy;
     private CacheConfig cacheConfig;
     private boolean deleteCache;
+    private CacheKeyGenerator cacheKeyGenerator;
 
     public static CachingH2AsyncClientBuilder create() {
         return new CachingH2AsyncClientBuilder();
@@ -112,6 +113,11 @@ public class CachingH2AsyncClientBuilder extends H2AsyncClientBuilder {
         return this;
     }
 
+    public final CachingH2AsyncClientBuilder setCacheKeyGenerator(final CacheKeyGenerator cacheKeyGenerator) {
+        this.cacheKeyGenerator = cacheKeyGenerator;
+        return this;
+    }
+
     @Override
     protected void customizeExecChain(final NamedElementChain<AsyncExecChainHandler> execChainDefinition) {
         final CacheConfig config = this.cacheConfig != null ? this.cacheConfig : CacheConfig.DEFAULT;
@@ -142,7 +148,7 @@ public class CachingH2AsyncClientBuilder extends H2AsyncClientBuilder {
                 resourceFactoryCopy,
                 HttpCacheEntryFactory.INSTANCE,
                 storageCopy,
-                CacheKeyGenerator.INSTANCE);
+                this.cacheKeyGenerator != null ? this.cacheKeyGenerator : CacheKeyGenerator.INSTANCE);
 
         DefaultAsyncCacheRevalidator cacheRevalidator = null;
         if (config.getAsynchronousWorkers() > 0) {

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingHttpAsyncClientBuilder.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingHttpAsyncClientBuilder.java
@@ -60,6 +60,7 @@ public class CachingHttpAsyncClientBuilder extends HttpAsyncClientBuilder {
     private SchedulingStrategy schedulingStrategy;
     private CacheConfig cacheConfig;
     private boolean deleteCache;
+    private CacheKeyGenerator cacheKeyGenerator;
 
     public static CachingHttpAsyncClientBuilder create() {
         return new CachingHttpAsyncClientBuilder();
@@ -116,6 +117,11 @@ public class CachingHttpAsyncClientBuilder extends HttpAsyncClientBuilder {
         return this;
     }
 
+    public final CachingHttpAsyncClientBuilder setCacheKeyGenerator(final CacheKeyGenerator cacheKeyGenerator) {
+        this.cacheKeyGenerator = cacheKeyGenerator;
+        return this;
+    }
+
     @Override
     protected void customizeExecChain(final NamedElementChain<AsyncExecChainHandler> execChainDefinition) {
         final CacheConfig config = this.cacheConfig != null ? this.cacheConfig : CacheConfig.DEFAULT;
@@ -146,7 +152,7 @@ public class CachingHttpAsyncClientBuilder extends HttpAsyncClientBuilder {
                 resourceFactoryCopy,
                 HttpCacheEntryFactory.INSTANCE,
                 storageCopy,
-                CacheKeyGenerator.INSTANCE);
+                this.cacheKeyGenerator != null ? this.cacheKeyGenerator : CacheKeyGenerator.INSTANCE);
 
         DefaultAsyncCacheRevalidator cacheRevalidator = null;
         if (config.getAsynchronousWorkers() > 0) {

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingHttpClientBuilder.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingHttpClientBuilder.java
@@ -58,6 +58,7 @@ public class CachingHttpClientBuilder extends HttpClientBuilder {
     private SchedulingStrategy schedulingStrategy;
     private CacheConfig cacheConfig;
     private boolean deleteCache;
+    private CacheKeyGenerator cacheKeyGenerator;
 
     public static CachingHttpClientBuilder create() {
         return new CachingHttpClientBuilder();
@@ -110,6 +111,11 @@ public class CachingHttpClientBuilder extends HttpClientBuilder {
         return this;
     }
 
+    public final CachingHttpClientBuilder setCacheKeyGenerator(final CacheKeyGenerator cacheKeyGenerator) {
+        this.cacheKeyGenerator = cacheKeyGenerator;
+        return this;
+    }
+
     @Override
     protected void customizeExecChain(final NamedElementChain<ExecChainHandler> execChainDefinition) {
         final CacheConfig config = this.cacheConfig != null ? this.cacheConfig : CacheConfig.DEFAULT;
@@ -140,7 +146,7 @@ public class CachingHttpClientBuilder extends HttpClientBuilder {
                 resourceFactoryCopy,
                 HttpCacheEntryFactory.INSTANCE,
                 storageCopy,
-                CacheKeyGenerator.INSTANCE);
+                this.cacheKeyGenerator != null ? this.cacheKeyGenerator : CacheKeyGenerator.INSTANCE);
 
         DefaultCacheRevalidator cacheRevalidator = null;
         if (config.getAsynchronousWorkers() > 0) {

--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/ResponseCachingPolicy.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/ResponseCachingPolicy.java
@@ -98,9 +98,9 @@ class ResponseCachingPolicy {
             return false;
         }
 
-        // Presently only GET and HEAD methods are supported
+        // Presently only GET, HEAD and QUERY methods are supported
         final String httpMethod = request.getMethod();
-        if (!Method.GET.isSame(httpMethod) && !Method.HEAD.isSame(httpMethod)) {
+        if (!Method.GET.isSame(httpMethod) && !Method.HEAD.isSame(httpMethod) && !Method.QUERY.isSame(httpMethod)) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("{} method response is not cacheable", httpMethod);
             }

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestCacheKeyGenerator.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestCacheKeyGenerator.java
@@ -26,6 +26,7 @@
  */
 package org.apache.hc.client5.http.impl.cache;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -34,13 +35,17 @@ import java.util.List;
 
 import org.apache.hc.client5.http.cache.HttpCacheEntry;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.async.methods.SimpleHttpRequest;
+import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.apache.hc.core5.http.message.BasicHeader;
 import org.apache.hc.core5.http.message.BasicHeaderIterator;
 import org.apache.hc.core5.http.message.BasicHttpRequest;
+import org.apache.hc.core5.http.message.BasicClassicHttpRequest;
 import org.apache.hc.core5.http.support.BasicRequestBuilder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -352,6 +357,58 @@ class TestCacheKeyGenerator {
                 new BasicHeader("Vary", "User-Agent, Accept-Encoding")
         );
         Assertions.assertEquals("{accept-encoding=text%2Fplain&user-agent=agent1}", extractor.generateVariantKey(request, entry2));
+    }
+
+    @Test
+    void testQueryKeyGenerationWithBody() throws Exception {
+        final HttpHost host = new HttpHost("http", "www.example.com", -1);
+
+        // SimpleHttpRequest with body
+        final SimpleHttpRequest req1 = SimpleHttpRequest.create("QUERY", "/stuff");
+        req1.setBody("my-query-1", ContentType.TEXT_PLAIN);
+        final String key1 = extractor.generateKey(host, req1);
+
+        final SimpleHttpRequest req2 = SimpleHttpRequest.create("QUERY", "/stuff");
+        req2.setBody("my-query-2", ContentType.TEXT_PLAIN);
+        final String key2 = extractor.generateKey(host, req2);
+
+        Assertions.assertNotEquals(key1, key2);
+        Assertions.assertTrue(key1.contains("\u001e"));
+
+        // ClassicHttpRequest with body
+        final BasicClassicHttpRequest req3 = new BasicClassicHttpRequest("QUERY", "/stuff");
+        req3.setEntity(new StringEntity("my-query-1", ContentType.TEXT_PLAIN));
+        final String key3 = extractor.generateKey(host, req3);
+        Assertions.assertEquals(key1, key3);
+    }
+
+    @Test
+    void testQueryKeyGenerationWithCustomSubclass() throws Exception {
+        final HttpHost host = new HttpHost("http", "www.example.com", -1);
+        final CacheKeyGenerator customGenerator = new CacheKeyGenerator() {
+            @Override
+            protected byte[] getRequestBodyBytes(final HttpRequest request) {
+                return "custom-subclass-body".getBytes(StandardCharsets.UTF_8);
+            }
+        };
+
+        final SimpleHttpRequest req = SimpleHttpRequest.create("QUERY", "/stuff");
+        final String key = customGenerator.generateKey(host, req);
+        Assertions.assertTrue(key.contains("\u001e"));
+        Assertions.assertTrue(key.endsWith("01db3f2aa79e0ed79fa787efe21aae8708f2f395082bb420537cb4a1fbc04d6d"));
+    }
+
+    @Test
+    void testQueryKeyGenerationWithCustomExtractor() throws Exception {
+        final HttpHost host = new HttpHost("http", "www.example.com", -1);
+        final CacheKeyGenerator customGenerator = new CacheKeyGenerator(
+                request -> "custom-extractor-body".getBytes(StandardCharsets.UTF_8)
+        );
+
+        final SimpleHttpRequest req = SimpleHttpRequest.create("QUERY", "/stuff");
+        final String key = customGenerator.generateKey(host, req);
+        Assertions.assertTrue(key.contains("\u001e"));
+        Assertions.assertTrue(key.endsWith("1277c424fd056514377d8acd78e602891cee40812bef763577c06b0428c4a817"));
     }
 
 }

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestCachingExecChain.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestCachingExecChain.java
@@ -59,8 +59,10 @@ import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.io.entity.InputStreamEntity;
+import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.apache.hc.core5.http.io.support.ClassicRequestBuilder;
 import org.apache.hc.core5.http.message.BasicClassicHttpRequest;
 import org.apache.hc.core5.http.message.BasicClassicHttpResponse;
@@ -1289,6 +1291,95 @@ class TestCachingExecChain {
 
         // Verify that the backend was called to revalidate the response, as per the new logic
         Mockito.verify(mockExecChain, Mockito.times(5)).proceed(Mockito.any(), Mockito.any());
+    }
+
+    @Test
+    void testQueryRequestsGoIntoCacheAndMatchBody() throws Exception {
+        final ClassicHttpRequest req1 = new BasicClassicHttpRequest("QUERY", "/stuff");
+        req1.setEntity(new StringEntity("query-body-1", ContentType.TEXT_PLAIN));
+
+        final ClassicHttpResponse resp1 = new BasicClassicHttpResponse(200, "OK");
+        resp1.setHeader("Date", DateUtils.formatStandardDate(Instant.now()));
+        resp1.setHeader("Cache-Control", "max-age=3600");
+        resp1.setHeader("Content-Type", "text/plain");
+        resp1.setEntity(new StringEntity("response-body-1", ContentType.TEXT_PLAIN));
+
+        Mockito.when(mockExecChain.proceed(Mockito.any(), Mockito.any())).thenReturn(resp1);
+
+        // First execution (Cache Miss, goes to backend)
+        final ClassicHttpResponse result1 = execute(req1);
+        Assertions.assertEquals(200, result1.getCode());
+        Assertions.assertEquals("response-body-1", EntityUtils.toString(result1.getEntity()));
+
+        // Second execution with identical QUERY request (Cache Hit)
+        final ClassicHttpRequest req2 = new BasicClassicHttpRequest("QUERY", "/stuff");
+        req2.setEntity(new StringEntity("query-body-1", ContentType.TEXT_PLAIN));
+        final ClassicHttpResponse result2 = execute(req2);
+        Assertions.assertEquals(200, result2.getCode());
+        Assertions.assertEquals("response-body-1", EntityUtils.toString(result2.getEntity()));
+        Assertions.assertEquals(CacheResponseStatus.CACHE_HIT, context.getCacheResponseStatus());
+
+        // Third execution with different QUERY request body (Cache Miss, goes to backend)
+        final ClassicHttpRequest req3 = new BasicClassicHttpRequest("QUERY", "/stuff");
+        req3.setEntity(new StringEntity("query-body-2", ContentType.TEXT_PLAIN));
+
+        final ClassicHttpResponse resp3 = new BasicClassicHttpResponse(200, "OK");
+        resp3.setHeader("Date", DateUtils.formatStandardDate(Instant.now()));
+        resp3.setHeader("Cache-Control", "max-age=3600");
+        resp3.setHeader("Content-Type", "text/plain");
+        resp3.setEntity(new StringEntity("response-body-2", ContentType.TEXT_PLAIN));
+
+        Mockito.when(mockExecChain.proceed(Mockito.any(), Mockito.any())).thenReturn(resp3);
+
+        final ClassicHttpResponse result3 = execute(req3);
+        Assertions.assertEquals(200, result3.getCode());
+        Assertions.assertEquals("response-body-2", EntityUtils.toString(result3.getEntity()));
+        Assertions.assertEquals(CacheResponseStatus.CACHE_MISS, context.getCacheResponseStatus());
+    }
+
+    @Test
+    void testQueryAndGetRequestsCachedSeparately() throws Exception {
+        // 1. GET request
+        final ClassicHttpRequest getReq = new BasicClassicHttpRequest("GET", "/stuff");
+        final ClassicHttpResponse getResp = new BasicClassicHttpResponse(200, "OK");
+        getResp.setHeader("Date", DateUtils.formatStandardDate(Instant.now()));
+        getResp.setHeader("Cache-Control", "max-age=3600");
+        getResp.setHeader("Content-Type", "text/plain");
+        getResp.setEntity(new StringEntity("get-response-content", ContentType.TEXT_PLAIN));
+
+        Mockito.when(mockExecChain.proceed(Mockito.any(), Mockito.any())).thenReturn(getResp);
+
+        // Execute GET (Cache Miss)
+        final ClassicHttpResponse getResult1 = execute(getReq);
+        Assertions.assertEquals("get-response-content", EntityUtils.toString(getResult1.getEntity()));
+        Assertions.assertEquals(CacheResponseStatus.CACHE_MISS, context.getCacheResponseStatus());
+
+        // 2. QUERY request
+        final ClassicHttpRequest queryReq = new BasicClassicHttpRequest("QUERY", "/stuff");
+        queryReq.setEntity(new StringEntity("query-body", ContentType.TEXT_PLAIN));
+
+        final ClassicHttpResponse queryResp = new BasicClassicHttpResponse(200, "OK");
+        queryResp.setHeader("Date", DateUtils.formatStandardDate(Instant.now()));
+        queryResp.setHeader("Cache-Control", "max-age=3600");
+        queryResp.setHeader("Content-Type", "text/plain");
+        queryResp.setEntity(new StringEntity("query-response-content", ContentType.TEXT_PLAIN));
+
+        Mockito.when(mockExecChain.proceed(Mockito.any(), Mockito.any())).thenReturn(queryResp);
+
+        // Execute QUERY (Cache Miss)
+        final ClassicHttpResponse queryResult1 = execute(queryReq);
+        Assertions.assertEquals("query-response-content", EntityUtils.toString(queryResult1.getEntity()));
+        Assertions.assertEquals(CacheResponseStatus.CACHE_MISS, context.getCacheResponseStatus());
+
+        // 3. Re-execute GET (should Cache Hit with GET content)
+        final ClassicHttpResponse getResult2 = execute(getReq);
+        Assertions.assertEquals("get-response-content", EntityUtils.toString(getResult2.getEntity()));
+        Assertions.assertEquals(CacheResponseStatus.CACHE_HIT, context.getCacheResponseStatus());
+
+        // 4. Re-execute QUERY (should Cache Hit with QUERY content)
+        final ClassicHttpResponse queryResult2 = execute(queryReq);
+        Assertions.assertEquals("query-response-content", EntityUtils.toString(queryResult2.getEntity()));
+        Assertions.assertEquals(CacheResponseStatus.CACHE_HIT, context.getCacheResponseStatus());
     }
 
 }


### PR DESCRIPTION
This part was dropped from #840 but I reworked it based on the feedback I got. Now CacheKeyGenerator is not a singleton but a regular class that can receive a body extraction function.