### PR TITLE
reject control characters in bearer token in BearerScheme

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/BearerScheme.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/BearerScheme.java
@@ -160,7 +160,13 @@ public class BearerScheme implements AuthScheme, StateHolder<BearerScheme.State>
             final HttpRequest request,
             final HttpContext context) throws AuthenticationException {
         Asserts.notNull(bearerToken, "Bearer token");
-        return StandardAuthScheme.BEARER + " " + bearerToken.getToken();
+        final String token = bearerToken.getToken();
+        for (int i = 0; i < token.length(); i++) {
+            if (Character.isISOControl(token.charAt(i))) {
+                throw new AuthenticationException("Bearer token must not contain any control characters");
+            }
+        }
+        return StandardAuthScheme.BEARER + " " + token;
     }
 
     @Override

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestBearerScheme.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestBearerScheme.java
@@ -29,6 +29,7 @@ package org.apache.hc.client5.http.impl.auth;
 import org.apache.hc.client5.http.auth.AuthChallenge;
 import org.apache.hc.client5.http.auth.AuthScheme;
 import org.apache.hc.client5.http.auth.AuthScope;
+import org.apache.hc.client5.http.auth.AuthenticationException;
 import org.apache.hc.client5.http.auth.BearerToken;
 import org.apache.hc.client5.http.auth.ChallengeType;
 import org.apache.hc.client5.http.auth.CredentialsProvider;
@@ -72,6 +73,25 @@ class TestBearerScheme {
         Assertions.assertEquals("test", authscheme.getRealm());
         Assertions.assertTrue(authscheme.isChallengeComplete());
         Assertions.assertFalse(authscheme.isConnectionBased());
+    }
+
+    @Test
+    void testBearerTokenWithControlCharacters() throws Exception {
+        final AuthChallenge authChallenge = new AuthChallenge(ChallengeType.TARGET, "Bearer",
+                new BasicNameValuePair("realm", "test"));
+
+        final AuthScheme authscheme = new BearerScheme();
+        authscheme.processChallenge(authChallenge, null);
+
+        final HttpHost host = new HttpHost("somehost", 80);
+        final CredentialsProvider credentialsProvider = CredentialsProviderBuilder.create()
+                .add(new AuthScope(host, "test", null), new BearerToken("token\r\nX-Injected: evil"))
+                .build();
+
+        final HttpRequest request = new BasicHttpRequest("GET", "/");
+        Assertions.assertTrue(authscheme.isResponseReady(host, credentialsProvider, null));
+        Assertions.assertThrows(AuthenticationException.class,
+                () -> authscheme.generateAuthResponse(host, request, null));
     }
 
     @Test


### PR DESCRIPTION
BearerScheme writes the token straight into the Authorization header, and unlike BasicScheme it never checks the credential for control characters. A bearer token carrying CR/LF is neutralised by the HTTP/1.1 line formatter, which replaces those bytes with spaces, but the HTTP/2 request converter passes header values through unchanged, so over h2 such a token can inject extra header material into the request. This applies the same control-character guard BasicScheme already uses, rejecting the token before the header is built.