### PR TITLE
compare scheme in redirect same-authority check

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/DefaultRedirectStrategy.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/DefaultRedirectStrategy.java
@@ -93,7 +93,7 @@ public class DefaultRedirectStrategy implements RedirectStrategy {
             final HttpRequest redirect,
             final HttpContext context) {
 
-        // If authority (host + effective port) differs, disallow automatic redirect
+        // If the origin (scheme, host and effective port) differs, disallow automatic redirect
         if (!isSameAuthority(currentTarget, newTarget)) {
             for (final Iterator<Header> it = redirect.headerIterator(); it.hasNext(); ) {
                 final Header header = it.next();
@@ -109,6 +109,9 @@ public class DefaultRedirectStrategy implements RedirectStrategy {
 
     private boolean isSameAuthority(final HttpHost h1, final HttpHost h2) {
         if (h1 == null || h2 == null) {
+            return false;
+        }
+        if (!h1.getSchemeName().equalsIgnoreCase(h2.getSchemeName())) {
             return false;
         }
         final String host1 = h1.getHostName();

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/TestDefaultRedirectStrategy.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/TestDefaultRedirectStrategy.java
@@ -321,6 +321,48 @@ class TestDefaultRedirectStrategy {
 
 
     @Test
+    void testRedirectAllowedCrossSchemeSamePort() {
+        final DefaultRedirectStrategy redirectStrategy = new DefaultRedirectStrategy();
+
+        // https -> http on the same host and same explicit port is a different origin,
+        // so a redirect carrying credential-bearing headers is not followed
+        final HttpHost secure = new HttpHost("https", "example.com", 8443);
+        final HttpHost insecure = new HttpHost("http", "example.com", 8443);
+
+        Assertions.assertFalse(redirectStrategy.isRedirectAllowed(
+                secure,
+                insecure,
+                BasicRequestBuilder.get("/")
+                        .addHeader(HttpHeaders.AUTHORIZATION, "let me pass")
+                        .build(),
+                null));
+
+        Assertions.assertFalse(redirectStrategy.isRedirectAllowed(
+                secure,
+                insecure,
+                BasicRequestBuilder.get("/")
+                        .addHeader(HttpHeaders.COOKIE, "stuff=blah")
+                        .build(),
+                null));
+
+        // no sensitive headers -> the redirect itself is still permitted
+        Assertions.assertTrue(redirectStrategy.isRedirectAllowed(
+                secure,
+                insecure,
+                BasicRequestBuilder.get("/").build(),
+                null));
+
+        // same scheme, host and port stays same origin
+        Assertions.assertTrue(redirectStrategy.isRedirectAllowed(
+                secure,
+                new HttpHost("https", "example.com", 8443),
+                BasicRequestBuilder.get("/")
+                        .addHeader(HttpHeaders.AUTHORIZATION, "let me pass")
+                        .build(),
+                null));
+    }
+
+    @Test
     void testRedirectAllowedDefaultPortNormalization() {
         final DefaultRedirectStrategy redirectStrategy = new DefaultRedirectStrategy();
 


### PR DESCRIPTION
DefaultRedirectStrategy decides whether to keep the Authorization and Cookie headers on a redirect by comparing the current and new targets, but isSameAuthority only looks at the host name and the resolved port and leaves the scheme out. A response that redirects from https to http on the same host and the same explicit port, say https://host:8443/ to http://host:8443/, is treated as the same origin, so those credentials are retained and end up being sent in the clear. I've added the scheme to that comparison so a cross-scheme downgrade counts as a different origin and the sensitive headers are stripped as they already are for a different host or port.