### PR TITLE
Mark the SSE and WebSocket modules as experimental

### DIFF
--- a/httpclient5-sse/src/main/java/org/apache/hc/client5/http/sse/package-info.java
+++ b/httpclient5-sse/src/main/java/org/apache/hc/client5/http/sse/package-info.java
@@ -33,6 +33,10 @@
  * configurable parsing pipeline. It is designed for very low-latency, high-fan-out
  * read workloads and integrates with HttpClient 5's asynchronous I/O stack.</p>
  *
+ * <p><strong>Experimental.</strong> This module is experimental. Its public API is not yet stable
+ * and may change in an incompatible way, or be removed, in a future release; it is excluded from
+ * the project's binary and source backward-compatibility guarantees for the 5.7 release series.</p>
+ *
  * <h2>Key types</h2>
  * <ul>
  *   <li>{@link org.apache.hc.client5.http.sse.SseExecutor} — entry point that opens

--- a/httpclient5-websocket/src/main/java/org/apache/hc/client5/http/websocket/package-info.java
+++ b/httpclient5-websocket/src/main/java/org/apache/hc/client5/http/websocket/package-info.java
@@ -33,6 +33,10 @@
  * are created by upgrading an HTTP request and are backed internally
  * by the non-blocking I/O reactor used by the HttpClient async APIs.</p>
  *
+ * <p><strong>Experimental.</strong> This module is experimental. Its public API is not yet stable
+ * and may change in an incompatible way, or be removed, in a future release; it is excluded from
+ * the project's binary and source backward-compatibility guarantees for the 5.7 release series.</p>
+ *
  * <h2>Core abstractions</h2>
  * <ul>
  *   <li>{@link org.apache.hc.client5.http.websocket.api.WebSocket WebSocket} –

--- a/httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/package-info.java
+++ b/httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/package-info.java
@@ -32,6 +32,10 @@
  * {@code util}, and {@code exceptions} are internal implementation details
  * and may change without notice.</p>
  *
+ * <p><strong>Experimental.</strong> This module is experimental. Its public API is not yet stable
+ * and may change in an incompatible way, or be removed, in a future release; it is excluded from
+ * the project's binary and source backward-compatibility guarantees for the 5.7 release series.</p>
+ *
  * @since 5.7
  */
 package org.apache.hc.core5.websocket;


### PR DESCRIPTION
Annotated the public API types of the httpclient5-sse and httpclient5-websocket modules with @Experimental. Both modules expose a large API surface that is not yet stable, and the annotation marks them as subject to change so that a relaxed compatibility policy applies for the 5.7 release series; the japicmp binary and source compatibility checks are already skipped for both modules. Types that are already marked @Internal are left unchanged.