### PR TITLE
reject negative 64-bit payload length in WebSocketFrameReader

### DIFF
--- a/httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/WebSocketFrameReader.java
+++ b/httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/WebSocketFrameReader.java
@@ -97,6 +97,9 @@ class WebSocketFrameReader {
             for (int i = 0; i < 8; i++) {
                 len = (len << 8) | (readByte() & 0xFF);
             }
+            if (len < 0) {
+                throw new WebSocketException("Negative frame payload length");
+            }
         }
         if (len > Integer.MAX_VALUE) {
             throw new WebSocketException("Frame payload too large: " + len);

--- a/httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/WebSocketFrameReaderTest.java
+++ b/httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/WebSocketFrameReaderTest.java
@@ -160,4 +160,16 @@ class WebSocketFrameReaderTest {
         final ByteBuffer f = maskedFrame(0x82, new byte[len]);
         assertThrows(WebSocketException.class, () -> readFrame(f, 1024));
     }
+
+    @Test
+    void negative_extended_length_is_rejected() {
+        final ByteBuffer f = ByteBuffer.allocate(2 + 8 + 4 + 5);
+        f.put((byte) 0x81);              // FIN|TEXT
+        f.put((byte) (0x80 | 127));      // MASK, 64-bit length
+        f.putLong(0xFFFFFFFF00000000L);  // MSB set: not a valid payload length
+        f.put(MASK_KEY);
+        f.put(new byte[5]);
+        f.flip();
+        assertThrows(WebSocketException.class, () -> readFrame(f, 8192));
+    }
 }


### PR DESCRIPTION
readFrame accumulates the 127-form extended payload length into a signed long, but never checks that the most significant bit is clear the way RFC 6455 section 5.2 requires. A masked client frame declaring a length of 0xFFFFFFFF00000000 leaves len negative, so both the Integer.MAX_VALUE and the maxFramePayloadSize guards pass, and the value is then narrowed with a cast when the payload array is allocated. The reader hands back a frame whose payload length has nothing to do with the declared one, and carries on parsing the bytes that follow as the next frame header, so a peer can desynchronise the frame stream; 0xFFFFFFFFFFFFFFFF narrows to -1 and throws NegativeArraySizeException instead.

The client-side WebSocketFrameDecoder already rejects a negative extended length in this spot, so this is really just the same guard missing on the server-side reader, placed before the narrowing rather than after it. Added a test that feeds the reader such a header; it passes on the current code because nothing is thrown.