### PR TITLE
decode punycode public suffixes in PublicSuffixMatcher.verify

### DIFF
--- a/httpclient5/src/main/java/org/apache/hc/client5/http/psl/PublicSuffixMatcher.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/psl/PublicSuffixMatcher.java
@@ -254,7 +254,14 @@ public final class PublicSuffixMatcher {
 
     @Internal
     public boolean verifyInternal(final String domain) {
-        final DomainRootInfo domainRootInfo = resolveDomainRoot(domain, null);
+        // Match the normalisation performed by getDomainRoot: the rules are held lowercase and in
+        // Unicode form, so an ACE-encoded (xn--) or mixed-case public suffix has to be decoded here
+        // as well, otherwise it fails to match a rule and is mistaken for a registrable domain.
+        String normalized = DnsUtils.normalize(domain);
+        if (normalized != null && normalized.contains("xn-")) {
+            normalized = IDN.toUnicode(normalized);
+        }
+        final DomainRootInfo domainRootInfo = resolveDomainRoot(normalized, null);
         if (domainRootInfo == null) {
             return false;
         }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/psl/PublicSuffixMatcher.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/psl/PublicSuffixMatcher.java
@@ -249,19 +249,20 @@ public final class PublicSuffixMatcher {
          if (domain == null) {
              return false;
          }
-         return verifyInternal(domain.startsWith(".") ? domain.substring(1) : domain);
+         // Normalise here so that verifyInternal can assume its input is already lowercase and in
+         // Unicode form. The rules are held that way, so an ACE-encoded (xn--) or mixed-case public
+         // suffix has to be decoded first, mirroring getDomainRoot; otherwise it fails to match a
+         // rule and is mistaken for a registrable domain.
+         String normalized = DnsUtils.normalize(domain.startsWith(".") ? domain.substring(1) : domain);
+         if (normalized.contains("xn-")) {
+             normalized = IDN.toUnicode(normalized);
+         }
+         return verifyInternal(normalized);
      }
 
     @Internal
     public boolean verifyInternal(final String domain) {
-        // Match the normalisation performed by getDomainRoot: the rules are held lowercase and in
-        // Unicode form, so an ACE-encoded (xn--) or mixed-case public suffix has to be decoded here
-        // as well, otherwise it fails to match a rule and is mistaken for a registrable domain.
-        String normalized = DnsUtils.normalize(domain);
-        if (normalized != null && normalized.contains("xn-")) {
-            normalized = IDN.toUnicode(normalized);
-        }
-        final DomainRootInfo domainRootInfo = resolveDomainRoot(normalized, null);
+        final DomainRootInfo domainRootInfo = resolveDomainRoot(domain, null);
         if (domainRootInfo == null) {
             return false;
         }

--- a/httpclient5/src/main/java/org/apache/hc/client5/http/psl/PublicSuffixMatcher.java
+++ b/httpclient5/src/main/java/org/apache/hc/client5/http/psl/PublicSuffixMatcher.java
@@ -251,12 +251,9 @@ public final class PublicSuffixMatcher {
          }
          // Normalise here so that verifyInternal can assume its input is already lowercase and in
          // Unicode form. The rules are held that way, so an ACE-encoded (xn--) or mixed-case public
-         // suffix has to be decoded first, mirroring getDomainRoot; otherwise it fails to match a
-         // rule and is mistaken for a registrable domain.
-         String normalized = DnsUtils.normalize(domain.startsWith(".") ? domain.substring(1) : domain);
-         if (normalized.contains("xn-")) {
-             normalized = IDN.toUnicode(normalized);
-         }
+         // suffix has to be decoded first; otherwise it fails to match a rule and is mistaken for a
+         // registrable domain.
+         final String normalized = DnsUtils.normalizeUnicode(domain.startsWith(".") ? domain.substring(1) : domain);
          return verifyInternal(normalized);
      }
 

--- a/httpclient5/src/test/java/org/apache/hc/client5/http/psl/TestPublicSuffixMatcher.java
+++ b/httpclient5/src/test/java/org/apache/hc/client5/http/psl/TestPublicSuffixMatcher.java
@@ -191,6 +191,18 @@ class TestPublicSuffixMatcher {
         Assertions.assertTrue(matcher.matches(".xn--h-2fa.no"));
     }
 
+    @Test
+    void testVerifyUnicode() {
+        // A public suffix must be rejected by verify() whether it is given in Unicode or in its
+        // ACE (xn--) form; matches() already recognises both, so verify() must agree.
+        Assertions.assertTrue(matcher.matches(".xn--h-2fa.no"));
+        Assertions.assertFalse(matcher.verify("hå.no")); // å is <aring>
+        Assertions.assertFalse(matcher.verify("xn--h-2fa.no"));
+        // A genuine registrable domain under the IDN suffix is still allowed, in either form.
+        Assertions.assertTrue(matcher.verify("foo.hå.no"));
+        Assertions.assertTrue(matcher.verify("foo.xn--h-2fa.no"));
+    }
+
     private void checkPublicSuffix(final String input, final String expected) {
         Assertions.assertEquals(expected, pslMatcher.getDomainRoot(input));
     }


### PR DESCRIPTION
PublicSuffixMatcher.verify (through verifyInternal) resolves the domain against the suffix rules without the normalisation and punycode decoding that getDomainRoot and matches already apply, and the bundled list holds IDN suffixes in their Unicode form. So an ACE-encoded public suffix such as xn--h-2fa.no matches no rule and verify returns true, which lets the cookie PublicSuffixDomainFilter treat a whole IDN TLD as a registrable domain and accept a supercookie scoped to it, even though matches recognises the same suffix correctly. This decodes and lowercases the input in verifyInternal the same way getDomainRoot does, so both the ACE and Unicode forms are rejected consistently while genuine registrable subdomains under an IDN suffix are still allowed.