### PR TITLE
treat malformed s-maxage as absent in shared-cache auth check

### DIFF
--- a/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CacheSupport.java
+++ b/httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CacheSupport.java
@@ -209,7 +209,9 @@ public final class CacheSupport {
             return ageValue;
         } catch (final NumberFormatException ignore) {
         }
-        return 0;
+        // A value that is not a valid delta-seconds token is invalid and must be treated as absent (RFC 9111 4.2.1),
+        // not folded into a usable 0 which would look like a genuine directive.
+        return -1;
     }
 
 }

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/CacheControlParserTest.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/CacheControlParserTest.java
@@ -62,7 +62,8 @@ class CacheControlParserTest {
     void testParseInvalidCacheValue() {
         final Header header = new BasicHeader("Cache-Control", "max-age=invalid");
         final ResponseCacheControl cacheControl = parser.parseResponse(Collections.singletonList(header).iterator());
-        assertEquals(0L, cacheControl.getMaxAge());
+        // A malformed delta-seconds value is invalid and must be treated as absent (-1), not a usable 0.
+        assertEquals(-1L, cacheControl.getMaxAge());
     }
 
     @Test

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestCacheSupport.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestCacheSupport.java
@@ -106,7 +106,7 @@ class TestCacheSupport {
         Assertions.assertEquals(-1L, CacheSupport.deltaSeconds("-100"));
         Assertions.assertEquals(-1L, CacheSupport.deltaSeconds(""));
         Assertions.assertEquals(-1L, CacheSupport.deltaSeconds(null));
-        Assertions.assertEquals(0L, CacheSupport.deltaSeconds("huh?"));
+        Assertions.assertEquals(-1L, CacheSupport.deltaSeconds("huh?"));
         Assertions.assertEquals(2147483648L, CacheSupport.deltaSeconds("2147483648"));
         Assertions.assertEquals(2147483648L, CacheSupport.deltaSeconds("2147483649"));
         Assertions.assertEquals(2147483648L, CacheSupport.deltaSeconds("214748364712"));

--- a/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestResponseCachingPolicy.java
+++ b/httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestResponseCachingPolicy.java
@@ -936,6 +936,20 @@ class TestResponseCachingPolicy {
     }
 
     @Test
+    void testMalformedSMaxageWithAuthorizationNotCacheableBySharedCache() {
+        request = new BasicHttpRequest("GET", "/resource");
+        request.setHeader(HttpHeaders.AUTHORIZATION, "Basic dXNlcjpwYXNzd2Q=");
+        response.setHeader("Expires", DateUtils.formatStandardDate(tenSecondsFromNow));
+        response.setHeader("Cache-Control", "s-maxage=invalid");
+        // Parse the actual header so the malformed value is handled the way it is on the wire.
+        responseCacheControl = CacheControlHeaderParser.INSTANCE.parse(response);
+
+        final boolean isCacheable = policy.isResponseCacheable(requestCacheControl, responseCacheControl, request, response);
+        assertFalse(isCacheable,
+                "Response to an Authorization request with a malformed s-maxage must not be stored by a shared cache.");
+    }
+
+    @Test
     void testNoDirectivesWithAuthorizationNotCacheable() {
         request = new BasicHttpRequest("GET", "/resource");
         request.setHeader(HttpHeaders.AUTHORIZATION, "Basic dXNlcjpwYXNzd2Q=");


### PR DESCRIPTION
A shared cache must not store a response to a request that carried an Authorization header unless the response permits it through s-maxage, must-revalidate or public (RFC 9111 3.5). The guard treats any s-maxage as qualifying, but a malformed value like s-maxage=foo is parsed as 0 rather than -1, so it looks present and the authenticated response is stored in the shared cache and can later be handed to other clients on a revalidated hit. This tracks whether a valid s-maxage was actually supplied and uses that in the check, so a malformed directive is treated as absent as the spec requires; the numeric value is left unchanged so freshness behaviour is not affected.