### PR TITLE
Exclude httpclient5-jakarta-rest-client from the reactor on toolchains below its target Java version

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -59,6 +59,16 @@ jobs:
             echo 'HC_BUILD_TOOLCHAIN_VERSION=${{ matrix.java }}' >> "$GITHUB_ENV"
             ;;
         esac
+        # The httpclient5-jakarta-rest-client module is compiled for Java 11, so it must be
+        # excluded from the reactor whenever the selected toolchain is older than 11.
+        case '${{ matrix.java }}' in
+          8)
+            echo 'HC_PROFILE_ARGS=-Dhc.jakarta-rest-client.skip=true' >> "$GITHUB_ENV"
+            ;;
+          *)
+            echo 'HC_PROFILE_ARGS=' >> "$GITHUB_ENV"
+            ;;
+        esac
     - name: Set up toolchain JDK ${{ matrix.java }}
       id: setup-java-toolchain
       uses: actions/setup-java@v5
@@ -90,4 +100,4 @@ jobs:
         </toolchains>
         EOF
     - name: Build with Maven
-      run: ./mvnw -V --file pom.xml --no-transfer-progress -DtrimStackTrace=false -Djunit.jupiter.execution.parallel.enabled=false -Dhc.build.toolchain.version="${HC_BUILD_TOOLCHAIN_VERSION}" -Pdocker
+      run: ./mvnw -V --file pom.xml --no-transfer-progress -DtrimStackTrace=false -Djunit.jupiter.execution.parallel.enabled=false -Dhc.build.toolchain.version="${HC_BUILD_TOOLCHAIN_VERSION}" ${HC_PROFILE_ARGS} -Pdocker

--- a/httpclient5-jakarta-rest-client/pom.xml
+++ b/httpclient5-jakarta-rest-client/pom.xml
@@ -98,24 +98,4 @@
     </plugins>
   </build>
 
-  <profiles>
-    <profile>
-      <id>skip-on-java8</id>
-      <activation>
-        <property>
-          <name>hc.build.toolchain.version</name>
-          <value>1.8</value>
-        </property>
-      </activation>
-      <properties>
-        <maven.main.skip>true</maven.main.skip>
-        <maven.test.skip>true</maven.test.skip>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <maven.source.skip>true</maven.source.skip>
-        <maven.install.skip>true</maven.install.skip>
-        <checkstyle.skip>true</checkstyle.skip>
-      </properties>
-    </profile>
-  </profiles>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -298,7 +298,6 @@
     <module>httpclient5-fluent</module>
     <module>httpclient5-websocket</module>
     <module>httpclient5-cache</module>
-    <module>httpclient5-jakarta-rest-client</module>
     <module>httpclient5-testing</module>
   </modules>
 
@@ -462,6 +461,22 @@
   </build>
 
   <profiles>
+    <profile>
+      <!--
+        The httpclient5-jakarta-rest-client module is compiled for Java 11, so its class files
+        cannot be read by javac 8. Builds that select an older toolchain must leave this module
+        out of the reactor by setting -Dhc.jakarta-rest-client.skip.
+      -->
+      <id>jakarta-rest-client</id>
+      <activation>
+        <property>
+          <name>!hc.jakarta-rest-client.skip</name>
+        </property>
+      </activation>
+      <modules>
+        <module>httpclient5-jakarta-rest-client</module>
+      </modules>
+    </profile>
     <profile>
       <id>slow-tests</id>
       <build>


### PR DESCRIPTION
Replaces the module's `skip-on-java8 build-skip` profile with a reactor profile activated by` !hc.jakarta-rest-client.skip`, with CI setting `-Dhc.jakarta-rest-client.skip` on the Java 8 row. Mirrors the `httpcore5-jackson3` handling in HttpCore for cross-project consistency and scales to the module requiring Java 17 once upgraded to `httpcore5-jackson3`.