### PR TITLE
Fix resource leaking on error in AsyncCachingExec

### DIFF
--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/AsyncCachingExec.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/AsyncCachingExec.java
@@ -126,8 +126,9 @@ class AsyncCachingExec extends CachingExecBase implements AsyncExecChainHandler 
         final SimpleBody body = cacheResponse.getBody();
         final byte[] content = body != null ? body.getBodyBytes() : null;
         final ContentType contentType = body != null ? body.getContentType() : null;
+        AsyncDataConsumer dataConsumer = null;
         try {
-            final AsyncDataConsumer dataConsumer = asyncExecCallback.handleResponse(
+            dataConsumer = asyncExecCallback.handleResponse(
                     cacheResponse,
                     content != null ? new BasicEntityDetails(content.length, contentType) : null);
             if (dataConsumer != null) {
@@ -139,6 +140,10 @@ class AsyncCachingExec extends CachingExecBase implements AsyncExecChainHandler 
             asyncExecCallback.completed();
         } catch (final HttpException | IOException ex) {
             asyncExecCallback.failed(ex);
+        } finally {
+            if (dataConsumer != null) {
+                dataConsumer.releaseResources();
+            }
         }
     }
 

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/async/methods/InflatingZstdDataConsumer.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/async/methods/InflatingZstdDataConsumer.java
@@ -130,7 +130,9 @@ public final class InflatingZstdDataConsumer implements AsyncDataConsumer {
 
     @Override
     public void releaseResources() {
-        dctx.close();
+        if (closed.compareAndSet(false, true)) {
+            dctx.close();
+        }
         downstream.releaseResources();
     }
 }


### PR DESCRIPTION
When `dataConsumer.consume` throws, the resources allocated by the consumer are never released. This causes a memory leak, especially with zstd, since `ZstdDecompressCtx` allocates native memory in its `init` that must be freed explicitly.

Trace found while investigating the leak:

```
libasyncProfiler.so.malloc_hook()
com.github.luben.zstd.util.Native.load() [native malloc inside zstd-jni init]
com.github.luben.zstd.ZstdDecompressCtx.init()
com.github.luben.zstd.ZstdDecompressCtx.<init>() line: 27
org.apache.hc.client5.http.async.methods.InflatingZstdDataConsumer.<init>(AsyncDataConsumer) line: 68
org.apache.hc.client5.http.impl.async.ContentCompressionAsyncExec$$Lambda.apply(Object)
org.apache.hc.client5.http.impl.async.ContentCompressionAsyncExec$1.handleResponse(HttpResponse, EntityDetails) line: 159
[...]
org.apache.hc.client5.http.impl.async.AsyncHttpRequestRetryExec$1.handleResponse(...) line: 133
org.apache.hc.client5.http.impl.cache.AsyncCachingExec$1.handleResponse(...) line: 209
org.apache.hc.client5.http.impl.cache.AsyncCachingExec.triggerResponse(...) line: 130
org.apache.hc.client5.http.impl.cache.AsyncCachingExec.handleCacheHit(...) line: 748
```

This mostly happens when requests are cancelled, which causes `consume()` to throw.

The fix wraps the returned `AsyncDataConsumer` so `releaseResources()` is always called if `consume()` throws, since `AsyncCachingExec.triggerResponse` doesn't do this itself.