### PR TITLE
Add WebSocket RFCs to the standards compliance list

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ Protocol conformance
 - [RFC 9218](https://datatracker.ietf.org/doc/html/rfc9218) - Extensible Prioritization Scheme for HTTP
 - [RFC 7804](https://datatracker.ietf.org/doc/html/rfc7804) - Salted Challenge Response HTTP Authentication Mechanism
 - [RFC 10008](https://datatracker.ietf.org/doc/html/rfc10008) - The HTTP QUERY Method
+- [RFC 6455](https://datatracker.ietf.org/doc/html/rfc6455) - The WebSocket Protocol
+- [RFC 7692](https://datatracker.ietf.org/doc/html/rfc7692) - Compression Extensions for WebSocket (permessage-deflate)
+- [RFC 8441](https://datatracker.ietf.org/doc/html/rfc8441) - Bootstrapping WebSockets with HTTP/2
 
 Licensing
 ---------


### PR DESCRIPTION
List RFC 6455 (WebSocket), RFC 7692 (permessage-deflate) and RFC 8441 (WebSockets over HTTP/2) covered by the httpclient5-websocket module.